### PR TITLE
Dev

### DIFF
--- a/R/fct_data_covid.R
+++ b/R/fct_data_covid.R
@@ -368,7 +368,6 @@ prepare_data_covid <- function(
   input_data <- patient |>
     left_join(covariates, by = "zip")
 
-  input_data_stan <- input_data
 
   new_data <- tidyr::expand_grid(
     sex  = demo_levels$sex,
@@ -394,9 +393,8 @@ prepare_data_covid <- function(
   # list of variables for model specification
   vars <- list(
     fixed = list(
-      "Individual-level Predictor" = c("sex", "race", "age", "time"),
-      "Geographic Predictor" = names(covariates) |> setdiff(c("zip", "county")),
-      "Geographic Indicator" = c("zip")
+      "Individual-level Predictor" = c("sex"),
+      "Geographic Predictor" = names(covariates) |> setdiff(c("zip", "county"))
     ),
     varying = list(
       "Individual-level Predictor" = c("race", "age", "time"),

--- a/R/fct_data_poll.R
+++ b/R/fct_data_poll.R
@@ -196,7 +196,7 @@ prepare_data_poll <- function(
   # list of variables for model specification
   vars <- list(
     fixed = list(
-      "Individual-level Predictor" = c("sex", "race", "age", "edu")
+      "Individual-level Predictor" = list("sex")
     ),
     varying = list(
       "Individual-level Predictor" = c("race", "age", "edu")
@@ -204,8 +204,8 @@ prepare_data_poll <- function(
   )
 
   if(!is.null(states_in_data)) {
-    vars$fixed[["Geographic Predictor"]] <- setdiff(names(covar), "state")
-    vars$fixed[["Geographic Indicator"]] <- "state"
+    # NOTE: current implementation only accepts continuous covariates
+    vars$fixed[["Geographic Predictor"]] <- names(covar)[sapply(covar, is.numeric)]
     vars$varying[["Geographic Indicator"]] <- "state"
   }
 

--- a/R/mod_analyze_model.R
+++ b/R/mod_analyze_model.R
@@ -195,15 +195,6 @@ mod_analyze_model_server <- function(id, global){
             session = global$session
           )
         } else {
-          updateVirtualSelect(
-            inputId = "fixed",
-            choices = global$mrp$vars$fixed
-          )
-
-          updateVirtualSelect(
-            inputId = "varying",
-            choices = global$mrp$vars$varying
-          )
         }
       }
     })
@@ -401,34 +392,30 @@ mod_analyze_model_server <- function(id, global){
 
     observeEvent(input$diagnos_btn, {
 
-      if(global$web_version) {
-        show_alert("This functionality is currently not available for the web version of the MRP interface.", global$session)
-      } else {
-        selected_names <- input$model_select
+      selected_names <- input$model_select
 
-        if(length(selected_names) > 0) {
+      if(length(selected_names) > 0) {
 
-          yreps <- purrr::map(global$models[selected_names], function(m) m$yrep)
+        yreps <- purrr::map(global$models[selected_names], function(m) m$yrep)
 
-          purrr::map(1:length(yreps), function(i) {
-            output[[paste0("compare_ppc", i)]] <- renderPlot({
-              if(!is.null(isolate(global$models))) {
-                if(global$covid) {
-                  plot_ppc_covid_subset(
-                    yreps[[i]],
-                    global$mrp$input,
-                    global$plotdata$dates
-                  )
-                } else {
-                  plot_ppc_poll(
-                    yreps[[i]],
-                    global$mrp$input
-                  )
-                }
+        purrr::map(1:length(yreps), function(i) {
+          output[[paste0("compare_ppc", i)]] <- renderPlot({
+            if(!is.null(isolate(global$models))) {
+              if(global$covid) {
+                plot_ppc_covid_subset(
+                  yreps[[i]],
+                  global$mrp$input,
+                  global$plotdata$dates
+                )
+              } else {
+                plot_ppc_poll(
+                  yreps[[i]],
+                  global$mrp$input
+                )
               }
-            })
+            }
           })
-        }
+        })
       }
 
     })
@@ -1049,12 +1036,12 @@ mod_analyze_model_server <- function(id, global){
 
       updateVirtualSelect(
         inputId = "fixed",
-        choices = list()
+        choices = global$mrp$vars$fixed
       )
 
       updateVirtualSelect(
         inputId = "varying",
-        choices = list()
+        choices = global$mrp$vars$varying
       )
 
       updateVirtualSelect(

--- a/R/mod_home.R
+++ b/R/mod_home.R
@@ -50,30 +50,18 @@ mod_home_server <- function(id, global){
 
     observe({
       if(!global$web_version) {
-        # check if CmdStan is installed and prompt user
+        # install CmdStan if not installed already
         if(is.null(cmdstanr::cmdstan_version(error_on_NA = FALSE))) {
-          shinyWidgets::ask_confirmation(
-            inputId = ns("setup_popup"),
-            title = "Confirm",
-            text = "CmdStan is required to fit user-defined models but not necessary for testing the interface via example results. Do you want to proceed with the installation?",
-            btn_labels = c("No", "Yes")
+          waiter::waiter_show(
+            html = waiter_ui("setup"),
+            color = waiter::transparent(0.9)
           )
+
+          cmdstanr::check_cmdstan_toolchain(fix = TRUE)
+          cmdstanr::install_cmdstan(check_toolchain = FALSE)
+
+          waiter::waiter_hide()
         }
-
-        # install CmdStan if user agrees
-        observeEvent(input$setup_popup, {
-          if(input$setup_popup) {
-            waiter::waiter_show(
-              html = waiter_ui("setup"),
-              color = waiter::transparent(0.9)
-            )
-
-            cmdstanr::check_cmdstan_toolchain(fix = TRUE)
-            cmdstanr::install_cmdstan(check_toolchain = FALSE)
-
-            waiter::waiter_hide()
-          }
-        })
       } else {
         shinyWidgets::sendSweetAlert(
           title = "Information",

--- a/inst/extdata/CES_data_aggregated.csv
+++ b/inst/extdata/CES_data_aggregated.csv
@@ -1,2365 +1,2365 @@
-sex,race,age,edu,state,total,positive,repvote,region
-male,other,50-59,4-year college,AK,1,1,0.583856547,4
-female,white,50-59,hs,AK,1,0,0.583856547,4
-male,white,18-29,some college,AK,1,0,0.583856547,4
-male,white,30-39,post-grad,AK,1,0,0.583856547,4
-female,black,18-29,hs,AL,1,0,0.643741436,3
-female,black,18-29,some college,AL,1,0,0.643741436,3
-female,black,30-39,4-year college,AL,1,0,0.643741436,3
-female,black,30-39,hs,AL,1,0,0.643741436,3
-female,black,30-39,some college,AL,1,0,0.643741436,3
-female,black,40-49,hs,AL,1,1,0.643741436,3
-female,black,40-49,some college,AL,2,0,0.643741436,3
-female,black,50-59,post-grad,AL,1,0,0.643741436,3
-female,black,50-59,some college,AL,1,0,0.643741436,3
-female,black,60-69,some college,AL,1,1,0.643741436,3
-male,black,40-49,some college,AL,1,1,0.643741436,3
-female,other,18-29,4-year college,AL,1,0,0.643741436,3
-female,other,30-39,hs,AL,1,0,0.643741436,3
-female,other,40-49,some college,AL,1,1,0.643741436,3
-female,white,18-29,4-year college,AL,3,0,0.643741436,3
-female,white,18-29,hs,AL,4,1,0.643741436,3
-female,white,18-29,some college,AL,2,1,0.643741436,3
-female,white,30-39,4-year college,AL,2,1,0.643741436,3
-female,white,30-39,hs,AL,2,2,0.643741436,3
-female,white,30-39,no hs,AL,1,1,0.643741436,3
-female,white,30-39,some college,AL,4,4,0.643741436,3
-female,white,40-49,hs,AL,3,1,0.643741436,3
-female,white,40-49,no hs,AL,1,1,0.643741436,3
-female,white,40-49,post-grad,AL,1,0,0.643741436,3
-female,white,50-59,hs,AL,4,2,0.643741436,3
-female,white,50-59,post-grad,AL,1,1,0.643741436,3
-female,white,50-59,some college,AL,2,1,0.643741436,3
-female,white,60-69,4-year college,AL,1,0,0.643741436,3
-female,white,60-69,no hs,AL,2,0,0.643741436,3
-female,white,60-69,some college,AL,2,1,0.643741436,3
-female,white,70+,4-year college,AL,1,1,0.643741436,3
-female,white,70+,hs,AL,2,2,0.643741436,3
-female,white,70+,post-grad,AL,1,0,0.643741436,3
-female,white,70+,some college,AL,6,3,0.643741436,3
-male,white,18-29,4-year college,AL,2,1,0.643741436,3
-male,white,30-39,4-year college,AL,1,0,0.643741436,3
-male,white,30-39,hs,AL,1,1,0.643741436,3
-male,white,30-39,post-grad,AL,1,1,0.643741436,3
-male,white,40-49,4-year college,AL,1,1,0.643741436,3
-male,white,40-49,hs,AL,2,2,0.643741436,3
-male,white,40-49,some college,AL,4,2,0.643741436,3
-male,white,50-59,hs,AL,3,3,0.643741436,3
-male,white,50-59,some college,AL,2,2,0.643741436,3
-male,white,60-69,4-year college,AL,2,2,0.643741436,3
-male,white,70+,4-year college,AL,5,5,0.643741436,3
-male,white,70+,post-grad,AL,1,1,0.643741436,3
-female,black,60-69,some college,AR,1,0,0.642851377,3
-female,black,70+,some college,AR,1,0,0.642851377,3
-male,black,30-39,some college,AR,1,1,0.642851377,3
-male,black,40-49,hs,AR,2,0,0.642851377,3
-female,other,30-39,hs,AR,1,0,0.642851377,3
-female,other,40-49,no hs,AR,1,1,0.642851377,3
-male,other,18-29,some college,AR,1,0,0.642851377,3
-male,other,50-59,some college,AR,1,1,0.642851377,3
-female,white,18-29,4-year college,AR,1,0,0.642851377,3
-female,white,18-29,hs,AR,1,0,0.642851377,3
-female,white,18-29,post-grad,AR,1,0,0.642851377,3
-female,white,18-29,some college,AR,5,4,0.642851377,3
-female,white,30-39,some college,AR,3,3,0.642851377,3
-female,white,40-49,4-year college,AR,1,1,0.642851377,3
-female,white,40-49,hs,AR,2,2,0.642851377,3
-female,white,40-49,some college,AR,2,2,0.642851377,3
-female,white,50-59,4-year college,AR,2,1,0.642851377,3
-female,white,50-59,hs,AR,1,1,0.642851377,3
-female,white,50-59,no hs,AR,1,1,0.642851377,3
-female,white,50-59,some college,AR,2,1,0.642851377,3
-female,white,60-69,hs,AR,1,1,0.642851377,3
-female,white,60-69,no hs,AR,1,0,0.642851377,3
-female,white,60-69,some college,AR,3,3,0.642851377,3
-female,white,70+,post-grad,AR,2,0,0.642851377,3
-female,white,70+,some college,AR,2,1,0.642851377,3
-male,white,18-29,4-year college,AR,1,0,0.642851377,3
-male,white,18-29,post-grad,AR,2,1,0.642851377,3
-male,white,30-39,no hs,AR,1,0,0.642851377,3
-male,white,40-49,no hs,AR,1,0,0.642851377,3
-male,white,50-59,some college,AR,1,0,0.642851377,3
-male,white,60-69,4-year college,AR,1,0,0.642851377,3
-male,white,60-69,hs,AR,2,1,0.642851377,3
-male,white,70+,4-year college,AR,1,1,0.642851377,3
-male,white,70+,hs,AR,1,1,0.642851377,3
-male,black,18-29,some college,AZ,1,0,0.518900234,4
-male,black,50-59,no hs,AZ,1,0,0.518900234,4
-female,other,18-29,4-year college,AZ,3,1,0.518900234,4
-female,other,18-29,no hs,AZ,1,0,0.518900234,4
-female,other,18-29,post-grad,AZ,1,0,0.518900234,4
-female,other,18-29,some college,AZ,3,0,0.518900234,4
-female,other,30-39,4-year college,AZ,1,0,0.518900234,4
-female,other,30-39,hs,AZ,2,1,0.518900234,4
-female,other,30-39,no hs,AZ,1,1,0.518900234,4
-female,other,30-39,post-grad,AZ,1,1,0.518900234,4
-female,other,40-49,some college,AZ,1,0,0.518900234,4
-female,other,50-59,4-year college,AZ,1,1,0.518900234,4
-female,other,50-59,some college,AZ,1,0,0.518900234,4
-female,other,70+,4-year college,AZ,2,1,0.518900234,4
-female,other,70+,some college,AZ,1,1,0.518900234,4
-male,other,18-29,4-year college,AZ,2,0,0.518900234,4
-male,other,18-29,no hs,AZ,1,0,0.518900234,4
-male,other,18-29,some college,AZ,1,0,0.518900234,4
-male,other,30-39,some college,AZ,1,0,0.518900234,4
-male,other,40-49,4-year college,AZ,1,0,0.518900234,4
-male,other,40-49,post-grad,AZ,1,0,0.518900234,4
-male,other,40-49,some college,AZ,1,1,0.518900234,4
-male,other,50-59,4-year college,AZ,2,0,0.518900234,4
-male,other,50-59,some college,AZ,1,1,0.518900234,4
-female,white,18-29,hs,AZ,1,1,0.518900234,4
-female,white,30-39,4-year college,AZ,1,0,0.518900234,4
-female,white,30-39,hs,AZ,2,1,0.518900234,4
-female,white,30-39,some college,AZ,2,0,0.518900234,4
-female,white,40-49,4-year college,AZ,1,0,0.518900234,4
-female,white,40-49,hs,AZ,2,2,0.518900234,4
-female,white,40-49,post-grad,AZ,1,0,0.518900234,4
-female,white,40-49,some college,AZ,1,0,0.518900234,4
-female,white,50-59,4-year college,AZ,3,0,0.518900234,4
-female,white,50-59,hs,AZ,4,2,0.518900234,4
-female,white,50-59,no hs,AZ,2,1,0.518900234,4
-female,white,50-59,post-grad,AZ,1,1,0.518900234,4
-female,white,50-59,some college,AZ,8,5,0.518900234,4
-female,white,60-69,4-year college,AZ,3,1,0.518900234,4
-female,white,60-69,hs,AZ,5,3,0.518900234,4
-female,white,60-69,post-grad,AZ,1,0,0.518900234,4
-female,white,60-69,some college,AZ,4,2,0.518900234,4
-female,white,70+,4-year college,AZ,3,1,0.518900234,4
-female,white,70+,hs,AZ,4,2,0.518900234,4
-female,white,70+,post-grad,AZ,1,0,0.518900234,4
-female,white,70+,some college,AZ,2,1,0.518900234,4
-male,white,18-29,4-year college,AZ,2,1,0.518900234,4
-male,white,18-29,hs,AZ,1,1,0.518900234,4
-male,white,18-29,post-grad,AZ,1,0,0.518900234,4
-male,white,30-39,4-year college,AZ,2,1,0.518900234,4
-male,white,30-39,hs,AZ,2,1,0.518900234,4
-male,white,30-39,some college,AZ,1,0,0.518900234,4
-male,white,40-49,4-year college,AZ,2,1,0.518900234,4
-male,white,40-49,some college,AZ,3,1,0.518900234,4
-male,white,50-59,4-year college,AZ,2,2,0.518900234,4
-male,white,50-59,some college,AZ,2,1,0.518900234,4
-male,white,60-69,4-year college,AZ,3,1,0.518900234,4
-male,white,60-69,hs,AZ,2,0,0.518900234,4
-male,white,60-69,post-grad,AZ,2,1,0.518900234,4
-male,white,60-69,some college,AZ,6,6,0.518900234,4
-male,white,70+,4-year college,AZ,1,0,0.518900234,4
-male,white,70+,hs,AZ,2,1,0.518900234,4
-male,white,70+,no hs,AZ,1,1,0.518900234,4
-male,white,70+,post-grad,AZ,4,0,0.518900234,4
-male,white,70+,some college,AZ,2,2,0.518900234,4
-female,black,18-29,hs,CA,1,0,0.338717892,4
-female,black,18-29,no hs,CA,1,1,0.338717892,4
-female,black,18-29,some college,CA,4,1,0.338717892,4
-female,black,30-39,4-year college,CA,2,1,0.338717892,4
-female,black,30-39,post-grad,CA,1,1,0.338717892,4
-female,black,30-39,some college,CA,1,0,0.338717892,4
-female,black,40-49,4-year college,CA,2,1,0.338717892,4
-female,black,40-49,some college,CA,2,0,0.338717892,4
-female,black,50-59,some college,CA,5,2,0.338717892,4
-male,black,18-29,hs,CA,3,0,0.338717892,4
-male,black,18-29,some college,CA,2,1,0.338717892,4
-male,black,30-39,no hs,CA,1,1,0.338717892,4
-male,black,30-39,some college,CA,5,2,0.338717892,4
-male,black,40-49,4-year college,CA,1,1,0.338717892,4
-male,black,50-59,4-year college,CA,1,0,0.338717892,4
-male,black,50-59,hs,CA,2,0,0.338717892,4
-male,black,50-59,post-grad,CA,1,0,0.338717892,4
-male,black,60-69,4-year college,CA,1,0,0.338717892,4
-male,black,60-69,some college,CA,1,0,0.338717892,4
-male,black,70+,post-grad,CA,1,0,0.338717892,4
-female,other,18-29,4-year college,CA,12,5,0.338717892,4
-female,other,18-29,hs,CA,15,5,0.338717892,4
-female,other,18-29,no hs,CA,1,1,0.338717892,4
-female,other,18-29,post-grad,CA,5,3,0.338717892,4
-female,other,18-29,some college,CA,20,4,0.338717892,4
-female,other,30-39,4-year college,CA,5,3,0.338717892,4
-female,other,30-39,hs,CA,6,1,0.338717892,4
-female,other,30-39,post-grad,CA,3,0,0.338717892,4
-female,other,30-39,some college,CA,3,1,0.338717892,4
-female,other,40-49,4-year college,CA,4,3,0.338717892,4
-female,other,40-49,hs,CA,3,1,0.338717892,4
-female,other,40-49,post-grad,CA,1,0,0.338717892,4
-female,other,40-49,some college,CA,9,2,0.338717892,4
-female,other,50-59,4-year college,CA,1,0,0.338717892,4
-female,other,50-59,hs,CA,5,3,0.338717892,4
-female,other,50-59,post-grad,CA,1,0,0.338717892,4
-female,other,50-59,some college,CA,3,1,0.338717892,4
-female,other,60-69,4-year college,CA,1,0,0.338717892,4
-female,other,60-69,hs,CA,1,1,0.338717892,4
-female,other,60-69,some college,CA,3,1,0.338717892,4
-female,other,70+,post-grad,CA,1,0,0.338717892,4
-female,other,70+,some college,CA,1,1,0.338717892,4
-male,other,18-29,4-year college,CA,3,1,0.338717892,4
-male,other,18-29,hs,CA,3,1,0.338717892,4
-male,other,18-29,post-grad,CA,1,0,0.338717892,4
-male,other,18-29,some college,CA,18,9,0.338717892,4
-male,other,30-39,4-year college,CA,6,1,0.338717892,4
-male,other,30-39,hs,CA,3,1,0.338717892,4
-male,other,30-39,post-grad,CA,1,1,0.338717892,4
-male,other,30-39,some college,CA,8,2,0.338717892,4
-male,other,40-49,4-year college,CA,1,1,0.338717892,4
-male,other,40-49,post-grad,CA,2,1,0.338717892,4
-male,other,40-49,some college,CA,2,1,0.338717892,4
-male,other,50-59,4-year college,CA,2,1,0.338717892,4
-male,other,50-59,hs,CA,1,1,0.338717892,4
-male,other,50-59,post-grad,CA,2,0,0.338717892,4
-male,other,50-59,some college,CA,5,1,0.338717892,4
-male,other,60-69,hs,CA,3,0,0.338717892,4
-male,other,60-69,some college,CA,1,0,0.338717892,4
-male,other,70+,4-year college,CA,1,0,0.338717892,4
-male,other,70+,hs,CA,1,0,0.338717892,4
-male,other,70+,some college,CA,1,1,0.338717892,4
-female,white,18-29,4-year college,CA,9,2,0.338717892,4
-female,white,18-29,hs,CA,4,2,0.338717892,4
-female,white,18-29,no hs,CA,1,0,0.338717892,4
-female,white,18-29,post-grad,CA,4,1,0.338717892,4
-female,white,18-29,some college,CA,11,3,0.338717892,4
-female,white,30-39,4-year college,CA,5,0,0.338717892,4
-female,white,30-39,hs,CA,3,1,0.338717892,4
-female,white,30-39,post-grad,CA,5,0,0.338717892,4
-female,white,30-39,some college,CA,7,3,0.338717892,4
-female,white,40-49,4-year college,CA,4,2,0.338717892,4
-female,white,40-49,hs,CA,3,0,0.338717892,4
-female,white,40-49,post-grad,CA,1,0,0.338717892,4
-female,white,40-49,some college,CA,4,0,0.338717892,4
-female,white,50-59,4-year college,CA,3,0,0.338717892,4
-female,white,50-59,hs,CA,9,4,0.338717892,4
-female,white,50-59,no hs,CA,3,2,0.338717892,4
-female,white,50-59,post-grad,CA,4,0,0.338717892,4
-female,white,50-59,some college,CA,3,2,0.338717892,4
-female,white,60-69,4-year college,CA,9,3,0.338717892,4
-female,white,60-69,hs,CA,5,1,0.338717892,4
-female,white,60-69,no hs,CA,2,0,0.338717892,4
-female,white,60-69,post-grad,CA,6,1,0.338717892,4
-female,white,60-69,some college,CA,7,4,0.338717892,4
-female,white,70+,4-year college,CA,8,3,0.338717892,4
-female,white,70+,hs,CA,6,3,0.338717892,4
-female,white,70+,no hs,CA,1,1,0.338717892,4
-female,white,70+,post-grad,CA,1,0,0.338717892,4
-female,white,70+,some college,CA,10,6,0.338717892,4
-male,white,18-29,4-year college,CA,3,1,0.338717892,4
-male,white,18-29,hs,CA,4,0,0.338717892,4
-male,white,18-29,no hs,CA,1,0,0.338717892,4
-male,white,18-29,post-grad,CA,1,1,0.338717892,4
-male,white,18-29,some college,CA,6,5,0.338717892,4
-male,white,30-39,4-year college,CA,3,2,0.338717892,4
-male,white,30-39,hs,CA,3,3,0.338717892,4
-male,white,30-39,post-grad,CA,2,1,0.338717892,4
-male,white,30-39,some college,CA,5,3,0.338717892,4
-male,white,40-49,4-year college,CA,1,0,0.338717892,4
-male,white,40-49,hs,CA,2,0,0.338717892,4
-male,white,40-49,post-grad,CA,2,1,0.338717892,4
-male,white,40-49,some college,CA,2,2,0.338717892,4
-male,white,50-59,4-year college,CA,5,2,0.338717892,4
-male,white,50-59,hs,CA,7,4,0.338717892,4
-male,white,50-59,no hs,CA,1,0,0.338717892,4
-male,white,50-59,post-grad,CA,8,4,0.338717892,4
-male,white,50-59,some college,CA,5,1,0.338717892,4
-male,white,60-69,4-year college,CA,10,3,0.338717892,4
-male,white,60-69,hs,CA,4,4,0.338717892,4
-male,white,60-69,post-grad,CA,9,2,0.338717892,4
-male,white,60-69,some college,CA,6,2,0.338717892,4
-male,white,70+,4-year college,CA,9,3,0.338717892,4
-male,white,70+,hs,CA,3,1,0.338717892,4
-male,white,70+,post-grad,CA,7,4,0.338717892,4
-male,white,70+,some college,CA,13,11,0.338717892,4
-female,black,18-29,some college,CO,2,0,0.473166666,4
-female,black,40-49,4-year college,CO,1,0,0.473166666,4
-female,black,50-59,4-year college,CO,1,0,0.473166666,4
-male,black,30-39,hs,CO,1,1,0.473166666,4
-male,black,50-59,4-year college,CO,1,0,0.473166666,4
-female,other,30-39,4-year college,CO,2,0,0.473166666,4
-female,other,30-39,some college,CO,1,0,0.473166666,4
-female,other,40-49,4-year college,CO,1,1,0.473166666,4
-female,other,50-59,some college,CO,1,1,0.473166666,4
-female,other,60-69,hs,CO,1,0,0.473166666,4
-female,other,60-69,some college,CO,1,1,0.473166666,4
-female,other,70+,4-year college,CO,1,0,0.473166666,4
-male,other,18-29,some college,CO,1,0,0.473166666,4
-male,other,30-39,4-year college,CO,1,1,0.473166666,4
-male,other,50-59,hs,CO,1,0,0.473166666,4
-female,white,18-29,4-year college,CO,3,1,0.473166666,4
-female,white,18-29,post-grad,CO,1,0,0.473166666,4
-female,white,30-39,4-year college,CO,3,2,0.473166666,4
-female,white,30-39,hs,CO,1,1,0.473166666,4
-female,white,30-39,no hs,CO,1,0,0.473166666,4
-female,white,30-39,post-grad,CO,3,1,0.473166666,4
-female,white,30-39,some college,CO,2,2,0.473166666,4
-female,white,40-49,4-year college,CO,1,1,0.473166666,4
-female,white,40-49,hs,CO,1,0,0.473166666,4
-female,white,40-49,some college,CO,4,1,0.473166666,4
-female,white,50-59,4-year college,CO,1,0,0.473166666,4
-female,white,50-59,hs,CO,1,1,0.473166666,4
-female,white,50-59,post-grad,CO,2,0,0.473166666,4
-female,white,50-59,some college,CO,1,0,0.473166666,4
-female,white,60-69,4-year college,CO,1,1,0.473166666,4
-female,white,60-69,hs,CO,1,0,0.473166666,4
-female,white,60-69,post-grad,CO,1,1,0.473166666,4
-female,white,60-69,some college,CO,2,0,0.473166666,4
-female,white,70+,hs,CO,2,0,0.473166666,4
-male,white,30-39,4-year college,CO,1,0,0.473166666,4
-male,white,30-39,some college,CO,1,0,0.473166666,4
-male,white,40-49,4-year college,CO,1,0,0.473166666,4
-male,white,40-49,hs,CO,1,1,0.473166666,4
-male,white,40-49,some college,CO,1,0,0.473166666,4
-male,white,50-59,4-year college,CO,3,3,0.473166666,4
-male,white,50-59,hs,CO,1,1,0.473166666,4
-male,white,50-59,some college,CO,1,1,0.473166666,4
-male,white,60-69,4-year college,CO,3,1,0.473166666,4
-male,white,60-69,hs,CO,1,1,0.473166666,4
-male,white,60-69,post-grad,CO,2,2,0.473166666,4
-male,white,60-69,some college,CO,1,0,0.473166666,4
-male,white,70+,post-grad,CO,2,1,0.473166666,4
-male,white,70+,some college,CO,1,1,0.473166666,4
-female,black,18-29,some college,CT,1,0,0.428584525,2
-female,black,30-39,some college,CT,1,1,0.428584525,2
-female,black,40-49,post-grad,CT,1,0,0.428584525,2
-male,black,40-49,hs,CT,1,1,0.428584525,2
-male,black,50-59,4-year college,CT,1,0,0.428584525,2
-female,other,18-29,4-year college,CT,1,1,0.428584525,2
-female,other,18-29,some college,CT,1,0,0.428584525,2
-female,other,40-49,hs,CT,1,1,0.428584525,2
-female,other,60-69,hs,CT,1,0,0.428584525,2
-male,other,30-39,4-year college,CT,1,0,0.428584525,2
-male,other,30-39,post-grad,CT,1,0,0.428584525,2
-male,other,50-59,4-year college,CT,1,1,0.428584525,2
-male,other,50-59,some college,CT,1,0,0.428584525,2
-female,white,18-29,4-year college,CT,2,0,0.428584525,2
-female,white,18-29,post-grad,CT,1,0,0.428584525,2
-female,white,18-29,some college,CT,1,0,0.428584525,2
-female,white,30-39,4-year college,CT,2,0,0.428584525,2
-female,white,30-39,hs,CT,2,1,0.428584525,2
-female,white,30-39,some college,CT,1,1,0.428584525,2
-female,white,40-49,post-grad,CT,1,0,0.428584525,2
-female,white,40-49,some college,CT,3,1,0.428584525,2
-female,white,50-59,4-year college,CT,1,1,0.428584525,2
-female,white,50-59,hs,CT,1,0,0.428584525,2
-female,white,50-59,post-grad,CT,2,0,0.428584525,2
-female,white,50-59,some college,CT,1,1,0.428584525,2
-female,white,60-69,4-year college,CT,1,1,0.428584525,2
-female,white,60-69,hs,CT,2,0,0.428584525,2
-female,white,60-69,no hs,CT,1,1,0.428584525,2
-female,white,60-69,post-grad,CT,1,0,0.428584525,2
-female,white,60-69,some college,CT,1,0,0.428584525,2
-female,white,70+,some college,CT,1,1,0.428584525,2
-male,white,18-29,4-year college,CT,1,0,0.428584525,2
-male,white,18-29,hs,CT,1,1,0.428584525,2
-male,white,30-39,4-year college,CT,1,0,0.428584525,2
-male,white,30-39,some college,CT,1,1,0.428584525,2
-male,white,40-49,4-year college,CT,1,0,0.428584525,2
-male,white,40-49,hs,CT,2,1,0.428584525,2
-male,white,40-49,post-grad,CT,1,1,0.428584525,2
-male,white,50-59,4-year college,CT,1,0,0.428584525,2
-male,white,50-59,post-grad,CT,1,0,0.428584525,2
-male,white,50-59,some college,CT,1,0,0.428584525,2
-male,white,60-69,4-year college,CT,1,0,0.428584525,2
-male,white,60-69,hs,CT,2,1,0.428584525,2
-male,white,60-69,post-grad,CT,2,1,0.428584525,2
-male,white,70+,4-year college,CT,1,0,0.428584525,2
-male,white,70+,post-grad,CT,2,1,0.428584525,2
-male,white,70+,some college,CT,1,0,0.428584525,2
-male,black,18-29,some college,DE,1,1,0.440013786,3
-female,other,40-49,post-grad,DE,1,0,0.440013786,3
-male,other,50-59,some college,DE,1,0,0.440013786,3
-female,white,18-29,4-year college,DE,1,1,0.440013786,3
-female,white,30-39,hs,DE,1,0,0.440013786,3
-female,white,40-49,hs,DE,1,1,0.440013786,3
-female,white,50-59,no hs,DE,1,1,0.440013786,3
-female,white,50-59,post-grad,DE,1,1,0.440013786,3
-female,white,50-59,some college,DE,2,2,0.440013786,3
-female,white,70+,hs,DE,2,1,0.440013786,3
-male,white,40-49,4-year college,DE,1,1,0.440013786,3
-male,white,40-49,post-grad,DE,1,1,0.440013786,3
-male,white,40-49,some college,DE,1,1,0.440013786,3
-male,white,50-59,post-grad,DE,1,0,0.440013786,3
-male,white,50-59,some college,DE,1,1,0.440013786,3
-male,white,60-69,4-year college,DE,1,1,0.440013786,3
-male,white,70+,4-year college,DE,1,1,0.440013786,3
-male,white,70+,hs,DE,2,0,0.440013786,3
-female,black,18-29,hs,FL,1,1,0.506188355,3
-female,black,18-29,no hs,FL,1,0,0.506188355,3
-female,black,18-29,some college,FL,2,0,0.506188355,3
-female,black,30-39,post-grad,FL,1,0,0.506188355,3
-female,black,30-39,some college,FL,4,1,0.506188355,3
-female,black,40-49,4-year college,FL,1,1,0.506188355,3
-female,black,40-49,some college,FL,1,1,0.506188355,3
-female,black,60-69,some college,FL,1,0,0.506188355,3
-female,black,70+,hs,FL,1,0,0.506188355,3
-male,black,18-29,hs,FL,2,1,0.506188355,3
-male,black,18-29,some college,FL,1,0,0.506188355,3
-male,black,40-49,some college,FL,1,1,0.506188355,3
-male,black,50-59,4-year college,FL,1,0,0.506188355,3
-male,black,50-59,some college,FL,1,0,0.506188355,3
-male,black,60-69,some college,FL,2,0,0.506188355,3
-male,black,70+,some college,FL,1,0,0.506188355,3
-female,other,18-29,4-year college,FL,8,3,0.506188355,3
-female,other,18-29,hs,FL,4,2,0.506188355,3
-female,other,18-29,no hs,FL,2,1,0.506188355,3
-female,other,18-29,post-grad,FL,3,0,0.506188355,3
-female,other,18-29,some college,FL,5,3,0.506188355,3
-female,other,30-39,4-year college,FL,2,2,0.506188355,3
-female,other,30-39,no hs,FL,1,0,0.506188355,3
-female,other,30-39,some college,FL,4,0,0.506188355,3
-female,other,40-49,4-year college,FL,2,0,0.506188355,3
-female,other,40-49,hs,FL,1,1,0.506188355,3
-female,other,40-49,some college,FL,3,1,0.506188355,3
-female,other,50-59,4-year college,FL,1,0,0.506188355,3
-female,other,50-59,post-grad,FL,2,0,0.506188355,3
-female,other,50-59,some college,FL,2,1,0.506188355,3
-female,other,60-69,4-year college,FL,1,1,0.506188355,3
-female,other,60-69,hs,FL,1,1,0.506188355,3
-female,other,60-69,some college,FL,2,1,0.506188355,3
-female,other,70+,4-year college,FL,1,1,0.506188355,3
-female,other,70+,post-grad,FL,1,1,0.506188355,3
-female,other,70+,some college,FL,2,1,0.506188355,3
-male,other,18-29,4-year college,FL,1,0,0.506188355,3
-male,other,18-29,hs,FL,2,2,0.506188355,3
-male,other,18-29,post-grad,FL,1,0,0.506188355,3
-male,other,18-29,some college,FL,3,1,0.506188355,3
-male,other,30-39,4-year college,FL,1,0,0.506188355,3
-male,other,30-39,post-grad,FL,1,0,0.506188355,3
-male,other,30-39,some college,FL,2,0,0.506188355,3
-male,other,40-49,4-year college,FL,2,0,0.506188355,3
-male,other,40-49,hs,FL,1,0,0.506188355,3
-male,other,40-49,post-grad,FL,1,1,0.506188355,3
-male,other,40-49,some college,FL,2,1,0.506188355,3
-male,other,50-59,4-year college,FL,1,1,0.506188355,3
-male,other,50-59,post-grad,FL,1,1,0.506188355,3
-male,other,50-59,some college,FL,2,0,0.506188355,3
-male,other,60-69,4-year college,FL,3,1,0.506188355,3
-male,other,60-69,hs,FL,1,1,0.506188355,3
-male,other,60-69,some college,FL,2,2,0.506188355,3
-male,other,70+,post-grad,FL,1,1,0.506188355,3
-female,white,18-29,4-year college,FL,5,1,0.506188355,3
-female,white,18-29,hs,FL,8,3,0.506188355,3
-female,white,18-29,post-grad,FL,1,0,0.506188355,3
-female,white,18-29,some college,FL,6,2,0.506188355,3
-female,white,30-39,4-year college,FL,5,1,0.506188355,3
-female,white,30-39,hs,FL,2,1,0.506188355,3
-female,white,30-39,no hs,FL,1,0,0.506188355,3
-female,white,30-39,post-grad,FL,2,0,0.506188355,3
-female,white,30-39,some college,FL,3,1,0.506188355,3
-female,white,40-49,4-year college,FL,7,3,0.506188355,3
-female,white,40-49,hs,FL,4,2,0.506188355,3
-female,white,40-49,no hs,FL,2,1,0.506188355,3
-female,white,40-49,post-grad,FL,2,0,0.506188355,3
-female,white,40-49,some college,FL,3,0,0.506188355,3
-female,white,50-59,4-year college,FL,4,3,0.506188355,3
-female,white,50-59,hs,FL,11,4,0.506188355,3
-female,white,50-59,post-grad,FL,4,0,0.506188355,3
-female,white,50-59,some college,FL,12,7,0.506188355,3
-female,white,60-69,4-year college,FL,2,1,0.506188355,3
-female,white,60-69,hs,FL,12,7,0.506188355,3
-female,white,60-69,no hs,FL,1,0,0.506188355,3
-female,white,60-69,post-grad,FL,2,0,0.506188355,3
-female,white,60-69,some college,FL,11,6,0.506188355,3
-female,white,70+,4-year college,FL,7,5,0.506188355,3
-female,white,70+,hs,FL,10,6,0.506188355,3
-female,white,70+,no hs,FL,1,0,0.506188355,3
-female,white,70+,post-grad,FL,4,0,0.506188355,3
-female,white,70+,some college,FL,1,0,0.506188355,3
-male,white,18-29,4-year college,FL,4,3,0.506188355,3
-male,white,18-29,hs,FL,4,2,0.506188355,3
-male,white,18-29,no hs,FL,1,0,0.506188355,3
-male,white,18-29,some college,FL,6,3,0.506188355,3
-male,white,30-39,4-year college,FL,2,0,0.506188355,3
-male,white,30-39,hs,FL,2,0,0.506188355,3
-male,white,30-39,post-grad,FL,5,3,0.506188355,3
-male,white,30-39,some college,FL,6,2,0.506188355,3
-male,white,40-49,4-year college,FL,2,0,0.506188355,3
-male,white,40-49,hs,FL,1,1,0.506188355,3
-male,white,40-49,post-grad,FL,3,2,0.506188355,3
-male,white,40-49,some college,FL,1,1,0.506188355,3
-male,white,50-59,4-year college,FL,4,2,0.506188355,3
-male,white,50-59,hs,FL,6,4,0.506188355,3
-male,white,50-59,no hs,FL,1,0,0.506188355,3
-male,white,50-59,post-grad,FL,3,3,0.506188355,3
-male,white,50-59,some college,FL,5,1,0.506188355,3
-male,white,60-69,4-year college,FL,4,3,0.506188355,3
-male,white,60-69,hs,FL,7,3,0.506188355,3
-male,white,60-69,post-grad,FL,4,3,0.506188355,3
-male,white,60-69,some college,FL,7,1,0.506188355,3
-male,white,70+,4-year college,FL,5,4,0.506188355,3
-male,white,70+,hs,FL,6,5,0.506188355,3
-male,white,70+,no hs,FL,2,2,0.506188355,3
-male,white,70+,post-grad,FL,7,3,0.506188355,3
-male,white,70+,some college,FL,6,4,0.506188355,3
-female,black,18-29,4-year college,GA,3,3,0.526611726,3
-female,black,18-29,hs,GA,1,0,0.526611726,3
-female,black,18-29,post-grad,GA,1,1,0.526611726,3
-female,black,18-29,some college,GA,3,1,0.526611726,3
-female,black,30-39,4-year college,GA,1,1,0.526611726,3
-female,black,30-39,hs,GA,1,1,0.526611726,3
-female,black,30-39,no hs,GA,1,0,0.526611726,3
-female,black,30-39,some college,GA,3,2,0.526611726,3
-female,black,40-49,4-year college,GA,3,0,0.526611726,3
-female,black,40-49,post-grad,GA,1,0,0.526611726,3
-female,black,50-59,some college,GA,2,0,0.526611726,3
-female,black,60-69,4-year college,GA,2,1,0.526611726,3
-female,black,60-69,post-grad,GA,1,0,0.526611726,3
-female,black,60-69,some college,GA,2,1,0.526611726,3
-female,black,70+,4-year college,GA,1,0,0.526611726,3
-male,black,18-29,4-year college,GA,1,1,0.526611726,3
-male,black,18-29,some college,GA,2,1,0.526611726,3
-male,black,30-39,4-year college,GA,1,0,0.526611726,3
-male,black,30-39,hs,GA,3,2,0.526611726,3
-male,black,30-39,some college,GA,1,1,0.526611726,3
-male,black,40-49,4-year college,GA,1,1,0.526611726,3
-male,black,40-49,hs,GA,1,1,0.526611726,3
-male,black,40-49,some college,GA,3,0,0.526611726,3
-male,black,60-69,some college,GA,1,0,0.526611726,3
-female,other,18-29,4-year college,GA,1,0,0.526611726,3
-female,other,18-29,hs,GA,2,1,0.526611726,3
-female,other,30-39,4-year college,GA,3,1,0.526611726,3
-female,other,30-39,hs,GA,1,1,0.526611726,3
-female,other,30-39,no hs,GA,1,1,0.526611726,3
-female,other,30-39,some college,GA,1,1,0.526611726,3
-female,other,40-49,4-year college,GA,2,0,0.526611726,3
-male,other,18-29,4-year college,GA,2,0,0.526611726,3
-male,other,18-29,some college,GA,3,0,0.526611726,3
-male,other,30-39,4-year college,GA,2,1,0.526611726,3
-male,other,30-39,no hs,GA,1,1,0.526611726,3
-male,other,40-49,post-grad,GA,2,1,0.526611726,3
-male,other,70+,4-year college,GA,1,1,0.526611726,3
-female,white,18-29,4-year college,GA,2,1,0.526611726,3
-female,white,18-29,hs,GA,3,2,0.526611726,3
-female,white,18-29,no hs,GA,3,0,0.526611726,3
-female,white,18-29,post-grad,GA,1,1,0.526611726,3
-female,white,18-29,some college,GA,5,0,0.526611726,3
-female,white,30-39,4-year college,GA,1,0,0.526611726,3
-female,white,30-39,hs,GA,3,2,0.526611726,3
-female,white,30-39,no hs,GA,1,0,0.526611726,3
-female,white,30-39,post-grad,GA,1,0,0.526611726,3
-female,white,30-39,some college,GA,2,1,0.526611726,3
-female,white,40-49,4-year college,GA,3,3,0.526611726,3
-female,white,40-49,hs,GA,1,0,0.526611726,3
-female,white,40-49,post-grad,GA,1,0,0.526611726,3
-female,white,40-49,some college,GA,1,1,0.526611726,3
-female,white,50-59,4-year college,GA,3,2,0.526611726,3
-female,white,50-59,hs,GA,2,2,0.526611726,3
-female,white,50-59,post-grad,GA,2,2,0.526611726,3
-female,white,50-59,some college,GA,2,2,0.526611726,3
-female,white,60-69,4-year college,GA,3,1,0.526611726,3
-female,white,60-69,hs,GA,7,5,0.526611726,3
-female,white,60-69,post-grad,GA,4,3,0.526611726,3
-female,white,60-69,some college,GA,6,5,0.526611726,3
-female,white,70+,hs,GA,4,4,0.526611726,3
-female,white,70+,some college,GA,2,2,0.526611726,3
-male,white,18-29,4-year college,GA,1,0,0.526611726,3
-male,white,18-29,hs,GA,1,1,0.526611726,3
-male,white,18-29,some college,GA,4,3,0.526611726,3
-male,white,30-39,4-year college,GA,1,1,0.526611726,3
-male,white,30-39,hs,GA,2,2,0.526611726,3
-male,white,30-39,some college,GA,1,1,0.526611726,3
-male,white,40-49,no hs,GA,3,2,0.526611726,3
-male,white,40-49,post-grad,GA,3,2,0.526611726,3
-male,white,50-59,4-year college,GA,1,0,0.526611726,3
-male,white,50-59,hs,GA,1,0,0.526611726,3
-male,white,50-59,no hs,GA,1,1,0.526611726,3
-male,white,50-59,post-grad,GA,2,2,0.526611726,3
-male,white,60-69,4-year college,GA,3,2,0.526611726,3
-male,white,60-69,hs,GA,4,1,0.526611726,3
-male,white,60-69,post-grad,GA,2,1,0.526611726,3
-male,white,60-69,some college,GA,2,2,0.526611726,3
-male,white,70+,4-year college,GA,2,2,0.526611726,3
-male,white,70+,hs,GA,1,1,0.526611726,3
-male,white,70+,post-grad,GA,2,1,0.526611726,3
-male,white,70+,some college,GA,3,2,0.526611726,3
-female,other,30-39,4-year college,HI,1,0,0.325586625,4
-female,other,30-39,some college,HI,1,1,0.325586625,4
-female,other,40-49,hs,HI,2,0,0.325586625,4
-male,other,30-39,some college,HI,1,0,0.325586625,4
-male,other,40-49,4-year college,HI,1,0,0.325586625,4
-male,other,50-59,hs,HI,1,0,0.325586625,4
-male,other,70+,4-year college,HI,1,1,0.325586625,4
-female,white,18-29,some college,HI,1,0,0.325586625,4
-female,white,30-39,4-year college,HI,1,0,0.325586625,4
-female,white,50-59,some college,HI,2,2,0.325586625,4
-female,white,60-69,hs,HI,1,1,0.325586625,4
-female,white,60-69,some college,HI,1,1,0.325586625,4
-female,white,70+,4-year college,HI,1,1,0.325586625,4
-female,white,70+,hs,HI,1,1,0.325586625,4
-female,white,70+,some college,HI,1,0,0.325586625,4
-male,white,50-59,some college,HI,1,0,0.325586625,4
-male,white,60-69,post-grad,HI,2,1,0.325586625,4
-male,white,70+,post-grad,HI,2,1,0.325586625,4
-male,white,70+,some college,HI,1,1,0.325586625,4
-female,other,50-59,hs,IA,1,1,0.550635478,1
-female,other,50-59,no hs,IA,1,1,0.550635478,1
-female,white,18-29,4-year college,IA,2,1,0.550635478,1
-female,white,18-29,hs,IA,1,1,0.550635478,1
-female,white,18-29,post-grad,IA,1,0,0.550635478,1
-female,white,30-39,4-year college,IA,2,0,0.550635478,1
-female,white,30-39,post-grad,IA,1,0,0.550635478,1
-female,white,40-49,hs,IA,3,0,0.550635478,1
-female,white,40-49,post-grad,IA,2,1,0.550635478,1
-female,white,40-49,some college,IA,3,3,0.550635478,1
-female,white,50-59,hs,IA,2,1,0.550635478,1
-female,white,50-59,no hs,IA,1,0,0.550635478,1
-female,white,60-69,hs,IA,4,1,0.550635478,1
-female,white,60-69,some college,IA,1,0,0.550635478,1
-female,white,70+,4-year college,IA,1,1,0.550635478,1
-female,white,70+,no hs,IA,1,1,0.550635478,1
-female,white,70+,some college,IA,1,0,0.550635478,1
-male,white,18-29,4-year college,IA,1,0,0.550635478,1
-male,white,18-29,no hs,IA,1,0,0.550635478,1
-male,white,18-29,some college,IA,1,1,0.550635478,1
-male,white,30-39,hs,IA,1,1,0.550635478,1
-male,white,40-49,hs,IA,1,0,0.550635478,1
-male,white,50-59,4-year college,IA,1,0,0.550635478,1
-male,white,60-69,hs,IA,1,0,0.550635478,1
-male,white,60-69,some college,IA,2,0,0.550635478,1
-male,white,70+,4-year college,IA,1,1,0.550635478,1
-male,white,70+,hs,IA,1,0,0.550635478,1
-male,white,70+,post-grad,IA,2,0,0.550635478,1
-male,white,70+,some college,IA,1,1,0.550635478,1
-female,black,60-69,4-year college,ID,1,0,0.683101767,4
-female,other,18-29,hs,ID,1,0,0.683101767,4
-male,other,30-39,hs,ID,1,1,0.683101767,4
-female,white,18-29,4-year college,ID,1,0,0.683101767,4
-female,white,18-29,no hs,ID,1,1,0.683101767,4
-female,white,18-29,some college,ID,2,1,0.683101767,4
-female,white,40-49,post-grad,ID,1,1,0.683101767,4
-female,white,50-59,hs,ID,2,0,0.683101767,4
-female,white,50-59,some college,ID,1,1,0.683101767,4
-female,white,60-69,hs,ID,1,1,0.683101767,4
-female,white,70+,4-year college,ID,2,1,0.683101767,4
-female,white,70+,hs,ID,2,1,0.683101767,4
-male,white,30-39,some college,ID,1,1,0.683101767,4
-male,white,40-49,4-year college,ID,1,1,0.683101767,4
-male,white,40-49,hs,ID,1,1,0.683101767,4
-male,white,40-49,some college,ID,1,1,0.683101767,4
-male,white,50-59,4-year college,ID,1,0,0.683101767,4
-male,white,50-59,hs,ID,3,1,0.683101767,4
-male,white,60-69,hs,ID,1,0,0.683101767,4
-male,white,70+,4-year college,ID,1,1,0.683101767,4
-male,white,70+,post-grad,ID,2,1,0.683101767,4
-male,white,70+,some college,ID,2,2,0.683101767,4
-female,black,18-29,no hs,IL,1,0,0.409799486,1
-female,black,18-29,post-grad,IL,1,0,0.409799486,1
-female,black,18-29,some college,IL,2,1,0.409799486,1
-female,black,30-39,4-year college,IL,1,0,0.409799486,1
-female,black,30-39,some college,IL,3,1,0.409799486,1
-female,black,40-49,hs,IL,1,1,0.409799486,1
-female,black,40-49,some college,IL,1,0,0.409799486,1
-female,black,50-59,hs,IL,2,0,0.409799486,1
-female,black,50-59,post-grad,IL,3,0,0.409799486,1
-female,black,50-59,some college,IL,2,0,0.409799486,1
-female,black,70+,no hs,IL,1,0,0.409799486,1
-male,black,18-29,some college,IL,1,1,0.409799486,1
-male,black,30-39,4-year college,IL,3,0,0.409799486,1
-male,black,40-49,hs,IL,1,1,0.409799486,1
-male,black,60-69,hs,IL,1,0,0.409799486,1
-female,other,18-29,4-year college,IL,1,1,0.409799486,1
-female,other,18-29,no hs,IL,1,1,0.409799486,1
-female,other,18-29,post-grad,IL,2,1,0.409799486,1
-female,other,18-29,some college,IL,2,1,0.409799486,1
-female,other,30-39,4-year college,IL,1,0,0.409799486,1
-female,other,30-39,hs,IL,1,0,0.409799486,1
-female,other,30-39,no hs,IL,1,0,0.409799486,1
-female,other,30-39,some college,IL,1,0,0.409799486,1
-female,other,40-49,4-year college,IL,1,0,0.409799486,1
-female,other,40-49,some college,IL,1,0,0.409799486,1
-female,other,70+,hs,IL,1,1,0.409799486,1
-male,other,18-29,post-grad,IL,1,1,0.409799486,1
-male,other,18-29,some college,IL,1,1,0.409799486,1
-male,other,30-39,4-year college,IL,1,0,0.409799486,1
-male,other,30-39,post-grad,IL,1,0,0.409799486,1
-male,other,30-39,some college,IL,1,1,0.409799486,1
-male,other,40-49,4-year college,IL,1,1,0.409799486,1
-male,other,40-49,some college,IL,1,1,0.409799486,1
-male,other,50-59,post-grad,IL,1,0,0.409799486,1
-female,white,18-29,4-year college,IL,10,2,0.409799486,1
-female,white,18-29,hs,IL,1,1,0.409799486,1
-female,white,18-29,no hs,IL,1,0,0.409799486,1
-female,white,18-29,some college,IL,3,3,0.409799486,1
-female,white,30-39,4-year college,IL,5,0,0.409799486,1
-female,white,30-39,hs,IL,5,2,0.409799486,1
-female,white,30-39,post-grad,IL,2,0,0.409799486,1
-female,white,30-39,some college,IL,5,1,0.409799486,1
-female,white,40-49,4-year college,IL,4,2,0.409799486,1
-female,white,40-49,hs,IL,5,2,0.409799486,1
-female,white,40-49,post-grad,IL,4,1,0.409799486,1
-female,white,40-49,some college,IL,3,2,0.409799486,1
-female,white,50-59,4-year college,IL,2,1,0.409799486,1
-female,white,50-59,hs,IL,6,1,0.409799486,1
-female,white,50-59,no hs,IL,1,1,0.409799486,1
-female,white,50-59,post-grad,IL,3,1,0.409799486,1
-female,white,50-59,some college,IL,1,1,0.409799486,1
-female,white,60-69,4-year college,IL,1,1,0.409799486,1
-female,white,60-69,hs,IL,7,3,0.409799486,1
-female,white,60-69,no hs,IL,1,1,0.409799486,1
-female,white,60-69,post-grad,IL,2,0,0.409799486,1
-female,white,60-69,some college,IL,2,0,0.409799486,1
-female,white,70+,hs,IL,3,1,0.409799486,1
-female,white,70+,no hs,IL,1,1,0.409799486,1
-female,white,70+,some college,IL,3,1,0.409799486,1
-male,white,18-29,4-year college,IL,1,1,0.409799486,1
-male,white,18-29,hs,IL,2,2,0.409799486,1
-male,white,18-29,some college,IL,3,1,0.409799486,1
-male,white,30-39,4-year college,IL,5,1,0.409799486,1
-male,white,30-39,hs,IL,3,2,0.409799486,1
-male,white,30-39,post-grad,IL,1,0,0.409799486,1
-male,white,30-39,some college,IL,1,0,0.409799486,1
-male,white,40-49,4-year college,IL,1,0,0.409799486,1
-male,white,40-49,hs,IL,5,2,0.409799486,1
-male,white,40-49,post-grad,IL,1,0,0.409799486,1
-male,white,40-49,some college,IL,4,2,0.409799486,1
-male,white,50-59,4-year college,IL,4,2,0.409799486,1
-male,white,50-59,hs,IL,1,1,0.409799486,1
-male,white,50-59,post-grad,IL,1,1,0.409799486,1
-male,white,50-59,some college,IL,3,3,0.409799486,1
-male,white,60-69,4-year college,IL,1,1,0.409799486,1
-male,white,60-69,hs,IL,6,2,0.409799486,1
-male,white,60-69,no hs,IL,1,0,0.409799486,1
-male,white,60-69,some college,IL,8,4,0.409799486,1
-male,white,70+,4-year college,IL,3,2,0.409799486,1
-male,white,70+,post-grad,IL,3,2,0.409799486,1
-female,black,30-39,post-grad,IN,1,0,0.601173095,1
-female,black,30-39,some college,IN,3,0,0.601173095,1
-female,black,40-49,post-grad,IN,1,0,0.601173095,1
-female,black,40-49,some college,IN,1,1,0.601173095,1
-female,black,50-59,hs,IN,1,0,0.601173095,1
-female,black,50-59,some college,IN,1,0,0.601173095,1
-female,black,60-69,some college,IN,2,0,0.601173095,1
-male,black,30-39,hs,IN,1,0,0.601173095,1
-male,black,40-49,4-year college,IN,1,1,0.601173095,1
-male,black,50-59,hs,IN,1,1,0.601173095,1
-female,other,18-29,hs,IN,1,0,0.601173095,1
-female,other,18-29,some college,IN,2,1,0.601173095,1
-female,other,30-39,4-year college,IN,1,1,0.601173095,1
-female,other,30-39,hs,IN,1,1,0.601173095,1
-male,other,18-29,hs,IN,1,0,0.601173095,1
-male,other,50-59,some college,IN,1,1,0.601173095,1
-male,other,60-69,some college,IN,1,0,0.601173095,1
-male,other,70+,4-year college,IN,1,1,0.601173095,1
-female,white,18-29,4-year college,IN,2,1,0.601173095,1
-female,white,18-29,hs,IN,4,2,0.601173095,1
-female,white,18-29,post-grad,IN,1,1,0.601173095,1
-female,white,18-29,some college,IN,6,4,0.601173095,1
-female,white,30-39,4-year college,IN,4,4,0.601173095,1
-female,white,30-39,hs,IN,2,1,0.601173095,1
-female,white,30-39,no hs,IN,1,1,0.601173095,1
-female,white,30-39,post-grad,IN,1,0,0.601173095,1
-female,white,30-39,some college,IN,2,1,0.601173095,1
-female,white,40-49,4-year college,IN,1,0,0.601173095,1
-female,white,40-49,hs,IN,2,2,0.601173095,1
-female,white,40-49,no hs,IN,1,0,0.601173095,1
-female,white,40-49,post-grad,IN,1,1,0.601173095,1
-female,white,40-49,some college,IN,3,1,0.601173095,1
-female,white,50-59,4-year college,IN,1,0,0.601173095,1
-female,white,50-59,hs,IN,4,0,0.601173095,1
-female,white,50-59,no hs,IN,1,0,0.601173095,1
-female,white,50-59,post-grad,IN,1,0,0.601173095,1
-female,white,50-59,some college,IN,2,0,0.601173095,1
-female,white,60-69,4-year college,IN,1,1,0.601173095,1
-female,white,60-69,hs,IN,7,3,0.601173095,1
-female,white,60-69,post-grad,IN,2,2,0.601173095,1
-female,white,70+,4-year college,IN,1,1,0.601173095,1
-female,white,70+,hs,IN,3,0,0.601173095,1
-female,white,70+,no hs,IN,1,1,0.601173095,1
-female,white,70+,post-grad,IN,1,1,0.601173095,1
-male,white,18-29,hs,IN,3,2,0.601173095,1
-male,white,18-29,no hs,IN,1,1,0.601173095,1
-male,white,18-29,post-grad,IN,1,0,0.601173095,1
-male,white,18-29,some college,IN,2,1,0.601173095,1
-male,white,30-39,4-year college,IN,3,1,0.601173095,1
-male,white,30-39,hs,IN,1,1,0.601173095,1
-male,white,30-39,post-grad,IN,1,0,0.601173095,1
-male,white,30-39,some college,IN,6,3,0.601173095,1
-male,white,40-49,4-year college,IN,1,0,0.601173095,1
-male,white,40-49,hs,IN,2,1,0.601173095,1
-male,white,40-49,post-grad,IN,3,1,0.601173095,1
-male,white,40-49,some college,IN,2,0,0.601173095,1
-male,white,50-59,4-year college,IN,4,1,0.601173095,1
-male,white,50-59,hs,IN,1,1,0.601173095,1
-male,white,50-59,post-grad,IN,1,0,0.601173095,1
-male,white,50-59,some college,IN,1,0,0.601173095,1
-male,white,60-69,4-year college,IN,2,2,0.601173095,1
-male,white,60-69,hs,IN,3,2,0.601173095,1
-male,white,60-69,post-grad,IN,1,1,0.601173095,1
-male,white,60-69,some college,IN,3,3,0.601173095,1
-male,white,70+,hs,IN,2,1,0.601173095,1
-male,white,70+,post-grad,IN,2,2,0.601173095,1
-male,white,70+,some college,IN,6,2,0.601173095,1
-female,black,30-39,no hs,KS,1,1,0.611114703,1
-female,black,30-39,some college,KS,1,1,0.611114703,1
-female,black,40-49,4-year college,KS,1,0,0.611114703,1
-female,black,60-69,some college,KS,1,0,0.611114703,1
-female,other,30-39,post-grad,KS,1,0,0.611114703,1
-female,other,50-59,post-grad,KS,1,0,0.611114703,1
-female,white,18-29,4-year college,KS,2,2,0.611114703,1
-female,white,18-29,no hs,KS,1,0,0.611114703,1
-female,white,30-39,hs,KS,1,1,0.611114703,1
-female,white,30-39,post-grad,KS,1,0,0.611114703,1
-female,white,40-49,hs,KS,1,1,0.611114703,1
-female,white,40-49,post-grad,KS,1,1,0.611114703,1
-female,white,40-49,some college,KS,1,0,0.611114703,1
-female,white,50-59,hs,KS,1,0,0.611114703,1
-female,white,60-69,4-year college,KS,1,1,0.611114703,1
-female,white,60-69,hs,KS,1,0,0.611114703,1
-female,white,60-69,post-grad,KS,3,1,0.611114703,1
-female,white,70+,hs,KS,2,0,0.611114703,1
-female,white,70+,some college,KS,2,2,0.611114703,1
-male,white,18-29,4-year college,KS,1,1,0.611114703,1
-male,white,18-29,some college,KS,1,1,0.611114703,1
-male,white,30-39,4-year college,KS,1,0,0.611114703,1
-male,white,30-39,hs,KS,2,0,0.611114703,1
-male,white,40-49,hs,KS,1,0,0.611114703,1
-male,white,40-49,some college,KS,1,0,0.611114703,1
-male,white,50-59,4-year college,KS,2,1,0.611114703,1
-male,white,50-59,hs,KS,1,0,0.611114703,1
-male,white,50-59,post-grad,KS,1,0,0.611114703,1
-male,white,50-59,some college,KS,1,0,0.611114703,1
-male,white,60-69,4-year college,KS,1,1,0.611114703,1
-male,white,60-69,some college,KS,2,0,0.611114703,1
-male,white,70+,4-year college,KS,1,0,0.611114703,1
-male,white,70+,some college,KS,3,3,0.611114703,1
-female,black,60-69,hs,KY,1,0,0.65670629,3
-male,black,60-69,hs,KY,1,0,0.65670629,3
-female,other,18-29,hs,KY,1,0,0.65670629,3
-female,other,30-39,4-year college,KY,1,0,0.65670629,3
-female,other,30-39,some college,KY,1,1,0.65670629,3
-female,other,40-49,4-year college,KY,1,1,0.65670629,3
-female,other,50-59,some college,KY,1,1,0.65670629,3
-female,other,70+,post-grad,KY,1,1,0.65670629,3
-male,other,30-39,4-year college,KY,2,0,0.65670629,3
-female,white,18-29,4-year college,KY,2,0,0.65670629,3
-female,white,18-29,hs,KY,4,2,0.65670629,3
-female,white,18-29,post-grad,KY,1,0,0.65670629,3
-female,white,30-39,4-year college,KY,1,1,0.65670629,3
-female,white,30-39,hs,KY,1,1,0.65670629,3
-female,white,30-39,post-grad,KY,1,0,0.65670629,3
-female,white,30-39,some college,KY,2,2,0.65670629,3
-female,white,40-49,4-year college,KY,2,0,0.65670629,3
-female,white,40-49,hs,KY,1,0,0.65670629,3
-female,white,40-49,no hs,KY,1,0,0.65670629,3
-female,white,40-49,some college,KY,1,1,0.65670629,3
-female,white,50-59,hs,KY,1,0,0.65670629,3
-female,white,50-59,no hs,KY,1,1,0.65670629,3
-female,white,50-59,some college,KY,4,2,0.65670629,3
-female,white,60-69,hs,KY,6,2,0.65670629,3
-female,white,60-69,no hs,KY,1,0,0.65670629,3
-female,white,60-69,post-grad,KY,1,0,0.65670629,3
-female,white,60-69,some college,KY,4,4,0.65670629,3
-female,white,70+,hs,KY,1,1,0.65670629,3
-female,white,70+,no hs,KY,1,1,0.65670629,3
-female,white,70+,some college,KY,1,1,0.65670629,3
-male,white,18-29,hs,KY,2,0,0.65670629,3
-male,white,18-29,post-grad,KY,1,0,0.65670629,3
-male,white,18-29,some college,KY,3,1,0.65670629,3
-male,white,30-39,4-year college,KY,1,0,0.65670629,3
-male,white,30-39,hs,KY,1,0,0.65670629,3
-male,white,30-39,post-grad,KY,2,1,0.65670629,3
-male,white,30-39,some college,KY,3,1,0.65670629,3
-male,white,40-49,4-year college,KY,1,1,0.65670629,3
-male,white,40-49,hs,KY,1,0,0.65670629,3
-male,white,40-49,post-grad,KY,1,0,0.65670629,3
-male,white,40-49,some college,KY,2,1,0.65670629,3
-male,white,50-59,4-year college,KY,3,2,0.65670629,3
-male,white,50-59,hs,KY,3,2,0.65670629,3
-male,white,50-59,no hs,KY,1,0,0.65670629,3
-male,white,50-59,post-grad,KY,1,0,0.65670629,3
-male,white,50-59,some college,KY,1,0,0.65670629,3
-male,white,60-69,hs,KY,3,2,0.65670629,3
-male,white,60-69,no hs,KY,1,1,0.65670629,3
-male,white,60-69,post-grad,KY,1,0,0.65670629,3
-male,white,60-69,some college,KY,2,1,0.65670629,3
-male,white,70+,4-year college,KY,1,0,0.65670629,3
-male,white,70+,hs,KY,1,1,0.65670629,3
-male,white,70+,some college,KY,1,1,0.65670629,3
-female,black,18-29,hs,LA,1,0,0.601716772,3
-female,black,18-29,some college,LA,1,0,0.601716772,3
-female,black,30-39,hs,LA,2,1,0.601716772,3
-female,black,30-39,some college,LA,2,2,0.601716772,3
-female,black,40-49,4-year college,LA,1,0,0.601716772,3
-female,black,60-69,4-year college,LA,1,0,0.601716772,3
-male,black,18-29,hs,LA,1,1,0.601716772,3
-male,black,18-29,some college,LA,1,0,0.601716772,3
-male,black,30-39,hs,LA,1,0,0.601716772,3
-male,black,50-59,4-year college,LA,1,0,0.601716772,3
-male,black,60-69,some college,LA,1,1,0.601716772,3
-female,other,18-29,some college,LA,1,1,0.601716772,3
-female,other,30-39,some college,LA,1,0,0.601716772,3
-male,other,18-29,no hs,LA,1,1,0.601716772,3
-male,other,30-39,4-year college,LA,1,0,0.601716772,3
-male,other,50-59,post-grad,LA,1,1,0.601716772,3
-male,other,70+,post-grad,LA,1,1,0.601716772,3
-female,white,18-29,4-year college,LA,1,1,0.601716772,3
-female,white,18-29,post-grad,LA,1,1,0.601716772,3
-female,white,18-29,some college,LA,4,1,0.601716772,3
-female,white,30-39,4-year college,LA,2,1,0.601716772,3
-female,white,30-39,post-grad,LA,2,1,0.601716772,3
-female,white,30-39,some college,LA,1,1,0.601716772,3
-female,white,40-49,hs,LA,5,3,0.601716772,3
-female,white,50-59,4-year college,LA,1,1,0.601716772,3
-female,white,50-59,hs,LA,2,1,0.601716772,3
-female,white,50-59,some college,LA,3,1,0.601716772,3
-female,white,60-69,hs,LA,3,3,0.601716772,3
-female,white,60-69,some college,LA,1,1,0.601716772,3
-female,white,70+,some college,LA,2,2,0.601716772,3
-male,white,18-29,hs,LA,2,1,0.601716772,3
-male,white,18-29,no hs,LA,2,1,0.601716772,3
-male,white,18-29,some college,LA,1,1,0.601716772,3
-male,white,30-39,some college,LA,1,0,0.601716772,3
-male,white,50-59,some college,LA,1,1,0.601716772,3
-male,white,60-69,some college,LA,3,2,0.601716772,3
-male,white,70+,post-grad,LA,1,0,0.601716772,3
-female,black,18-29,hs,MA,1,1,0.353487213,2
-female,black,18-29,some college,MA,1,0,0.353487213,2
-female,black,30-39,post-grad,MA,1,0,0.353487213,2
-male,black,18-29,4-year college,MA,1,1,0.353487213,2
-female,other,18-29,no hs,MA,1,0,0.353487213,2
-female,other,18-29,post-grad,MA,1,1,0.353487213,2
-female,other,18-29,some college,MA,2,1,0.353487213,2
-female,other,30-39,4-year college,MA,1,1,0.353487213,2
-female,other,30-39,hs,MA,1,0,0.353487213,2
-female,other,30-39,post-grad,MA,1,0,0.353487213,2
-female,other,30-39,some college,MA,1,0,0.353487213,2
-female,other,40-49,4-year college,MA,1,0,0.353487213,2
-female,other,40-49,post-grad,MA,1,0,0.353487213,2
-male,other,40-49,no hs,MA,1,0,0.353487213,2
-male,other,40-49,some college,MA,1,0,0.353487213,2
-male,other,50-59,4-year college,MA,1,0,0.353487213,2
-female,white,18-29,4-year college,MA,3,0,0.353487213,2
-female,white,18-29,hs,MA,1,0,0.353487213,2
-female,white,18-29,no hs,MA,1,1,0.353487213,2
-female,white,18-29,post-grad,MA,1,0,0.353487213,2
-female,white,18-29,some college,MA,4,0,0.353487213,2
-female,white,30-39,4-year college,MA,1,0,0.353487213,2
-female,white,30-39,hs,MA,1,0,0.353487213,2
-female,white,30-39,post-grad,MA,2,1,0.353487213,2
-female,white,30-39,some college,MA,3,1,0.353487213,2
-female,white,40-49,4-year college,MA,1,0,0.353487213,2
-female,white,40-49,hs,MA,4,0,0.353487213,2
-female,white,40-49,some college,MA,2,1,0.353487213,2
-female,white,50-59,4-year college,MA,1,0,0.353487213,2
-female,white,50-59,hs,MA,6,2,0.353487213,2
-female,white,50-59,some college,MA,1,0,0.353487213,2
-female,white,60-69,4-year college,MA,4,0,0.353487213,2
-female,white,60-69,hs,MA,7,1,0.353487213,2
-female,white,60-69,post-grad,MA,2,0,0.353487213,2
-female,white,60-69,some college,MA,2,0,0.353487213,2
-female,white,70+,4-year college,MA,1,0,0.353487213,2
-female,white,70+,hs,MA,1,1,0.353487213,2
-female,white,70+,no hs,MA,1,1,0.353487213,2
-female,white,70+,post-grad,MA,3,0,0.353487213,2
-female,white,70+,some college,MA,1,0,0.353487213,2
-male,white,18-29,4-year college,MA,1,0,0.353487213,2
-male,white,18-29,post-grad,MA,1,1,0.353487213,2
-male,white,30-39,4-year college,MA,1,0,0.353487213,2
-male,white,30-39,post-grad,MA,3,1,0.353487213,2
-male,white,40-49,4-year college,MA,1,1,0.353487213,2
-male,white,40-49,hs,MA,4,0,0.353487213,2
-male,white,40-49,post-grad,MA,1,0,0.353487213,2
-male,white,40-49,some college,MA,1,0,0.353487213,2
-male,white,50-59,4-year college,MA,2,1,0.353487213,2
-male,white,50-59,hs,MA,1,1,0.353487213,2
-male,white,50-59,post-grad,MA,1,0,0.353487213,2
-male,white,50-59,some college,MA,1,1,0.353487213,2
-male,white,60-69,hs,MA,2,1,0.353487213,2
-male,white,60-69,post-grad,MA,2,2,0.353487213,2
-male,white,70+,4-year college,MA,2,1,0.353487213,2
-male,white,70+,post-grad,MA,1,0,0.353487213,2
-male,white,70+,some college,MA,2,1,0.353487213,2
-female,black,18-29,post-grad,MD,1,0,0.359837503,3
-female,black,30-39,4-year college,MD,1,0,0.359837503,3
-female,black,30-39,no hs,MD,1,0,0.359837503,3
-female,black,30-39,post-grad,MD,1,0,0.359837503,3
-female,black,40-49,4-year college,MD,4,1,0.359837503,3
-female,black,40-49,hs,MD,1,1,0.359837503,3
-female,black,40-49,post-grad,MD,1,0,0.359837503,3
-female,black,40-49,some college,MD,2,1,0.359837503,3
-female,black,50-59,4-year college,MD,1,1,0.359837503,3
-female,black,50-59,no hs,MD,1,1,0.359837503,3
-female,black,50-59,some college,MD,3,1,0.359837503,3
-female,black,60-69,some college,MD,1,0,0.359837503,3
-male,black,18-29,4-year college,MD,1,0,0.359837503,3
-male,black,30-39,4-year college,MD,1,1,0.359837503,3
-male,black,30-39,some college,MD,1,0,0.359837503,3
-male,black,70+,post-grad,MD,1,0,0.359837503,3
-female,other,30-39,post-grad,MD,1,0,0.359837503,3
-male,other,40-49,4-year college,MD,1,1,0.359837503,3
-male,other,50-59,some college,MD,1,1,0.359837503,3
-male,other,60-69,4-year college,MD,1,0,0.359837503,3
-female,white,18-29,4-year college,MD,1,0,0.359837503,3
-female,white,18-29,hs,MD,2,0,0.359837503,3
-female,white,18-29,some college,MD,1,0,0.359837503,3
-female,white,30-39,4-year college,MD,2,1,0.359837503,3
-female,white,30-39,hs,MD,1,0,0.359837503,3
-female,white,30-39,post-grad,MD,2,0,0.359837503,3
-female,white,30-39,some college,MD,1,0,0.359837503,3
-female,white,40-49,4-year college,MD,1,0,0.359837503,3
-female,white,40-49,some college,MD,1,0,0.359837503,3
-female,white,50-59,hs,MD,3,0,0.359837503,3
-female,white,50-59,post-grad,MD,3,1,0.359837503,3
-female,white,50-59,some college,MD,2,2,0.359837503,3
-female,white,60-69,4-year college,MD,3,1,0.359837503,3
-female,white,60-69,hs,MD,1,1,0.359837503,3
-female,white,60-69,no hs,MD,1,1,0.359837503,3
-female,white,60-69,post-grad,MD,3,3,0.359837503,3
-female,white,70+,4-year college,MD,1,0,0.359837503,3
-female,white,70+,hs,MD,2,1,0.359837503,3
-female,white,70+,post-grad,MD,2,1,0.359837503,3
-female,white,70+,some college,MD,1,0,0.359837503,3
-male,white,18-29,4-year college,MD,1,0,0.359837503,3
-male,white,18-29,hs,MD,2,2,0.359837503,3
-male,white,18-29,post-grad,MD,1,0,0.359837503,3
-male,white,18-29,some college,MD,1,0,0.359837503,3
-male,white,30-39,4-year college,MD,4,3,0.359837503,3
-male,white,30-39,post-grad,MD,3,1,0.359837503,3
-male,white,30-39,some college,MD,1,0,0.359837503,3
-male,white,40-49,4-year college,MD,1,1,0.359837503,3
-male,white,40-49,post-grad,MD,1,0,0.359837503,3
-male,white,40-49,some college,MD,2,1,0.359837503,3
-male,white,50-59,4-year college,MD,5,2,0.359837503,3
-male,white,50-59,hs,MD,2,1,0.359837503,3
-male,white,50-59,some college,MD,1,0,0.359837503,3
-male,white,60-69,4-year college,MD,1,0,0.359837503,3
-male,white,60-69,hs,MD,1,0,0.359837503,3
-male,white,60-69,post-grad,MD,4,2,0.359837503,3
-male,white,60-69,some college,MD,1,1,0.359837503,3
-male,white,70+,4-year college,MD,1,1,0.359837503,3
-male,white,70+,hs,MD,3,1,0.359837503,3
-male,white,70+,no hs,MD,1,1,0.359837503,3
-male,white,70+,some college,MD,2,2,0.359837503,3
-female,white,18-29,4-year college,ME,2,0,0.484032089,2
-female,white,18-29,hs,ME,4,1,0.484032089,2
-female,white,30-39,some college,ME,1,0,0.484032089,2
-female,white,40-49,no hs,ME,1,0,0.484032089,2
-female,white,50-59,hs,ME,2,0,0.484032089,2
-female,white,50-59,some college,ME,2,1,0.484032089,2
-female,white,60-69,hs,ME,1,0,0.484032089,2
-female,white,60-69,some college,ME,1,1,0.484032089,2
-female,white,70+,post-grad,ME,1,0,0.484032089,2
-male,white,40-49,4-year college,ME,1,0,0.484032089,2
-male,white,40-49,some college,ME,1,0,0.484032089,2
-male,white,70+,some college,ME,1,0,0.484032089,2
-female,black,18-29,some college,MI,2,0,0.501176682,1
-female,black,30-39,hs,MI,1,0,0.501176682,1
-female,black,40-49,4-year college,MI,1,0,0.501176682,1
-female,black,40-49,some college,MI,1,1,0.501176682,1
-female,black,50-59,4-year college,MI,1,0,0.501176682,1
-female,black,60-69,4-year college,MI,1,1,0.501176682,1
-female,black,60-69,hs,MI,1,0,0.501176682,1
-female,black,60-69,some college,MI,1,1,0.501176682,1
-female,black,70+,4-year college,MI,1,1,0.501176682,1
-female,black,70+,some college,MI,1,0,0.501176682,1
-male,black,18-29,no hs,MI,1,0,0.501176682,1
-male,black,60-69,4-year college,MI,1,0,0.501176682,1
-male,black,60-69,some college,MI,1,1,0.501176682,1
-female,other,18-29,4-year college,MI,1,0,0.501176682,1
-female,other,18-29,hs,MI,2,0,0.501176682,1
-female,other,18-29,some college,MI,1,0,0.501176682,1
-female,other,30-39,hs,MI,1,1,0.501176682,1
-female,other,30-39,some college,MI,1,0,0.501176682,1
-female,other,50-59,some college,MI,1,1,0.501176682,1
-male,other,18-29,4-year college,MI,1,0,0.501176682,1
-male,other,18-29,hs,MI,1,1,0.501176682,1
-male,other,18-29,post-grad,MI,1,0,0.501176682,1
-male,other,18-29,some college,MI,2,0,0.501176682,1
-male,other,40-49,some college,MI,1,0,0.501176682,1
-female,white,18-29,4-year college,MI,4,3,0.501176682,1
-female,white,18-29,hs,MI,6,0,0.501176682,1
-female,white,18-29,post-grad,MI,1,0,0.501176682,1
-female,white,18-29,some college,MI,6,1,0.501176682,1
-female,white,30-39,4-year college,MI,3,1,0.501176682,1
-female,white,30-39,hs,MI,2,0,0.501176682,1
-female,white,30-39,post-grad,MI,2,0,0.501176682,1
-female,white,30-39,some college,MI,6,2,0.501176682,1
-female,white,40-49,4-year college,MI,2,1,0.501176682,1
-female,white,40-49,hs,MI,1,0,0.501176682,1
-female,white,40-49,no hs,MI,2,0,0.501176682,1
-female,white,40-49,post-grad,MI,1,0,0.501176682,1
-female,white,40-49,some college,MI,4,3,0.501176682,1
-female,white,50-59,4-year college,MI,3,1,0.501176682,1
-female,white,50-59,no hs,MI,1,1,0.501176682,1
-female,white,50-59,post-grad,MI,1,1,0.501176682,1
-female,white,50-59,some college,MI,3,1,0.501176682,1
-female,white,60-69,4-year college,MI,7,3,0.501176682,1
-female,white,60-69,hs,MI,4,2,0.501176682,1
-female,white,60-69,no hs,MI,1,0,0.501176682,1
-female,white,60-69,post-grad,MI,1,0,0.501176682,1
-female,white,60-69,some college,MI,4,0,0.501176682,1
-female,white,70+,4-year college,MI,1,0,0.501176682,1
-female,white,70+,hs,MI,3,3,0.501176682,1
-female,white,70+,post-grad,MI,1,0,0.501176682,1
-female,white,70+,some college,MI,1,1,0.501176682,1
-male,white,18-29,4-year college,MI,1,1,0.501176682,1
-male,white,18-29,hs,MI,5,1,0.501176682,1
-male,white,18-29,some college,MI,1,0,0.501176682,1
-male,white,30-39,4-year college,MI,5,1,0.501176682,1
-male,white,30-39,post-grad,MI,5,1,0.501176682,1
-male,white,30-39,some college,MI,1,0,0.501176682,1
-male,white,40-49,4-year college,MI,2,1,0.501176682,1
-male,white,40-49,hs,MI,1,1,0.501176682,1
-male,white,40-49,some college,MI,2,0,0.501176682,1
-male,white,50-59,4-year college,MI,4,2,0.501176682,1
-male,white,50-59,hs,MI,1,0,0.501176682,1
-male,white,50-59,some college,MI,7,5,0.501176682,1
-male,white,60-69,4-year college,MI,3,3,0.501176682,1
-male,white,60-69,hs,MI,5,2,0.501176682,1
-male,white,60-69,post-grad,MI,2,0,0.501176682,1
-male,white,60-69,some college,MI,1,0,0.501176682,1
-male,white,70+,4-year college,MI,2,0,0.501176682,1
-male,white,70+,hs,MI,3,2,0.501176682,1
-male,white,70+,post-grad,MI,3,1,0.501176682,1
-male,white,70+,some college,MI,2,2,0.501176682,1
-female,black,18-29,4-year college,MN,1,0,0.491681431,1
-female,black,50-59,some college,MN,1,0,0.491681431,1
-female,other,18-29,some college,MN,2,0,0.491681431,1
-female,other,30-39,hs,MN,2,1,0.491681431,1
-female,other,30-39,post-grad,MN,1,0,0.491681431,1
-female,other,50-59,post-grad,MN,1,0,0.491681431,1
-male,other,18-29,some college,MN,1,0,0.491681431,1
-male,other,30-39,some college,MN,1,1,0.491681431,1
-male,other,40-49,4-year college,MN,1,1,0.491681431,1
-male,other,70+,some college,MN,1,1,0.491681431,1
-female,white,18-29,4-year college,MN,3,2,0.491681431,1
-female,white,18-29,hs,MN,1,0,0.491681431,1
-female,white,18-29,some college,MN,4,0,0.491681431,1
-female,white,30-39,post-grad,MN,1,1,0.491681431,1
-female,white,30-39,some college,MN,1,0,0.491681431,1
-female,white,40-49,4-year college,MN,1,1,0.491681431,1
-female,white,40-49,post-grad,MN,1,0,0.491681431,1
-female,white,40-49,some college,MN,2,2,0.491681431,1
-female,white,50-59,4-year college,MN,1,0,0.491681431,1
-female,white,50-59,hs,MN,3,1,0.491681431,1
-female,white,50-59,some college,MN,1,0,0.491681431,1
-female,white,60-69,hs,MN,4,2,0.491681431,1
-female,white,60-69,post-grad,MN,1,0,0.491681431,1
-female,white,60-69,some college,MN,1,0,0.491681431,1
-female,white,70+,hs,MN,2,1,0.491681431,1
-female,white,70+,post-grad,MN,1,1,0.491681431,1
-female,white,70+,some college,MN,1,1,0.491681431,1
-male,white,18-29,4-year college,MN,1,0,0.491681431,1
-male,white,18-29,hs,MN,1,1,0.491681431,1
-male,white,30-39,4-year college,MN,4,1,0.491681431,1
-male,white,30-39,post-grad,MN,2,1,0.491681431,1
-male,white,30-39,some college,MN,3,0,0.491681431,1
-male,white,40-49,4-year college,MN,2,2,0.491681431,1
-male,white,40-49,hs,MN,2,2,0.491681431,1
-male,white,40-49,some college,MN,1,1,0.491681431,1
-male,white,50-59,4-year college,MN,1,0,0.491681431,1
-male,white,50-59,hs,MN,1,0,0.491681431,1
-male,white,50-59,some college,MN,3,3,0.491681431,1
-male,white,60-69,hs,MN,1,0,0.491681431,1
-male,white,60-69,post-grad,MN,1,1,0.491681431,1
-male,white,70+,4-year college,MN,1,0,0.491681431,1
-male,white,70+,post-grad,MN,2,1,0.491681431,1
-male,white,70+,some college,MN,1,0,0.491681431,1
-female,black,30-39,4-year college,MO,1,0,0.59818561,1
-female,black,30-39,no hs,MO,1,0,0.59818561,1
-female,black,40-49,4-year college,MO,1,0,0.59818561,1
-female,black,50-59,hs,MO,1,1,0.59818561,1
-male,black,18-29,some college,MO,1,0,0.59818561,1
-male,black,50-59,4-year college,MO,1,0,0.59818561,1
-male,black,50-59,some college,MO,1,0,0.59818561,1
-female,other,30-39,4-year college,MO,1,1,0.59818561,1
-female,other,30-39,some college,MO,1,0,0.59818561,1
-male,other,18-29,hs,MO,2,1,0.59818561,1
-male,other,18-29,some college,MO,1,0,0.59818561,1
-male,other,40-49,some college,MO,1,1,0.59818561,1
-male,other,50-59,4-year college,MO,1,1,0.59818561,1
-male,other,60-69,hs,MO,1,0,0.59818561,1
-female,white,18-29,4-year college,MO,2,2,0.59818561,1
-female,white,18-29,hs,MO,3,0,0.59818561,1
-female,white,18-29,post-grad,MO,2,1,0.59818561,1
-female,white,18-29,some college,MO,6,4,0.59818561,1
-female,white,30-39,4-year college,MO,2,0,0.59818561,1
-female,white,30-39,hs,MO,2,1,0.59818561,1
-female,white,30-39,post-grad,MO,6,3,0.59818561,1
-female,white,30-39,some college,MO,3,1,0.59818561,1
-female,white,40-49,4-year college,MO,1,1,0.59818561,1
-female,white,40-49,some college,MO,3,2,0.59818561,1
-female,white,50-59,4-year college,MO,2,1,0.59818561,1
-female,white,50-59,hs,MO,4,2,0.59818561,1
-female,white,50-59,post-grad,MO,2,0,0.59818561,1
-female,white,50-59,some college,MO,3,2,0.59818561,1
-female,white,60-69,4-year college,MO,3,1,0.59818561,1
-female,white,60-69,hs,MO,6,4,0.59818561,1
-female,white,60-69,post-grad,MO,3,2,0.59818561,1
-female,white,60-69,some college,MO,5,4,0.59818561,1
-female,white,70+,hs,MO,4,3,0.59818561,1
-female,white,70+,post-grad,MO,1,0,0.59818561,1
-female,white,70+,some college,MO,2,1,0.59818561,1
-male,white,18-29,4-year college,MO,3,3,0.59818561,1
-male,white,18-29,hs,MO,1,1,0.59818561,1
-male,white,18-29,some college,MO,2,0,0.59818561,1
-male,white,30-39,post-grad,MO,2,0,0.59818561,1
-male,white,30-39,some college,MO,1,1,0.59818561,1
-male,white,40-49,hs,MO,2,1,0.59818561,1
-male,white,40-49,no hs,MO,1,1,0.59818561,1
-male,white,40-49,post-grad,MO,1,0,0.59818561,1
-male,white,40-49,some college,MO,2,0,0.59818561,1
-male,white,50-59,4-year college,MO,2,1,0.59818561,1
-male,white,50-59,hs,MO,3,2,0.59818561,1
-male,white,50-59,post-grad,MO,1,0,0.59818561,1
-male,white,50-59,some college,MO,4,1,0.59818561,1
-male,white,60-69,4-year college,MO,2,1,0.59818561,1
-male,white,60-69,hs,MO,2,0,0.59818561,1
-male,white,70+,4-year college,MO,2,2,0.59818561,1
-male,white,70+,hs,MO,4,2,0.59818561,1
-male,white,70+,post-grad,MO,4,2,0.59818561,1
-male,white,70+,some college,MO,2,1,0.59818561,1
-female,black,18-29,4-year college,MS,1,1,0.590898473,3
-female,black,18-29,no hs,MS,1,1,0.590898473,3
-female,black,30-39,hs,MS,1,0,0.590898473,3
-female,black,50-59,4-year college,MS,1,0,0.590898473,3
-female,black,50-59,some college,MS,1,1,0.590898473,3
-female,black,60-69,4-year college,MS,1,1,0.590898473,3
-male,black,18-29,some college,MS,1,1,0.590898473,3
-female,white,18-29,4-year college,MS,1,1,0.590898473,3
-female,white,18-29,some college,MS,4,4,0.590898473,3
-female,white,30-39,4-year college,MS,1,1,0.590898473,3
-female,white,30-39,some college,MS,1,1,0.590898473,3
-female,white,40-49,4-year college,MS,1,0,0.590898473,3
-female,white,50-59,hs,MS,2,1,0.590898473,3
-female,white,50-59,some college,MS,1,1,0.590898473,3
-female,white,60-69,hs,MS,1,0,0.590898473,3
-female,white,60-69,post-grad,MS,1,0,0.590898473,3
-female,white,70+,hs,MS,2,2,0.590898473,3
-female,white,70+,some college,MS,1,0,0.590898473,3
-male,white,18-29,hs,MS,1,1,0.590898473,3
-male,white,30-39,some college,MS,1,0,0.590898473,3
-male,white,50-59,4-year college,MS,1,1,0.590898473,3
-male,white,60-69,4-year college,MS,1,1,0.590898473,3
-male,white,60-69,no hs,MS,1,1,0.590898473,3
-male,white,60-69,post-grad,MS,1,1,0.590898473,3
-male,white,70+,4-year college,MS,1,1,0.590898473,3
-male,white,70+,some college,MS,1,1,0.590898473,3
-female,other,50-59,some college,MT,1,0,0.611096643,4
-male,other,50-59,4-year college,MT,1,1,0.611096643,4
-male,other,70+,hs,MT,1,1,0.611096643,4
-female,white,30-39,4-year college,MT,1,0,0.611096643,4
-female,white,30-39,post-grad,MT,1,0,0.611096643,4
-female,white,40-49,hs,MT,1,0,0.611096643,4
-female,white,40-49,some college,MT,2,2,0.611096643,4
-female,white,50-59,4-year college,MT,2,0,0.611096643,4
-female,white,60-69,4-year college,MT,1,1,0.611096643,4
-female,white,60-69,hs,MT,1,0,0.611096643,4
-female,white,60-69,post-grad,MT,1,0,0.611096643,4
-female,white,70+,hs,MT,1,1,0.611096643,4
-male,white,30-39,hs,MT,1,0,0.611096643,4
-male,white,30-39,post-grad,MT,1,1,0.611096643,4
-male,white,50-59,4-year college,MT,1,0,0.611096643,4
-male,white,50-59,some college,MT,1,1,0.611096643,4
-male,white,60-69,some college,MT,1,0,0.611096643,4
-male,white,70+,4-year college,MT,1,1,0.611096643,4
-female,black,18-29,hs,NC,2,2,0.519037458,3
-female,black,30-39,4-year college,NC,1,0,0.519037458,3
-female,black,30-39,post-grad,NC,1,0,0.519037458,3
-female,black,40-49,some college,NC,2,2,0.519037458,3
-female,black,50-59,4-year college,NC,1,0,0.519037458,3
-female,black,50-59,hs,NC,1,0,0.519037458,3
-female,black,50-59,post-grad,NC,1,0,0.519037458,3
-female,black,60-69,hs,NC,1,0,0.519037458,3
-female,black,70+,4-year college,NC,1,1,0.519037458,3
-female,black,70+,hs,NC,1,0,0.519037458,3
-female,black,70+,post-grad,NC,1,1,0.519037458,3
-male,black,18-29,hs,NC,2,2,0.519037458,3
-male,black,18-29,some college,NC,2,0,0.519037458,3
-male,black,30-39,4-year college,NC,1,1,0.519037458,3
-male,black,50-59,4-year college,NC,1,0,0.519037458,3
-male,black,50-59,some college,NC,1,0,0.519037458,3
-male,black,60-69,some college,NC,1,0,0.519037458,3
-female,other,18-29,4-year college,NC,1,0,0.519037458,3
-female,other,18-29,hs,NC,1,1,0.519037458,3
-female,other,18-29,some college,NC,1,1,0.519037458,3
-female,other,30-39,some college,NC,1,1,0.519037458,3
-female,other,40-49,4-year college,NC,1,0,0.519037458,3
-female,other,40-49,post-grad,NC,1,1,0.519037458,3
-female,other,50-59,some college,NC,1,0,0.519037458,3
-male,other,18-29,hs,NC,1,0,0.519037458,3
-male,other,30-39,4-year college,NC,1,0,0.519037458,3
-male,other,30-39,hs,NC,1,1,0.519037458,3
-male,other,30-39,post-grad,NC,2,0,0.519037458,3
-male,other,30-39,some college,NC,1,0,0.519037458,3
-male,other,50-59,4-year college,NC,1,0,0.519037458,3
-male,other,60-69,4-year college,NC,1,1,0.519037458,3
-female,white,18-29,hs,NC,5,3,0.519037458,3
-female,white,18-29,post-grad,NC,1,0,0.519037458,3
-female,white,18-29,some college,NC,7,2,0.519037458,3
-female,white,30-39,4-year college,NC,1,1,0.519037458,3
-female,white,30-39,hs,NC,2,1,0.519037458,3
-female,white,30-39,no hs,NC,2,0,0.519037458,3
-female,white,30-39,some college,NC,1,0,0.519037458,3
-female,white,40-49,4-year college,NC,1,1,0.519037458,3
-female,white,40-49,hs,NC,2,1,0.519037458,3
-female,white,40-49,post-grad,NC,1,0,0.519037458,3
-female,white,40-49,some college,NC,6,2,0.519037458,3
-female,white,50-59,4-year college,NC,2,1,0.519037458,3
-female,white,50-59,hs,NC,5,4,0.519037458,3
-female,white,50-59,post-grad,NC,1,0,0.519037458,3
-female,white,50-59,some college,NC,3,2,0.519037458,3
-female,white,60-69,4-year college,NC,3,0,0.519037458,3
-female,white,60-69,hs,NC,4,3,0.519037458,3
-female,white,60-69,post-grad,NC,2,0,0.519037458,3
-female,white,60-69,some college,NC,5,2,0.519037458,3
-female,white,70+,hs,NC,6,5,0.519037458,3
-female,white,70+,post-grad,NC,1,0,0.519037458,3
-female,white,70+,some college,NC,1,1,0.519037458,3
-male,white,18-29,4-year college,NC,3,1,0.519037458,3
-male,white,18-29,hs,NC,4,3,0.519037458,3
-male,white,18-29,some college,NC,2,2,0.519037458,3
-male,white,30-39,4-year college,NC,1,1,0.519037458,3
-male,white,30-39,hs,NC,2,1,0.519037458,3
-male,white,30-39,post-grad,NC,1,1,0.519037458,3
-male,white,30-39,some college,NC,3,0,0.519037458,3
-male,white,40-49,4-year college,NC,1,1,0.519037458,3
-male,white,40-49,hs,NC,3,1,0.519037458,3
-male,white,40-49,no hs,NC,1,1,0.519037458,3
-male,white,40-49,some college,NC,5,3,0.519037458,3
-male,white,50-59,4-year college,NC,3,2,0.519037458,3
-male,white,50-59,hs,NC,5,1,0.519037458,3
-male,white,50-59,post-grad,NC,1,1,0.519037458,3
-male,white,50-59,some college,NC,4,4,0.519037458,3
-male,white,60-69,4-year college,NC,1,0,0.519037458,3
-male,white,60-69,hs,NC,3,2,0.519037458,3
-male,white,60-69,no hs,NC,1,1,0.519037458,3
-male,white,60-69,some college,NC,3,2,0.519037458,3
-male,white,70+,4-year college,NC,1,1,0.519037458,3
-male,white,70+,hs,NC,5,3,0.519037458,3
-male,white,70+,no hs,NC,1,1,0.519037458,3
-male,white,70+,post-grad,NC,2,0,0.519037458,3
-male,white,70+,some college,NC,1,1,0.519037458,3
-female,other,30-39,post-grad,ND,1,0,0.698092429,1
-male,other,40-49,no hs,ND,1,1,0.698092429,1
-female,white,18-29,hs,ND,1,0,0.698092429,1
-female,white,18-29,some college,ND,1,1,0.698092429,1
-female,white,30-39,4-year college,ND,1,0,0.698092429,1
-female,white,30-39,some college,ND,1,0,0.698092429,1
-female,white,60-69,post-grad,ND,1,0,0.698092429,1
-female,white,60-69,some college,ND,1,0,0.698092429,1
-female,white,70+,4-year college,ND,1,1,0.698092429,1
-female,white,70+,hs,ND,1,0,0.698092429,1
-female,white,70+,some college,ND,1,0,0.698092429,1
-male,white,18-29,4-year college,ND,1,0,0.698092429,1
-male,white,18-29,some college,ND,1,0,0.698092429,1
-male,white,30-39,4-year college,ND,1,1,0.698092429,1
-male,white,30-39,hs,ND,1,1,0.698092429,1
-male,white,30-39,some college,ND,1,0,0.698092429,1
-male,white,50-59,hs,ND,1,1,0.698092429,1
-male,white,70+,some college,ND,1,1,0.698092429,1
-female,black,40-49,4-year college,NE,1,1,0.635476741,1
-female,black,50-59,some college,NE,1,0,0.635476741,1
-male,other,40-49,4-year college,NE,1,0,0.635476741,1
-female,white,18-29,post-grad,NE,1,0,0.635476741,1
-female,white,18-29,some college,NE,2,1,0.635476741,1
-female,white,30-39,hs,NE,1,0,0.635476741,1
-female,white,30-39,post-grad,NE,1,1,0.635476741,1
-female,white,40-49,4-year college,NE,1,1,0.635476741,1
-female,white,40-49,some college,NE,1,1,0.635476741,1
-female,white,50-59,hs,NE,1,0,0.635476741,1
-female,white,50-59,post-grad,NE,1,0,0.635476741,1
-female,white,50-59,some college,NE,1,0,0.635476741,1
-female,white,60-69,4-year college,NE,1,0,0.635476741,1
-female,white,60-69,hs,NE,2,1,0.635476741,1
-female,white,60-69,post-grad,NE,2,1,0.635476741,1
-female,white,60-69,some college,NE,3,2,0.635476741,1
-female,white,70+,hs,NE,3,1,0.635476741,1
-male,white,30-39,4-year college,NE,2,1,0.635476741,1
-male,white,40-49,post-grad,NE,1,0,0.635476741,1
-male,white,40-49,some college,NE,1,0,0.635476741,1
-male,white,60-69,hs,NE,1,1,0.635476741,1
-male,white,60-69,post-grad,NE,1,1,0.635476741,1
-male,white,70+,post-grad,NE,1,0,0.635476741,1
-male,white,70+,some college,NE,1,1,0.635476741,1
-female,other,40-49,post-grad,NH,1,0,0.498029716,2
-male,other,60-69,4-year college,NH,1,1,0.498029716,2
-female,white,18-29,4-year college,NH,1,0,0.498029716,2
-female,white,30-39,hs,NH,2,1,0.498029716,2
-female,white,30-39,no hs,NH,1,0,0.498029716,2
-female,white,50-59,4-year college,NH,1,0,0.498029716,2
-female,white,50-59,hs,NH,2,0,0.498029716,2
-female,white,50-59,post-grad,NH,1,0,0.498029716,2
-female,white,50-59,some college,NH,2,1,0.498029716,2
-female,white,60-69,some college,NH,1,0,0.498029716,2
-female,white,70+,hs,NH,1,0,0.498029716,2
-male,white,18-29,hs,NH,2,2,0.498029716,2
-male,white,18-29,post-grad,NH,1,1,0.498029716,2
-male,white,18-29,some college,NH,2,2,0.498029716,2
-male,white,30-39,4-year college,NH,2,1,0.498029716,2
-male,white,30-39,post-grad,NH,1,1,0.498029716,2
-male,white,30-39,some college,NH,1,1,0.498029716,2
-male,white,40-49,some college,NH,2,1,0.498029716,2
-male,white,50-59,hs,NH,1,1,0.498029716,2
-male,white,60-69,hs,NH,1,0,0.498029716,2
-male,white,70+,4-year college,NH,1,0,0.498029716,2
-male,white,70+,post-grad,NH,1,0,0.498029716,2
-female,black,18-29,4-year college,NJ,1,0,0.427158099,2
-female,black,30-39,4-year college,NJ,2,0,0.427158099,2
-female,black,30-39,post-grad,NJ,1,0,0.427158099,2
-female,black,30-39,some college,NJ,1,1,0.427158099,2
-female,black,40-49,4-year college,NJ,1,0,0.427158099,2
-female,black,40-49,some college,NJ,1,0,0.427158099,2
-female,black,50-59,hs,NJ,1,1,0.427158099,2
-female,black,70+,hs,NJ,1,0,0.427158099,2
-male,black,18-29,hs,NJ,3,2,0.427158099,2
-male,black,40-49,some college,NJ,1,1,0.427158099,2
-female,other,18-29,4-year college,NJ,2,0,0.427158099,2
-female,other,18-29,hs,NJ,1,1,0.427158099,2
-female,other,18-29,some college,NJ,1,0,0.427158099,2
-female,other,30-39,4-year college,NJ,2,0,0.427158099,2
-female,other,40-49,4-year college,NJ,2,1,0.427158099,2
-female,other,50-59,4-year college,NJ,1,0,0.427158099,2
-female,other,60-69,some college,NJ,1,0,0.427158099,2
-male,other,18-29,4-year college,NJ,1,0,0.427158099,2
-male,other,18-29,hs,NJ,1,0,0.427158099,2
-male,other,18-29,some college,NJ,2,0,0.427158099,2
-male,other,30-39,4-year college,NJ,1,1,0.427158099,2
-male,other,30-39,some college,NJ,1,1,0.427158099,2
-male,other,40-49,hs,NJ,1,0,0.427158099,2
-male,other,40-49,post-grad,NJ,2,1,0.427158099,2
-male,other,40-49,some college,NJ,1,0,0.427158099,2
-male,other,50-59,4-year college,NJ,1,0,0.427158099,2
-male,other,50-59,some college,NJ,1,1,0.427158099,2
-female,white,18-29,4-year college,NJ,4,1,0.427158099,2
-female,white,18-29,hs,NJ,2,0,0.427158099,2
-female,white,18-29,post-grad,NJ,1,0,0.427158099,2
-female,white,18-29,some college,NJ,6,1,0.427158099,2
-female,white,30-39,4-year college,NJ,3,1,0.427158099,2
-female,white,30-39,hs,NJ,2,1,0.427158099,2
-female,white,30-39,some college,NJ,1,1,0.427158099,2
-female,white,40-49,4-year college,NJ,2,1,0.427158099,2
-female,white,40-49,hs,NJ,5,3,0.427158099,2
-female,white,40-49,some college,NJ,2,1,0.427158099,2
-female,white,50-59,4-year college,NJ,4,2,0.427158099,2
-female,white,50-59,hs,NJ,5,2,0.427158099,2
-female,white,50-59,post-grad,NJ,4,2,0.427158099,2
-female,white,50-59,some college,NJ,1,0,0.427158099,2
-female,white,60-69,4-year college,NJ,5,2,0.427158099,2
-female,white,60-69,hs,NJ,3,2,0.427158099,2
-female,white,60-69,some college,NJ,1,1,0.427158099,2
-female,white,70+,4-year college,NJ,1,0,0.427158099,2
-female,white,70+,hs,NJ,4,1,0.427158099,2
-female,white,70+,post-grad,NJ,1,1,0.427158099,2
-male,white,18-29,hs,NJ,2,1,0.427158099,2
-male,white,18-29,some college,NJ,1,1,0.427158099,2
-male,white,30-39,4-year college,NJ,1,0,0.427158099,2
-male,white,30-39,hs,NJ,1,0,0.427158099,2
-male,white,30-39,post-grad,NJ,2,0,0.427158099,2
-male,white,30-39,some college,NJ,4,1,0.427158099,2
-male,white,40-49,4-year college,NJ,3,0,0.427158099,2
-male,white,40-49,some college,NJ,3,1,0.427158099,2
-male,white,50-59,4-year college,NJ,2,1,0.427158099,2
-male,white,50-59,hs,NJ,1,0,0.427158099,2
-male,white,50-59,post-grad,NJ,1,1,0.427158099,2
-male,white,50-59,some college,NJ,1,0,0.427158099,2
-male,white,60-69,4-year college,NJ,3,1,0.427158099,2
-male,white,60-69,hs,NJ,2,1,0.427158099,2
-male,white,60-69,no hs,NJ,1,1,0.427158099,2
-male,white,60-69,some college,NJ,1,0,0.427158099,2
-male,white,70+,4-year college,NJ,1,1,0.427158099,2
-male,white,70+,hs,NJ,2,2,0.427158099,2
-male,white,70+,some college,NJ,2,2,0.427158099,2
-female,black,18-29,hs,NM,1,0,0.453492051,4
-female,other,18-29,hs,NM,1,1,0.453492051,4
-female,other,30-39,4-year college,NM,1,0,0.453492051,4
-female,other,50-59,4-year college,NM,1,1,0.453492051,4
-male,other,18-29,some college,NM,1,1,0.453492051,4
-male,other,60-69,hs,NM,1,0,0.453492051,4
-male,other,60-69,some college,NM,1,0,0.453492051,4
-female,white,30-39,some college,NM,1,0,0.453492051,4
-female,white,40-49,4-year college,NM,2,0,0.453492051,4
-female,white,40-49,hs,NM,1,0,0.453492051,4
-female,white,40-49,some college,NM,1,1,0.453492051,4
-female,white,60-69,4-year college,NM,2,1,0.453492051,4
-female,white,70+,no hs,NM,1,1,0.453492051,4
-male,white,18-29,some college,NM,1,0,0.453492051,4
-male,white,30-39,hs,NM,1,0,0.453492051,4
-male,white,40-49,hs,NM,1,1,0.453492051,4
-male,white,50-59,4-year college,NM,1,0,0.453492051,4
-male,white,50-59,some college,NM,1,0,0.453492051,4
-male,white,60-69,4-year college,NM,2,0,0.453492051,4
-male,white,60-69,some college,NM,1,0,0.453492051,4
-male,white,70+,post-grad,NM,1,1,0.453492051,4
-male,white,70+,some college,NM,2,2,0.453492051,4
-male,black,18-29,hs,NV,2,0,0.487062906,4
-male,black,30-39,4-year college,NV,1,0,0.487062906,4
-male,black,30-39,some college,NV,1,1,0.487062906,4
-female,other,18-29,some college,NV,1,1,0.487062906,4
-female,other,30-39,some college,NV,1,1,0.487062906,4
-female,other,40-49,some college,NV,3,0,0.487062906,4
-female,other,60-69,4-year college,NV,1,1,0.487062906,4
-female,other,60-69,hs,NV,1,0,0.487062906,4
-male,other,18-29,hs,NV,1,1,0.487062906,4
-male,other,18-29,some college,NV,1,1,0.487062906,4
-male,other,30-39,4-year college,NV,1,1,0.487062906,4
-male,other,30-39,some college,NV,1,1,0.487062906,4
-male,other,40-49,some college,NV,1,0,0.487062906,4
-male,other,60-69,4-year college,NV,1,1,0.487062906,4
-female,white,30-39,4-year college,NV,1,0,0.487062906,4
-female,white,30-39,hs,NV,1,0,0.487062906,4
-female,white,30-39,some college,NV,1,1,0.487062906,4
-female,white,40-49,4-year college,NV,1,0,0.487062906,4
-female,white,40-49,some college,NV,1,0,0.487062906,4
-female,white,50-59,hs,NV,1,1,0.487062906,4
-female,white,50-59,some college,NV,1,0,0.487062906,4
-female,white,60-69,hs,NV,2,1,0.487062906,4
-female,white,60-69,post-grad,NV,1,1,0.487062906,4
-female,white,60-69,some college,NV,3,2,0.487062906,4
-female,white,70+,hs,NV,1,0,0.487062906,4
-female,white,70+,some college,NV,1,0,0.487062906,4
-male,white,18-29,4-year college,NV,1,0,0.487062906,4
-male,white,30-39,post-grad,NV,1,1,0.487062906,4
-male,white,50-59,hs,NV,2,0,0.487062906,4
-male,white,50-59,some college,NV,4,2,0.487062906,4
-male,white,60-69,4-year college,NV,2,2,0.487062906,4
-male,white,60-69,post-grad,NV,1,0,0.487062906,4
-male,white,60-69,some college,NV,2,1,0.487062906,4
-male,white,70+,hs,NV,1,1,0.487062906,4
-male,white,70+,post-grad,NV,2,2,0.487062906,4
-male,white,70+,some college,NV,1,1,0.487062906,4
-female,black,18-29,4-year college,NY,1,0,0.382275815,2
-female,black,18-29,hs,NY,2,0,0.382275815,2
-female,black,18-29,no hs,NY,1,0,0.382275815,2
-female,black,18-29,post-grad,NY,1,0,0.382275815,2
-female,black,18-29,some college,NY,1,1,0.382275815,2
-female,black,30-39,4-year college,NY,1,1,0.382275815,2
-female,black,30-39,no hs,NY,1,1,0.382275815,2
-female,black,30-39,some college,NY,2,1,0.382275815,2
-female,black,40-49,post-grad,NY,1,0,0.382275815,2
-female,black,40-49,some college,NY,1,0,0.382275815,2
-female,black,50-59,4-year college,NY,3,0,0.382275815,2
-female,black,50-59,hs,NY,3,1,0.382275815,2
-female,black,50-59,post-grad,NY,1,0,0.382275815,2
-female,black,50-59,some college,NY,1,0,0.382275815,2
-female,black,60-69,4-year college,NY,1,0,0.382275815,2
-female,black,60-69,hs,NY,1,0,0.382275815,2
-female,black,70+,4-year college,NY,1,0,0.382275815,2
-female,black,70+,post-grad,NY,1,0,0.382275815,2
-male,black,18-29,no hs,NY,1,0,0.382275815,2
-male,black,18-29,some college,NY,1,1,0.382275815,2
-male,black,30-39,4-year college,NY,1,0,0.382275815,2
-male,black,40-49,no hs,NY,1,0,0.382275815,2
-male,black,40-49,some college,NY,2,0,0.382275815,2
-male,black,50-59,4-year college,NY,1,0,0.382275815,2
-male,black,50-59,hs,NY,2,0,0.382275815,2
-male,black,50-59,some college,NY,2,0,0.382275815,2
-male,black,60-69,4-year college,NY,1,0,0.382275815,2
-female,other,18-29,4-year college,NY,5,2,0.382275815,2
-female,other,18-29,hs,NY,2,2,0.382275815,2
-female,other,18-29,no hs,NY,2,1,0.382275815,2
-female,other,18-29,some college,NY,1,0,0.382275815,2
-female,other,30-39,4-year college,NY,3,1,0.382275815,2
-female,other,30-39,hs,NY,1,0,0.382275815,2
-female,other,30-39,post-grad,NY,2,1,0.382275815,2
-female,other,30-39,some college,NY,2,0,0.382275815,2
-female,other,40-49,4-year college,NY,1,0,0.382275815,2
-female,other,40-49,hs,NY,1,0,0.382275815,2
-female,other,40-49,post-grad,NY,2,0,0.382275815,2
-female,other,40-49,some college,NY,2,1,0.382275815,2
-female,other,50-59,4-year college,NY,3,1,0.382275815,2
-female,other,50-59,hs,NY,1,1,0.382275815,2
-female,other,50-59,post-grad,NY,1,0,0.382275815,2
-female,other,60-69,hs,NY,1,0,0.382275815,2
-female,other,60-69,some college,NY,1,0,0.382275815,2
-male,other,18-29,hs,NY,1,0,0.382275815,2
-male,other,18-29,no hs,NY,1,0,0.382275815,2
-male,other,18-29,post-grad,NY,2,1,0.382275815,2
-male,other,18-29,some college,NY,3,1,0.382275815,2
-male,other,30-39,4-year college,NY,2,1,0.382275815,2
-male,other,30-39,hs,NY,2,1,0.382275815,2
-male,other,30-39,no hs,NY,1,0,0.382275815,2
-male,other,40-49,4-year college,NY,3,1,0.382275815,2
-male,other,40-49,hs,NY,2,1,0.382275815,2
-male,other,40-49,post-grad,NY,2,0,0.382275815,2
-male,other,50-59,hs,NY,1,0,0.382275815,2
-male,other,50-59,no hs,NY,1,1,0.382275815,2
-male,other,50-59,post-grad,NY,1,0,0.382275815,2
-male,other,50-59,some college,NY,1,0,0.382275815,2
-male,other,60-69,post-grad,NY,1,0,0.382275815,2
-male,other,60-69,some college,NY,1,1,0.382275815,2
-female,white,18-29,4-year college,NY,19,6,0.382275815,2
-female,white,18-29,hs,NY,3,1,0.382275815,2
-female,white,18-29,no hs,NY,1,0,0.382275815,2
-female,white,18-29,some college,NY,6,2,0.382275815,2
-female,white,30-39,4-year college,NY,3,2,0.382275815,2
-female,white,30-39,hs,NY,8,3,0.382275815,2
-female,white,30-39,no hs,NY,1,0,0.382275815,2
-female,white,30-39,post-grad,NY,4,1,0.382275815,2
-female,white,30-39,some college,NY,3,1,0.382275815,2
-female,white,40-49,4-year college,NY,4,1,0.382275815,2
-female,white,40-49,hs,NY,11,2,0.382275815,2
-female,white,40-49,post-grad,NY,1,0,0.382275815,2
-female,white,40-49,some college,NY,5,2,0.382275815,2
-female,white,50-59,4-year college,NY,4,0,0.382275815,2
-female,white,50-59,hs,NY,7,4,0.382275815,2
-female,white,50-59,no hs,NY,2,0,0.382275815,2
-female,white,50-59,post-grad,NY,2,1,0.382275815,2
-female,white,50-59,some college,NY,5,0,0.382275815,2
-female,white,60-69,4-year college,NY,1,0,0.382275815,2
-female,white,60-69,hs,NY,8,4,0.382275815,2
-female,white,60-69,post-grad,NY,2,0,0.382275815,2
-female,white,60-69,some college,NY,3,1,0.382275815,2
-female,white,70+,hs,NY,13,6,0.382275815,2
-female,white,70+,no hs,NY,1,1,0.382275815,2
-female,white,70+,post-grad,NY,4,1,0.382275815,2
-female,white,70+,some college,NY,5,2,0.382275815,2
-male,white,18-29,4-year college,NY,6,3,0.382275815,2
-male,white,18-29,hs,NY,5,1,0.382275815,2
-male,white,18-29,post-grad,NY,1,0,0.382275815,2
-male,white,18-29,some college,NY,2,1,0.382275815,2
-male,white,30-39,4-year college,NY,7,2,0.382275815,2
-male,white,30-39,hs,NY,4,2,0.382275815,2
-male,white,30-39,post-grad,NY,3,1,0.382275815,2
-male,white,30-39,some college,NY,2,1,0.382275815,2
-male,white,40-49,4-year college,NY,1,0,0.382275815,2
-male,white,40-49,hs,NY,8,0,0.382275815,2
-male,white,40-49,no hs,NY,1,0,0.382275815,2
-male,white,40-49,post-grad,NY,1,0,0.382275815,2
-male,white,40-49,some college,NY,4,1,0.382275815,2
-male,white,50-59,4-year college,NY,2,0,0.382275815,2
-male,white,50-59,hs,NY,6,1,0.382275815,2
-male,white,50-59,some college,NY,6,2,0.382275815,2
-male,white,60-69,4-year college,NY,4,3,0.382275815,2
-male,white,60-69,no hs,NY,1,1,0.382275815,2
-male,white,60-69,post-grad,NY,1,0,0.382275815,2
-male,white,60-69,some college,NY,3,0,0.382275815,2
-male,white,70+,4-year college,NY,5,2,0.382275815,2
-male,white,70+,hs,NY,4,1,0.382275815,2
-male,white,70+,post-grad,NY,5,1,0.382275815,2
-male,white,70+,some college,NY,1,1,0.382275815,2
-female,black,18-29,some college,OH,1,0,0.542676846,1
-female,black,30-39,4-year college,OH,4,3,0.542676846,1
-female,black,40-49,4-year college,OH,1,0,0.542676846,1
-female,black,40-49,hs,OH,1,0,0.542676846,1
-female,black,40-49,some college,OH,1,1,0.542676846,1
-female,black,60-69,hs,OH,1,1,0.542676846,1
-female,black,60-69,some college,OH,1,0,0.542676846,1
-male,black,40-49,4-year college,OH,1,0,0.542676846,1
-male,black,60-69,4-year college,OH,1,1,0.542676846,1
-female,other,18-29,4-year college,OH,1,0,0.542676846,1
-female,other,18-29,hs,OH,1,0,0.542676846,1
-female,other,18-29,post-grad,OH,1,0,0.542676846,1
-female,other,18-29,some college,OH,3,0,0.542676846,1
-female,other,30-39,hs,OH,1,0,0.542676846,1
-female,other,30-39,some college,OH,1,1,0.542676846,1
-female,other,40-49,4-year college,OH,1,0,0.542676846,1
-female,other,40-49,hs,OH,1,0,0.542676846,1
-female,other,40-49,post-grad,OH,1,0,0.542676846,1
-female,other,50-59,hs,OH,1,1,0.542676846,1
-female,other,50-59,some college,OH,1,1,0.542676846,1
-male,other,18-29,4-year college,OH,1,0,0.542676846,1
-male,other,18-29,post-grad,OH,1,0,0.542676846,1
-male,other,50-59,some college,OH,2,2,0.542676846,1
-male,other,70+,some college,OH,1,1,0.542676846,1
-female,white,18-29,4-year college,OH,6,1,0.542676846,1
-female,white,18-29,hs,OH,6,2,0.542676846,1
-female,white,18-29,no hs,OH,4,2,0.542676846,1
-female,white,18-29,post-grad,OH,1,0,0.542676846,1
-female,white,18-29,some college,OH,11,3,0.542676846,1
-female,white,30-39,4-year college,OH,4,2,0.542676846,1
-female,white,30-39,hs,OH,3,0,0.542676846,1
-female,white,30-39,post-grad,OH,4,1,0.542676846,1
-female,white,30-39,some college,OH,4,0,0.542676846,1
-female,white,40-49,4-year college,OH,2,0,0.542676846,1
-female,white,40-49,hs,OH,3,1,0.542676846,1
-female,white,40-49,post-grad,OH,4,1,0.542676846,1
-female,white,40-49,some college,OH,4,3,0.542676846,1
-female,white,50-59,4-year college,OH,1,0,0.542676846,1
-female,white,50-59,hs,OH,11,6,0.542676846,1
-female,white,50-59,no hs,OH,1,1,0.542676846,1
-female,white,50-59,post-grad,OH,5,1,0.542676846,1
-female,white,50-59,some college,OH,9,5,0.542676846,1
-female,white,60-69,4-year college,OH,2,0,0.542676846,1
-female,white,60-69,hs,OH,12,5,0.542676846,1
-female,white,60-69,no hs,OH,1,1,0.542676846,1
-female,white,60-69,post-grad,OH,2,2,0.542676846,1
-female,white,60-69,some college,OH,3,1,0.542676846,1
-female,white,70+,hs,OH,5,1,0.542676846,1
-female,white,70+,post-grad,OH,1,1,0.542676846,1
-male,white,18-29,4-year college,OH,2,0,0.542676846,1
-male,white,18-29,hs,OH,2,0,0.542676846,1
-male,white,18-29,no hs,OH,1,1,0.542676846,1
-male,white,18-29,post-grad,OH,1,0,0.542676846,1
-male,white,18-29,some college,OH,6,1,0.542676846,1
-male,white,30-39,4-year college,OH,4,2,0.542676846,1
-male,white,30-39,no hs,OH,1,1,0.542676846,1
-male,white,30-39,post-grad,OH,2,0,0.542676846,1
-male,white,30-39,some college,OH,6,2,0.542676846,1
-male,white,40-49,4-year college,OH,3,3,0.542676846,1
-male,white,40-49,hs,OH,3,1,0.542676846,1
-male,white,40-49,post-grad,OH,2,2,0.542676846,1
-male,white,40-49,some college,OH,1,1,0.542676846,1
-male,white,50-59,4-year college,OH,6,1,0.542676846,1
-male,white,50-59,hs,OH,5,3,0.542676846,1
-male,white,50-59,no hs,OH,1,1,0.542676846,1
-male,white,50-59,some college,OH,5,3,0.542676846,1
-male,white,60-69,4-year college,OH,3,2,0.542676846,1
-male,white,60-69,hs,OH,5,3,0.542676846,1
-male,white,60-69,no hs,OH,1,1,0.542676846,1
-male,white,60-69,some college,OH,6,2,0.542676846,1
-male,white,70+,4-year college,OH,2,1,0.542676846,1
-male,white,70+,hs,OH,4,2,0.542676846,1
-male,white,70+,post-grad,OH,1,1,0.542676846,1
-male,white,70+,some college,OH,2,1,0.542676846,1
-female,black,30-39,hs,OK,1,0,0.693047372,3
-female,black,50-59,some college,OK,1,0,0.693047372,3
-male,black,40-49,4-year college,OK,1,0,0.693047372,3
-female,other,18-29,4-year college,OK,1,0,0.693047372,3
-female,other,18-29,hs,OK,2,0,0.693047372,3
-female,other,18-29,some college,OK,1,1,0.693047372,3
-female,other,30-39,hs,OK,1,0,0.693047372,3
-female,other,40-49,some college,OK,1,0,0.693047372,3
-female,other,50-59,hs,OK,1,0,0.693047372,3
-male,other,18-29,no hs,OK,1,0,0.693047372,3
-male,other,40-49,some college,OK,1,1,0.693047372,3
-male,other,50-59,hs,OK,1,1,0.693047372,3
-male,other,70+,4-year college,OK,1,1,0.693047372,3
-male,other,70+,some college,OK,1,0,0.693047372,3
-female,white,18-29,4-year college,OK,2,1,0.693047372,3
-female,white,18-29,hs,OK,4,1,0.693047372,3
-female,white,30-39,4-year college,OK,1,1,0.693047372,3
-female,white,40-49,4-year college,OK,1,0,0.693047372,3
-female,white,40-49,hs,OK,1,1,0.693047372,3
-female,white,40-49,some college,OK,1,1,0.693047372,3
-female,white,50-59,4-year college,OK,1,0,0.693047372,3
-female,white,50-59,hs,OK,1,1,0.693047372,3
-female,white,50-59,post-grad,OK,2,0,0.693047372,3
-female,white,50-59,some college,OK,1,1,0.693047372,3
-female,white,60-69,hs,OK,2,1,0.693047372,3
-female,white,60-69,some college,OK,2,1,0.693047372,3
-female,white,70+,4-year college,OK,1,0,0.693047372,3
-female,white,70+,hs,OK,1,0,0.693047372,3
-female,white,70+,some college,OK,2,2,0.693047372,3
-male,white,18-29,hs,OK,2,1,0.693047372,3
-male,white,30-39,4-year college,OK,1,0,0.693047372,3
-male,white,30-39,some college,OK,1,1,0.693047372,3
-male,white,40-49,4-year college,OK,1,0,0.693047372,3
-male,white,40-49,some college,OK,1,1,0.693047372,3
-male,white,50-59,4-year college,OK,3,3,0.693047372,3
-male,white,50-59,hs,OK,1,0,0.693047372,3
-male,white,60-69,4-year college,OK,1,1,0.693047372,3
-male,white,70+,some college,OK,2,1,0.693047372,3
-female,other,18-29,4-year college,OR,1,0,0.438441611,4
-female,other,30-39,4-year college,OR,1,0,0.438441611,4
-female,other,60-69,hs,OR,1,0,0.438441611,4
-male,other,18-29,4-year college,OR,1,0,0.438441611,4
-male,other,60-69,post-grad,OR,1,1,0.438441611,4
-female,white,18-29,4-year college,OR,3,0,0.438441611,4
-female,white,18-29,no hs,OR,1,1,0.438441611,4
-female,white,18-29,some college,OR,1,0,0.438441611,4
-female,white,30-39,4-year college,OR,4,1,0.438441611,4
-female,white,30-39,hs,OR,1,1,0.438441611,4
-female,white,30-39,post-grad,OR,1,0,0.438441611,4
-female,white,30-39,some college,OR,1,0,0.438441611,4
-female,white,40-49,4-year college,OR,3,0,0.438441611,4
-female,white,40-49,hs,OR,1,1,0.438441611,4
-female,white,40-49,some college,OR,3,1,0.438441611,4
-female,white,50-59,hs,OR,3,2,0.438441611,4
-female,white,50-59,post-grad,OR,1,1,0.438441611,4
-female,white,50-59,some college,OR,1,0,0.438441611,4
-female,white,60-69,4-year college,OR,2,0,0.438441611,4
-female,white,60-69,hs,OR,4,1,0.438441611,4
-female,white,60-69,some college,OR,2,2,0.438441611,4
-female,white,70+,hs,OR,2,0,0.438441611,4
-female,white,70+,post-grad,OR,1,0,0.438441611,4
-female,white,70+,some college,OR,1,0,0.438441611,4
-male,white,18-29,no hs,OR,1,1,0.438441611,4
-male,white,30-39,4-year college,OR,1,1,0.438441611,4
-male,white,30-39,hs,OR,1,1,0.438441611,4
-male,white,40-49,4-year college,OR,2,1,0.438441611,4
-male,white,40-49,no hs,OR,1,1,0.438441611,4
-male,white,40-49,post-grad,OR,3,1,0.438441611,4
-male,white,50-59,hs,OR,3,1,0.438441611,4
-male,white,50-59,some college,OR,4,1,0.438441611,4
-male,white,60-69,4-year college,OR,1,1,0.438441611,4
-male,white,60-69,no hs,OR,1,0,0.438441611,4
-male,white,60-69,post-grad,OR,1,0,0.438441611,4
-male,white,60-69,some college,OR,1,0,0.438441611,4
-male,white,70+,hs,OR,1,0,0.438441611,4
-male,white,70+,post-grad,OR,2,1,0.438441611,4
-male,white,70+,some college,OR,1,0,0.438441611,4
-female,black,18-29,hs,PA,3,1,0.503755358,2
-female,black,18-29,some college,PA,1,0,0.503755358,2
-female,black,30-39,4-year college,PA,1,1,0.503755358,2
-female,black,30-39,no hs,PA,1,0,0.503755358,2
-female,black,40-49,some college,PA,1,1,0.503755358,2
-female,black,50-59,hs,PA,1,1,0.503755358,2
-female,black,50-59,post-grad,PA,2,0,0.503755358,2
-female,black,50-59,some college,PA,5,2,0.503755358,2
-female,black,60-69,hs,PA,1,0,0.503755358,2
-female,black,60-69,some college,PA,1,1,0.503755358,2
-male,black,18-29,some college,PA,2,1,0.503755358,2
-male,black,40-49,4-year college,PA,1,0,0.503755358,2
-male,black,40-49,hs,PA,1,1,0.503755358,2
-female,other,18-29,hs,PA,1,1,0.503755358,2
-female,other,18-29,no hs,PA,1,1,0.503755358,2
-female,other,30-39,post-grad,PA,2,0,0.503755358,2
-female,other,50-59,hs,PA,2,1,0.503755358,2
-female,other,50-59,some college,PA,1,1,0.503755358,2
-female,other,60-69,hs,PA,1,1,0.503755358,2
-male,other,18-29,hs,PA,1,1,0.503755358,2
-male,other,18-29,some college,PA,1,0,0.503755358,2
-male,other,30-39,4-year college,PA,2,1,0.503755358,2
-male,other,30-39,some college,PA,1,1,0.503755358,2
-male,other,50-59,4-year college,PA,2,1,0.503755358,2
-female,white,18-29,4-year college,PA,11,2,0.503755358,2
-female,white,18-29,hs,PA,11,4,0.503755358,2
-female,white,18-29,post-grad,PA,2,1,0.503755358,2
-female,white,18-29,some college,PA,7,2,0.503755358,2
-female,white,30-39,4-year college,PA,3,0,0.503755358,2
-female,white,30-39,hs,PA,6,3,0.503755358,2
-female,white,30-39,post-grad,PA,3,0,0.503755358,2
-female,white,30-39,some college,PA,5,1,0.503755358,2
-female,white,40-49,4-year college,PA,5,4,0.503755358,2
-female,white,40-49,hs,PA,5,5,0.503755358,2
-female,white,40-49,some college,PA,7,2,0.503755358,2
-female,white,50-59,4-year college,PA,1,1,0.503755358,2
-female,white,50-59,hs,PA,13,4,0.503755358,2
-female,white,50-59,no hs,PA,3,1,0.503755358,2
-female,white,50-59,post-grad,PA,4,3,0.503755358,2
-female,white,50-59,some college,PA,4,3,0.503755358,2
-female,white,60-69,4-year college,PA,2,2,0.503755358,2
-female,white,60-69,hs,PA,9,5,0.503755358,2
-female,white,60-69,post-grad,PA,2,1,0.503755358,2
-female,white,60-69,some college,PA,10,5,0.503755358,2
-female,white,70+,4-year college,PA,2,0,0.503755358,2
-female,white,70+,hs,PA,10,7,0.503755358,2
-female,white,70+,post-grad,PA,1,1,0.503755358,2
-female,white,70+,some college,PA,7,2,0.503755358,2
-male,white,18-29,4-year college,PA,2,0,0.503755358,2
-male,white,18-29,hs,PA,1,1,0.503755358,2
-male,white,18-29,some college,PA,6,2,0.503755358,2
-male,white,30-39,4-year college,PA,6,5,0.503755358,2
-male,white,30-39,hs,PA,3,3,0.503755358,2
-male,white,30-39,no hs,PA,2,1,0.503755358,2
-male,white,30-39,post-grad,PA,4,3,0.503755358,2
-male,white,30-39,some college,PA,4,0,0.503755358,2
-male,white,40-49,4-year college,PA,3,2,0.503755358,2
-male,white,40-49,hs,PA,2,1,0.503755358,2
-male,white,40-49,post-grad,PA,2,0,0.503755358,2
-male,white,40-49,some college,PA,1,1,0.503755358,2
-male,white,50-59,4-year college,PA,1,0,0.503755358,2
-male,white,50-59,hs,PA,7,2,0.503755358,2
-male,white,50-59,post-grad,PA,3,1,0.503755358,2
-male,white,50-59,some college,PA,4,2,0.503755358,2
-male,white,60-69,4-year college,PA,3,0,0.503755358,2
-male,white,60-69,hs,PA,12,8,0.503755358,2
-male,white,60-69,no hs,PA,3,1,0.503755358,2
-male,white,60-69,post-grad,PA,3,0,0.503755358,2
-male,white,60-69,some college,PA,7,3,0.503755358,2
-male,white,70+,4-year college,PA,2,2,0.503755358,2
-male,white,70+,hs,PA,3,2,0.503755358,2
-male,white,70+,no hs,PA,1,0,0.503755358,2
-male,white,70+,post-grad,PA,2,1,0.503755358,2
-male,white,70+,some college,PA,4,2,0.503755358,2
-female,other,18-29,4-year college,RI,1,0,0.416892959,2
-female,other,40-49,some college,RI,1,0,0.416892959,2
-male,other,50-59,4-year college,RI,1,0,0.416892959,2
-male,other,50-59,no hs,RI,1,1,0.416892959,2
-male,other,60-69,post-grad,RI,1,0,0.416892959,2
-female,white,18-29,4-year college,RI,1,0,0.416892959,2
-female,white,18-29,hs,RI,1,1,0.416892959,2
-female,white,18-29,some college,RI,2,0,0.416892959,2
-female,white,30-39,some college,RI,1,1,0.416892959,2
-female,white,40-49,hs,RI,1,1,0.416892959,2
-female,white,50-59,hs,RI,1,0,0.416892959,2
-female,white,60-69,hs,RI,2,0,0.416892959,2
-female,white,70+,hs,RI,1,1,0.416892959,2
-male,white,30-39,some college,RI,1,0,0.416892959,2
-male,white,50-59,some college,RI,1,0,0.416892959,2
-male,white,70+,4-year college,RI,1,1,0.416892959,2
-male,white,70+,hs,RI,1,0,0.416892959,2
-female,black,18-29,hs,SC,1,1,0.574602564,3
-female,black,18-29,some college,SC,1,0,0.574602564,3
-female,black,30-39,some college,SC,1,1,0.574602564,3
-female,black,50-59,4-year college,SC,2,1,0.574602564,3
-female,black,50-59,post-grad,SC,1,1,0.574602564,3
-female,black,60-69,hs,SC,2,1,0.574602564,3
-male,black,18-29,some college,SC,1,0,0.574602564,3
-male,black,40-49,hs,SC,1,0,0.574602564,3
-male,black,40-49,some college,SC,1,0,0.574602564,3
-female,other,18-29,hs,SC,1,1,0.574602564,3
-female,other,18-29,some college,SC,2,1,0.574602564,3
-male,other,70+,4-year college,SC,1,1,0.574602564,3
-female,white,18-29,4-year college,SC,1,0,0.574602564,3
-female,white,18-29,hs,SC,2,1,0.574602564,3
-female,white,18-29,some college,SC,2,1,0.574602564,3
-female,white,30-39,4-year college,SC,1,1,0.574602564,3
-female,white,30-39,hs,SC,1,1,0.574602564,3
-female,white,40-49,4-year college,SC,2,2,0.574602564,3
-female,white,40-49,hs,SC,3,2,0.574602564,3
-female,white,40-49,no hs,SC,2,1,0.574602564,3
-female,white,40-49,post-grad,SC,2,0,0.574602564,3
-female,white,40-49,some college,SC,1,0,0.574602564,3
-female,white,50-59,hs,SC,2,1,0.574602564,3
-female,white,50-59,some college,SC,1,0,0.574602564,3
-female,white,60-69,4-year college,SC,1,1,0.574602564,3
-female,white,60-69,hs,SC,4,4,0.574602564,3
-female,white,60-69,no hs,SC,1,0,0.574602564,3
-female,white,60-69,post-grad,SC,2,2,0.574602564,3
-female,white,70+,hs,SC,1,0,0.574602564,3
-female,white,70+,some college,SC,1,0,0.574602564,3
-male,white,30-39,4-year college,SC,1,1,0.574602564,3
-male,white,30-39,some college,SC,2,0,0.574602564,3
-male,white,40-49,hs,SC,2,2,0.574602564,3
-male,white,40-49,post-grad,SC,1,1,0.574602564,3
-male,white,50-59,4-year college,SC,1,0,0.574602564,3
-male,white,50-59,hs,SC,1,0,0.574602564,3
-male,white,50-59,post-grad,SC,1,1,0.574602564,3
-male,white,50-59,some college,SC,2,2,0.574602564,3
-male,white,60-69,hs,SC,2,0,0.574602564,3
-male,white,70+,4-year college,SC,1,1,0.574602564,3
-male,white,70+,post-grad,SC,1,1,0.574602564,3
-male,white,70+,some college,SC,1,1,0.574602564,3
-female,other,18-29,hs,SD,1,1,0.659718581,1
-female,white,18-29,some college,SD,1,0,0.659718581,1
-female,white,30-39,4-year college,SD,1,1,0.659718581,1
-female,white,60-69,some college,SD,1,0,0.659718581,1
-male,white,30-39,hs,SD,3,2,0.659718581,1
-male,white,40-49,4-year college,SD,1,0,0.659718581,1
-male,white,50-59,4-year college,SD,1,1,0.659718581,1
-male,white,50-59,hs,SD,1,0,0.659718581,1
-male,white,60-69,some college,SD,1,1,0.659718581,1
-female,black,18-29,some college,TN,3,1,0.63624343,3
-female,black,30-39,post-grad,TN,1,0,0.63624343,3
-female,black,40-49,no hs,TN,1,0,0.63624343,3
-female,black,40-49,some college,TN,1,0,0.63624343,3
-female,black,50-59,hs,TN,1,1,0.63624343,3
-female,black,60-69,no hs,TN,2,1,0.63624343,3
-female,black,70+,some college,TN,1,0,0.63624343,3
-male,black,18-29,some college,TN,1,0,0.63624343,3
-male,black,30-39,4-year college,TN,1,1,0.63624343,3
-male,black,40-49,post-grad,TN,1,0,0.63624343,3
-male,black,40-49,some college,TN,1,0,0.63624343,3
-female,other,18-29,hs,TN,1,0,0.63624343,3
-female,other,18-29,some college,TN,1,0,0.63624343,3
-female,other,30-39,hs,TN,1,1,0.63624343,3
-female,other,30-39,some college,TN,1,1,0.63624343,3
-female,other,60-69,4-year college,TN,1,0,0.63624343,3
-male,other,30-39,4-year college,TN,1,1,0.63624343,3
-male,other,40-49,post-grad,TN,1,0,0.63624343,3
-male,other,40-49,some college,TN,1,0,0.63624343,3
-male,other,60-69,4-year college,TN,1,1,0.63624343,3
-female,white,18-29,4-year college,TN,1,1,0.63624343,3
-female,white,18-29,hs,TN,2,1,0.63624343,3
-female,white,18-29,no hs,TN,1,0,0.63624343,3
-female,white,18-29,some college,TN,5,3,0.63624343,3
-female,white,30-39,4-year college,TN,2,1,0.63624343,3
-female,white,30-39,some college,TN,2,1,0.63624343,3
-female,white,40-49,hs,TN,6,4,0.63624343,3
-female,white,40-49,post-grad,TN,1,0,0.63624343,3
-female,white,40-49,some college,TN,4,3,0.63624343,3
-female,white,50-59,hs,TN,7,6,0.63624343,3
-female,white,50-59,no hs,TN,1,0,0.63624343,3
-female,white,50-59,post-grad,TN,1,0,0.63624343,3
-female,white,60-69,4-year college,TN,1,1,0.63624343,3
-female,white,60-69,hs,TN,2,1,0.63624343,3
-female,white,60-69,some college,TN,2,1,0.63624343,3
-female,white,70+,4-year college,TN,1,1,0.63624343,3
-female,white,70+,hs,TN,3,2,0.63624343,3
-male,white,18-29,some college,TN,2,0,0.63624343,3
-male,white,30-39,4-year college,TN,1,1,0.63624343,3
-male,white,30-39,hs,TN,1,1,0.63624343,3
-male,white,30-39,post-grad,TN,3,0,0.63624343,3
-male,white,30-39,some college,TN,5,2,0.63624343,3
-male,white,40-49,4-year college,TN,6,4,0.63624343,3
-male,white,40-49,hs,TN,2,1,0.63624343,3
-male,white,40-49,post-grad,TN,2,1,0.63624343,3
-male,white,40-49,some college,TN,3,0,0.63624343,3
-male,white,50-59,4-year college,TN,1,1,0.63624343,3
-male,white,50-59,hs,TN,4,2,0.63624343,3
-male,white,50-59,no hs,TN,1,0,0.63624343,3
-male,white,50-59,post-grad,TN,1,1,0.63624343,3
-male,white,50-59,some college,TN,2,2,0.63624343,3
-male,white,60-69,4-year college,TN,1,0,0.63624343,3
-male,white,60-69,hs,TN,3,2,0.63624343,3
-male,white,60-69,some college,TN,2,1,0.63624343,3
-male,white,70+,hs,TN,1,1,0.63624343,3
-male,white,70+,post-grad,TN,5,2,0.63624343,3
-male,white,70+,some college,TN,1,1,0.63624343,3
-female,black,18-29,4-year college,TX,1,1,0.547132256,3
-female,black,18-29,hs,TX,2,0,0.547132256,3
-female,black,18-29,some college,TX,3,1,0.547132256,3
-female,black,30-39,4-year college,TX,1,0,0.547132256,3
-female,black,30-39,some college,TX,4,1,0.547132256,3
-female,black,40-49,4-year college,TX,2,1,0.547132256,3
-female,black,40-49,hs,TX,1,0,0.547132256,3
-female,black,40-49,some college,TX,1,1,0.547132256,3
-female,black,50-59,4-year college,TX,3,0,0.547132256,3
-female,black,50-59,post-grad,TX,1,0,0.547132256,3
-female,black,50-59,some college,TX,1,0,0.547132256,3
-female,black,60-69,hs,TX,1,0,0.547132256,3
-female,black,60-69,some college,TX,1,0,0.547132256,3
-male,black,18-29,hs,TX,1,0,0.547132256,3
-male,black,18-29,no hs,TX,1,0,0.547132256,3
-male,black,18-29,some college,TX,2,1,0.547132256,3
-male,black,30-39,4-year college,TX,1,0,0.547132256,3
-male,black,30-39,some college,TX,2,0,0.547132256,3
-male,black,40-49,4-year college,TX,1,0,0.547132256,3
-male,black,40-49,some college,TX,1,1,0.547132256,3
-male,black,50-59,some college,TX,4,0,0.547132256,3
-male,black,60-69,hs,TX,1,0,0.547132256,3
-male,black,70+,some college,TX,1,1,0.547132256,3
-female,other,18-29,4-year college,TX,5,2,0.547132256,3
-female,other,18-29,hs,TX,6,1,0.547132256,3
-female,other,18-29,no hs,TX,2,2,0.547132256,3
-female,other,18-29,post-grad,TX,3,0,0.547132256,3
-female,other,18-29,some college,TX,10,4,0.547132256,3
-female,other,30-39,4-year college,TX,3,1,0.547132256,3
-female,other,30-39,hs,TX,7,2,0.547132256,3
-female,other,30-39,no hs,TX,1,1,0.547132256,3
-female,other,30-39,post-grad,TX,2,1,0.547132256,3
-female,other,30-39,some college,TX,9,5,0.547132256,3
-female,other,40-49,4-year college,TX,1,1,0.547132256,3
-female,other,40-49,hs,TX,4,3,0.547132256,3
-female,other,40-49,some college,TX,1,0,0.547132256,3
-female,other,50-59,4-year college,TX,3,0,0.547132256,3
-female,other,50-59,hs,TX,2,0,0.547132256,3
-female,other,50-59,no hs,TX,1,1,0.547132256,3
-female,other,50-59,some college,TX,6,3,0.547132256,3
-female,other,60-69,4-year college,TX,1,0,0.547132256,3
-female,other,60-69,hs,TX,2,2,0.547132256,3
-female,other,60-69,post-grad,TX,1,0,0.547132256,3
-female,other,70+,4-year college,TX,1,1,0.547132256,3
-female,other,70+,some college,TX,2,1,0.547132256,3
-male,other,18-29,4-year college,TX,5,0,0.547132256,3
-male,other,18-29,hs,TX,1,0,0.547132256,3
-male,other,18-29,post-grad,TX,1,0,0.547132256,3
-male,other,18-29,some college,TX,7,2,0.547132256,3
-male,other,30-39,4-year college,TX,3,2,0.547132256,3
-male,other,30-39,hs,TX,1,1,0.547132256,3
-male,other,30-39,post-grad,TX,1,1,0.547132256,3
-male,other,40-49,4-year college,TX,1,0,0.547132256,3
-male,other,40-49,hs,TX,2,1,0.547132256,3
-male,other,40-49,post-grad,TX,1,0,0.547132256,3
-male,other,40-49,some college,TX,2,1,0.547132256,3
-male,other,50-59,4-year college,TX,2,2,0.547132256,3
-male,other,50-59,hs,TX,1,0,0.547132256,3
-male,other,50-59,post-grad,TX,5,4,0.547132256,3
-male,other,60-69,4-year college,TX,1,0,0.547132256,3
-male,other,60-69,post-grad,TX,1,1,0.547132256,3
-male,other,60-69,some college,TX,1,0,0.547132256,3
-male,other,70+,4-year college,TX,2,2,0.547132256,3
-male,other,70+,post-grad,TX,2,1,0.547132256,3
-female,white,18-29,4-year college,TX,5,1,0.547132256,3
-female,white,18-29,hs,TX,7,4,0.547132256,3
-female,white,18-29,no hs,TX,1,1,0.547132256,3
-female,white,18-29,post-grad,TX,1,0,0.547132256,3
-female,white,18-29,some college,TX,13,5,0.547132256,3
-female,white,30-39,4-year college,TX,4,1,0.547132256,3
-female,white,30-39,hs,TX,11,9,0.547132256,3
-female,white,30-39,post-grad,TX,6,1,0.547132256,3
-female,white,30-39,some college,TX,2,0,0.547132256,3
-female,white,40-49,4-year college,TX,4,1,0.547132256,3
-female,white,40-49,hs,TX,4,3,0.547132256,3
-female,white,40-49,no hs,TX,1,1,0.547132256,3
-female,white,40-49,post-grad,TX,2,1,0.547132256,3
-female,white,40-49,some college,TX,5,4,0.547132256,3
-female,white,50-59,4-year college,TX,5,3,0.547132256,3
-female,white,50-59,hs,TX,2,1,0.547132256,3
-female,white,50-59,no hs,TX,1,1,0.547132256,3
-female,white,50-59,post-grad,TX,3,1,0.547132256,3
-female,white,50-59,some college,TX,9,4,0.547132256,3
-female,white,60-69,4-year college,TX,4,1,0.547132256,3
-female,white,60-69,hs,TX,7,6,0.547132256,3
-female,white,60-69,post-grad,TX,3,1,0.547132256,3
-female,white,60-69,some college,TX,10,8,0.547132256,3
-female,white,70+,4-year college,TX,4,3,0.547132256,3
-female,white,70+,hs,TX,5,3,0.547132256,3
-female,white,70+,post-grad,TX,2,1,0.547132256,3
-female,white,70+,some college,TX,5,3,0.547132256,3
-male,white,18-29,4-year college,TX,5,1,0.547132256,3
-male,white,18-29,hs,TX,3,1,0.547132256,3
-male,white,18-29,post-grad,TX,2,1,0.547132256,3
-male,white,18-29,some college,TX,3,0,0.547132256,3
-male,white,30-39,4-year college,TX,4,2,0.547132256,3
-male,white,30-39,hs,TX,2,2,0.547132256,3
-male,white,30-39,post-grad,TX,1,0,0.547132256,3
-male,white,30-39,some college,TX,4,0,0.547132256,3
-male,white,40-49,4-year college,TX,1,0,0.547132256,3
-male,white,40-49,hs,TX,3,0,0.547132256,3
-male,white,40-49,post-grad,TX,1,1,0.547132256,3
-male,white,40-49,some college,TX,5,3,0.547132256,3
-male,white,50-59,4-year college,TX,7,4,0.547132256,3
-male,white,50-59,hs,TX,6,4,0.547132256,3
-male,white,50-59,post-grad,TX,9,2,0.547132256,3
-male,white,50-59,some college,TX,6,6,0.547132256,3
-male,white,60-69,4-year college,TX,11,9,0.547132256,3
-male,white,60-69,hs,TX,1,0,0.547132256,3
-male,white,60-69,post-grad,TX,5,2,0.547132256,3
-male,white,60-69,some college,TX,4,3,0.547132256,3
-male,white,70+,4-year college,TX,5,3,0.547132256,3
-male,white,70+,hs,TX,4,3,0.547132256,3
-male,white,70+,no hs,TX,1,1,0.547132256,3
-male,white,70+,post-grad,TX,8,4,0.547132256,3
-male,white,70+,some college,TX,6,5,0.547132256,3
-female,black,30-39,4-year college,UT,1,0,0.623836582,4
-male,black,40-49,4-year college,UT,1,0,0.623836582,4
-male,black,50-59,hs,UT,1,0,0.623836582,4
-female,other,18-29,4-year college,UT,1,1,0.623836582,4
-female,other,18-29,some college,UT,1,0,0.623836582,4
-female,other,30-39,some college,UT,1,1,0.623836582,4
-female,other,40-49,4-year college,UT,1,1,0.623836582,4
-female,other,40-49,hs,UT,1,1,0.623836582,4
-female,other,40-49,some college,UT,1,0,0.623836582,4
-female,other,50-59,hs,UT,1,0,0.623836582,4
-male,other,18-29,4-year college,UT,1,0,0.623836582,4
-male,other,18-29,some college,UT,1,0,0.623836582,4
-female,white,18-29,4-year college,UT,1,0,0.623836582,4
-female,white,18-29,hs,UT,1,1,0.623836582,4
-female,white,18-29,some college,UT,3,3,0.623836582,4
-female,white,30-39,no hs,UT,1,0,0.623836582,4
-female,white,30-39,some college,UT,2,1,0.623836582,4
-female,white,40-49,some college,UT,1,1,0.623836582,4
-female,white,50-59,4-year college,UT,2,0,0.623836582,4
-female,white,50-59,hs,UT,2,1,0.623836582,4
-female,white,70+,hs,UT,2,1,0.623836582,4
-female,white,70+,no hs,UT,2,2,0.623836582,4
-female,white,70+,some college,UT,1,1,0.623836582,4
-male,white,18-29,some college,UT,1,0,0.623836582,4
-male,white,30-39,4-year college,UT,2,0,0.623836582,4
-male,white,30-39,post-grad,UT,1,1,0.623836582,4
-male,white,30-39,some college,UT,1,0,0.623836582,4
-male,white,40-49,4-year college,UT,1,0,0.623836582,4
-male,white,40-49,hs,UT,2,0,0.623836582,4
-male,white,40-49,some college,UT,1,1,0.623836582,4
-male,white,50-59,4-year college,UT,4,3,0.623836582,4
-male,white,50-59,post-grad,UT,1,1,0.623836582,4
-male,white,50-59,some college,UT,3,1,0.623836582,4
-male,white,60-69,4-year college,UT,2,1,0.623836582,4
-male,white,60-69,post-grad,UT,2,2,0.623836582,4
-male,white,60-69,some college,UT,1,0,0.623836582,4
-male,white,70+,4-year college,UT,2,1,0.623836582,4
-male,white,70+,no hs,UT,1,1,0.623836582,4
-male,white,70+,some college,UT,1,0,0.623836582,4
-female,black,18-29,4-year college,VA,2,0,0.471736237,3
-female,black,18-29,hs,VA,1,1,0.471736237,3
-female,black,30-39,hs,VA,3,1,0.471736237,3
-female,black,40-49,4-year college,VA,2,0,0.471736237,3
-female,black,40-49,hs,VA,2,0,0.471736237,3
-female,black,40-49,some college,VA,1,0,0.471736237,3
-female,black,50-59,hs,VA,3,2,0.471736237,3
-female,black,50-59,post-grad,VA,1,1,0.471736237,3
-female,black,50-59,some college,VA,2,0,0.471736237,3
-female,black,60-69,hs,VA,1,1,0.471736237,3
-female,black,60-69,no hs,VA,1,1,0.471736237,3
-female,black,60-69,some college,VA,1,0,0.471736237,3
-male,black,18-29,4-year college,VA,1,0,0.471736237,3
-male,black,40-49,hs,VA,1,1,0.471736237,3
-female,other,18-29,4-year college,VA,1,0,0.471736237,3
-female,other,18-29,some college,VA,1,0,0.471736237,3
-female,other,40-49,some college,VA,1,0,0.471736237,3
-female,other,50-59,post-grad,VA,1,1,0.471736237,3
-female,other,70+,hs,VA,1,1,0.471736237,3
-male,other,18-29,4-year college,VA,1,0,0.471736237,3
-male,other,18-29,hs,VA,1,0,0.471736237,3
-male,other,18-29,post-grad,VA,1,0,0.471736237,3
-male,other,18-29,some college,VA,1,0,0.471736237,3
-male,other,30-39,4-year college,VA,1,0,0.471736237,3
-male,other,30-39,post-grad,VA,1,1,0.471736237,3
-male,other,30-39,some college,VA,2,0,0.471736237,3
-male,other,40-49,post-grad,VA,1,1,0.471736237,3
-male,other,50-59,4-year college,VA,1,0,0.471736237,3
-male,other,60-69,hs,VA,2,2,0.471736237,3
-male,other,70+,post-grad,VA,1,1,0.471736237,3
-female,white,18-29,4-year college,VA,3,1,0.471736237,3
-female,white,18-29,hs,VA,4,2,0.471736237,3
-female,white,18-29,post-grad,VA,2,1,0.471736237,3
-female,white,18-29,some college,VA,5,1,0.471736237,3
-female,white,30-39,4-year college,VA,2,0,0.471736237,3
-female,white,30-39,hs,VA,4,2,0.471736237,3
-female,white,30-39,post-grad,VA,1,0,0.471736237,3
-female,white,30-39,some college,VA,2,1,0.471736237,3
-female,white,40-49,4-year college,VA,1,0,0.471736237,3
-female,white,40-49,hs,VA,2,0,0.471736237,3
-female,white,40-49,no hs,VA,1,1,0.471736237,3
-female,white,40-49,post-grad,VA,1,1,0.471736237,3
-female,white,40-49,some college,VA,4,2,0.471736237,3
-female,white,50-59,4-year college,VA,1,0,0.471736237,3
-female,white,50-59,hs,VA,1,1,0.471736237,3
-female,white,50-59,post-grad,VA,3,1,0.471736237,3
-female,white,60-69,4-year college,VA,1,0,0.471736237,3
-female,white,60-69,hs,VA,4,2,0.471736237,3
-female,white,60-69,post-grad,VA,2,0,0.471736237,3
-female,white,60-69,some college,VA,1,0,0.471736237,3
-female,white,70+,4-year college,VA,1,0,0.471736237,3
-female,white,70+,hs,VA,2,2,0.471736237,3
-female,white,70+,post-grad,VA,2,2,0.471736237,3
-female,white,70+,some college,VA,2,0,0.471736237,3
-male,white,18-29,4-year college,VA,2,1,0.471736237,3
-male,white,18-29,post-grad,VA,1,0,0.471736237,3
-male,white,18-29,some college,VA,4,3,0.471736237,3
-male,white,30-39,4-year college,VA,2,0,0.471736237,3
-male,white,30-39,hs,VA,1,0,0.471736237,3
-male,white,30-39,post-grad,VA,2,0,0.471736237,3
-male,white,30-39,some college,VA,4,2,0.471736237,3
-male,white,40-49,4-year college,VA,3,1,0.471736237,3
-male,white,40-49,hs,VA,2,0,0.471736237,3
-male,white,40-49,post-grad,VA,1,0,0.471736237,3
-male,white,40-49,some college,VA,1,0,0.471736237,3
-male,white,50-59,4-year college,VA,5,3,0.471736237,3
-male,white,50-59,hs,VA,1,1,0.471736237,3
-male,white,50-59,post-grad,VA,3,2,0.471736237,3
-male,white,50-59,some college,VA,3,2,0.471736237,3
-male,white,60-69,4-year college,VA,3,3,0.471736237,3
-male,white,60-69,hs,VA,2,2,0.471736237,3
-male,white,60-69,post-grad,VA,2,1,0.471736237,3
-male,white,60-69,some college,VA,5,2,0.471736237,3
-male,white,70+,4-year college,VA,2,2,0.471736237,3
-male,white,70+,hs,VA,2,1,0.471736237,3
-male,white,70+,post-grad,VA,3,2,0.471736237,3
-male,white,70+,some college,VA,1,1,0.471736237,3
-female,other,18-29,4-year college,VT,1,0,0.348135737,2
-female,white,18-29,some college,VT,1,0,0.348135737,2
-female,white,30-39,post-grad,VT,1,0,0.348135737,2
-female,white,50-59,some college,VT,1,1,0.348135737,2
-female,white,60-69,some college,VT,1,0,0.348135737,2
-female,white,70+,4-year college,VT,1,0,0.348135737,2
-male,white,18-29,hs,VT,1,1,0.348135737,2
-male,white,50-59,post-grad,VT,1,0,0.348135737,2
-male,white,70+,some college,VT,1,1,0.348135737,2
-male,black,40-49,post-grad,WA,1,0,0.412130688,4
-male,black,50-59,4-year college,WA,1,1,0.412130688,4
-female,other,18-29,4-year college,WA,1,0,0.412130688,4
-female,other,18-29,hs,WA,1,0,0.412130688,4
-female,other,18-29,post-grad,WA,2,0,0.412130688,4
-female,other,18-29,some college,WA,4,1,0.412130688,4
-female,other,30-39,4-year college,WA,2,1,0.412130688,4
-female,other,30-39,hs,WA,1,0,0.412130688,4
-female,other,30-39,some college,WA,2,0,0.412130688,4
-female,other,50-59,post-grad,WA,2,1,0.412130688,4
-male,other,18-29,some college,WA,1,0,0.412130688,4
-male,other,30-39,some college,WA,2,1,0.412130688,4
-male,other,40-49,hs,WA,1,0,0.412130688,4
-male,other,40-49,post-grad,WA,2,0,0.412130688,4
-male,other,40-49,some college,WA,1,1,0.412130688,4
-male,other,50-59,4-year college,WA,2,1,0.412130688,4
-male,other,50-59,some college,WA,1,1,0.412130688,4
-male,other,60-69,post-grad,WA,1,0,0.412130688,4
-male,other,70+,some college,WA,1,0,0.412130688,4
-female,white,18-29,4-year college,WA,2,0,0.412130688,4
-female,white,18-29,hs,WA,1,0,0.412130688,4
-female,white,18-29,no hs,WA,2,0,0.412130688,4
-female,white,30-39,4-year college,WA,5,1,0.412130688,4
-female,white,30-39,hs,WA,3,1,0.412130688,4
-female,white,30-39,post-grad,WA,3,0,0.412130688,4
-female,white,30-39,some college,WA,2,1,0.412130688,4
-female,white,40-49,4-year college,WA,2,1,0.412130688,4
-female,white,40-49,hs,WA,2,0,0.412130688,4
-female,white,40-49,post-grad,WA,1,0,0.412130688,4
-female,white,40-49,some college,WA,2,1,0.412130688,4
-female,white,50-59,hs,WA,1,1,0.412130688,4
-female,white,50-59,post-grad,WA,2,0,0.412130688,4
-female,white,50-59,some college,WA,4,1,0.412130688,4
-female,white,60-69,4-year college,WA,1,0,0.412130688,4
-female,white,60-69,hs,WA,2,0,0.412130688,4
-female,white,60-69,no hs,WA,1,0,0.412130688,4
-female,white,60-69,some college,WA,3,2,0.412130688,4
-female,white,70+,4-year college,WA,2,0,0.412130688,4
-female,white,70+,hs,WA,6,3,0.412130688,4
-female,white,70+,post-grad,WA,1,0,0.412130688,4
-female,white,70+,some college,WA,5,5,0.412130688,4
-male,white,18-29,hs,WA,5,1,0.412130688,4
-male,white,30-39,4-year college,WA,2,1,0.412130688,4
-male,white,30-39,hs,WA,2,0,0.412130688,4
-male,white,30-39,post-grad,WA,2,2,0.412130688,4
-male,white,30-39,some college,WA,1,1,0.412130688,4
-male,white,40-49,4-year college,WA,2,1,0.412130688,4
-male,white,40-49,hs,WA,2,2,0.412130688,4
-male,white,40-49,no hs,WA,1,1,0.412130688,4
-male,white,40-49,post-grad,WA,3,0,0.412130688,4
-male,white,50-59,4-year college,WA,3,1,0.412130688,4
-male,white,50-59,hs,WA,2,0,0.412130688,4
-male,white,50-59,post-grad,WA,1,1,0.412130688,4
-male,white,50-59,some college,WA,3,0,0.412130688,4
-male,white,60-69,4-year college,WA,3,2,0.412130688,4
-male,white,60-69,hs,WA,1,0,0.412130688,4
-male,white,60-69,post-grad,WA,1,0,0.412130688,4
-male,white,60-69,some college,WA,3,3,0.412130688,4
-male,white,70+,4-year college,WA,4,0,0.412130688,4
-male,white,70+,hs,WA,1,0,0.412130688,4
-male,white,70+,post-grad,WA,5,3,0.412130688,4
-male,white,70+,some college,WA,3,1,0.412130688,4
-female,black,50-59,some college,WI,1,0,0.50407989,1
-female,black,70+,post-grad,WI,1,0,0.50407989,1
-female,other,18-29,4-year college,WI,2,0,0.50407989,1
-female,other,18-29,some college,WI,1,0,0.50407989,1
-female,other,30-39,4-year college,WI,1,1,0.50407989,1
-female,other,30-39,post-grad,WI,1,0,0.50407989,1
-female,other,30-39,some college,WI,1,0,0.50407989,1
-male,other,18-29,hs,WI,1,1,0.50407989,1
-male,other,18-29,some college,WI,1,0,0.50407989,1
-male,other,30-39,hs,WI,1,1,0.50407989,1
-male,other,40-49,4-year college,WI,1,0,0.50407989,1
-female,white,18-29,4-year college,WI,5,0,0.50407989,1
-female,white,18-29,hs,WI,3,3,0.50407989,1
-female,white,18-29,post-grad,WI,1,0,0.50407989,1
-female,white,18-29,some college,WI,7,1,0.50407989,1
-female,white,30-39,4-year college,WI,2,0,0.50407989,1
-female,white,30-39,hs,WI,5,2,0.50407989,1
-female,white,30-39,post-grad,WI,1,0,0.50407989,1
-female,white,30-39,some college,WI,1,0,0.50407989,1
-female,white,40-49,4-year college,WI,3,1,0.50407989,1
-female,white,40-49,hs,WI,2,0,0.50407989,1
-female,white,50-59,4-year college,WI,1,1,0.50407989,1
-female,white,50-59,hs,WI,5,3,0.50407989,1
-female,white,50-59,some college,WI,8,2,0.50407989,1
-female,white,60-69,hs,WI,6,3,0.50407989,1
-female,white,60-69,some college,WI,4,1,0.50407989,1
-female,white,70+,hs,WI,4,3,0.50407989,1
-female,white,70+,some college,WI,2,0,0.50407989,1
-male,white,18-29,4-year college,WI,1,0,0.50407989,1
-male,white,18-29,hs,WI,1,1,0.50407989,1
-male,white,18-29,some college,WI,1,0,0.50407989,1
-male,white,30-39,4-year college,WI,4,2,0.50407989,1
-male,white,30-39,some college,WI,2,0,0.50407989,1
-male,white,40-49,hs,WI,1,1,0.50407989,1
-male,white,40-49,post-grad,WI,1,0,0.50407989,1
-male,white,40-49,some college,WI,3,1,0.50407989,1
-male,white,50-59,4-year college,WI,2,1,0.50407989,1
-male,white,50-59,post-grad,WI,2,1,0.50407989,1
-male,white,50-59,some college,WI,2,1,0.50407989,1
-male,white,60-69,4-year college,WI,1,1,0.50407989,1
-male,white,60-69,hs,WI,2,0,0.50407989,1
-male,white,60-69,post-grad,WI,2,1,0.50407989,1
-male,white,70+,4-year college,WI,1,0,0.50407989,1
-male,white,70+,hs,WI,3,2,0.50407989,1
-male,white,70+,post-grad,WI,2,0,0.50407989,1
-male,white,70+,some college,WI,1,1,0.50407989,1
-female,black,50-59,post-grad,WV,1,0,0.721610523,3
-female,black,50-59,some college,WV,1,0,0.721610523,3
-female,other,50-59,some college,WV,1,0,0.721610523,3
-male,other,40-49,some college,WV,2,2,0.721610523,3
-male,other,60-69,4-year college,WV,1,1,0.721610523,3
-female,white,18-29,4-year college,WV,1,1,0.721610523,3
-female,white,18-29,hs,WV,4,1,0.721610523,3
-female,white,18-29,no hs,WV,1,1,0.721610523,3
-female,white,18-29,post-grad,WV,1,0,0.721610523,3
-female,white,18-29,some college,WV,3,1,0.721610523,3
-female,white,30-39,hs,WV,1,1,0.721610523,3
-female,white,40-49,hs,WV,1,1,0.721610523,3
-female,white,40-49,some college,WV,1,0,0.721610523,3
-female,white,50-59,4-year college,WV,1,0,0.721610523,3
-female,white,50-59,hs,WV,2,2,0.721610523,3
-female,white,50-59,post-grad,WV,1,0,0.721610523,3
-female,white,60-69,hs,WV,2,1,0.721610523,3
-female,white,60-69,no hs,WV,1,0,0.721610523,3
-female,white,60-69,some college,WV,1,1,0.721610523,3
-female,white,70+,hs,WV,1,0,0.721610523,3
-female,white,70+,some college,WV,2,0,0.721610523,3
-male,white,18-29,4-year college,WV,1,1,0.721610523,3
-male,white,30-39,hs,WV,2,0,0.721610523,3
-male,white,30-39,some college,WV,1,1,0.721610523,3
-male,white,50-59,hs,WV,2,2,0.721610523,3
-male,white,50-59,post-grad,WV,1,1,0.721610523,3
-male,white,50-59,some college,WV,1,1,0.721610523,3
-male,white,60-69,hs,WV,2,2,0.721610523,3
-male,white,60-69,some college,WV,1,1,0.721610523,3
-male,white,70+,post-grad,WV,1,1,0.721610523,3
-male,white,70+,some college,WV,1,1,0.721610523,3
-female,other,18-29,hs,WY,1,0,0.757053196,4
-male,other,50-59,some college,WY,1,1,0.757053196,4
-female,white,30-39,hs,WY,1,1,0.757053196,4
-female,white,40-49,4-year college,WY,1,1,0.757053196,4
-female,white,40-49,no hs,WY,1,1,0.757053196,4
-female,white,40-49,some college,WY,2,1,0.757053196,4
-female,white,50-59,4-year college,WY,1,0,0.757053196,4
-female,white,50-59,some college,WY,1,0,0.757053196,4
-female,white,60-69,4-year college,WY,1,1,0.757053196,4
-male,white,40-49,post-grad,WY,1,1,0.757053196,4
-male,white,50-59,hs,WY,1,1,0.757053196,4
-male,white,60-69,4-year college,WY,1,0,0.757053196,4
+sex,race,age,edu,state,total,positive,repvote
+male,other,50-59,4-year college,AK,1,1,0.583856547
+female,white,50-59,hs,AK,1,0,0.583856547
+male,white,18-29,some college,AK,1,0,0.583856547
+male,white,30-39,post-grad,AK,1,0,0.583856547
+female,black,18-29,hs,AL,1,0,0.643741436
+female,black,18-29,some college,AL,1,0,0.643741436
+female,black,30-39,4-year college,AL,1,0,0.643741436
+female,black,30-39,hs,AL,1,0,0.643741436
+female,black,30-39,some college,AL,1,0,0.643741436
+female,black,40-49,hs,AL,1,1,0.643741436
+female,black,40-49,some college,AL,2,0,0.643741436
+female,black,50-59,post-grad,AL,1,0,0.643741436
+female,black,50-59,some college,AL,1,0,0.643741436
+female,black,60-69,some college,AL,1,1,0.643741436
+male,black,40-49,some college,AL,1,1,0.643741436
+female,other,18-29,4-year college,AL,1,0,0.643741436
+female,other,30-39,hs,AL,1,0,0.643741436
+female,other,40-49,some college,AL,1,1,0.643741436
+female,white,18-29,4-year college,AL,3,0,0.643741436
+female,white,18-29,hs,AL,4,1,0.643741436
+female,white,18-29,some college,AL,2,1,0.643741436
+female,white,30-39,4-year college,AL,2,1,0.643741436
+female,white,30-39,hs,AL,2,2,0.643741436
+female,white,30-39,no hs,AL,1,1,0.643741436
+female,white,30-39,some college,AL,4,4,0.643741436
+female,white,40-49,hs,AL,3,1,0.643741436
+female,white,40-49,no hs,AL,1,1,0.643741436
+female,white,40-49,post-grad,AL,1,0,0.643741436
+female,white,50-59,hs,AL,4,2,0.643741436
+female,white,50-59,post-grad,AL,1,1,0.643741436
+female,white,50-59,some college,AL,2,1,0.643741436
+female,white,60-69,4-year college,AL,1,0,0.643741436
+female,white,60-69,no hs,AL,2,0,0.643741436
+female,white,60-69,some college,AL,2,1,0.643741436
+female,white,70+,4-year college,AL,1,1,0.643741436
+female,white,70+,hs,AL,2,2,0.643741436
+female,white,70+,post-grad,AL,1,0,0.643741436
+female,white,70+,some college,AL,6,3,0.643741436
+male,white,18-29,4-year college,AL,2,1,0.643741436
+male,white,30-39,4-year college,AL,1,0,0.643741436
+male,white,30-39,hs,AL,1,1,0.643741436
+male,white,30-39,post-grad,AL,1,1,0.643741436
+male,white,40-49,4-year college,AL,1,1,0.643741436
+male,white,40-49,hs,AL,2,2,0.643741436
+male,white,40-49,some college,AL,4,2,0.643741436
+male,white,50-59,hs,AL,3,3,0.643741436
+male,white,50-59,some college,AL,2,2,0.643741436
+male,white,60-69,4-year college,AL,2,2,0.643741436
+male,white,70+,4-year college,AL,5,5,0.643741436
+male,white,70+,post-grad,AL,1,1,0.643741436
+female,black,60-69,some college,AR,1,0,0.642851377
+female,black,70+,some college,AR,1,0,0.642851377
+male,black,30-39,some college,AR,1,1,0.642851377
+male,black,40-49,hs,AR,2,0,0.642851377
+female,other,30-39,hs,AR,1,0,0.642851377
+female,other,40-49,no hs,AR,1,1,0.642851377
+male,other,18-29,some college,AR,1,0,0.642851377
+male,other,50-59,some college,AR,1,1,0.642851377
+female,white,18-29,4-year college,AR,1,0,0.642851377
+female,white,18-29,hs,AR,1,0,0.642851377
+female,white,18-29,post-grad,AR,1,0,0.642851377
+female,white,18-29,some college,AR,5,4,0.642851377
+female,white,30-39,some college,AR,3,3,0.642851377
+female,white,40-49,4-year college,AR,1,1,0.642851377
+female,white,40-49,hs,AR,2,2,0.642851377
+female,white,40-49,some college,AR,2,2,0.642851377
+female,white,50-59,4-year college,AR,2,1,0.642851377
+female,white,50-59,hs,AR,1,1,0.642851377
+female,white,50-59,no hs,AR,1,1,0.642851377
+female,white,50-59,some college,AR,2,1,0.642851377
+female,white,60-69,hs,AR,1,1,0.642851377
+female,white,60-69,no hs,AR,1,0,0.642851377
+female,white,60-69,some college,AR,3,3,0.642851377
+female,white,70+,post-grad,AR,2,0,0.642851377
+female,white,70+,some college,AR,2,1,0.642851377
+male,white,18-29,4-year college,AR,1,0,0.642851377
+male,white,18-29,post-grad,AR,2,1,0.642851377
+male,white,30-39,no hs,AR,1,0,0.642851377
+male,white,40-49,no hs,AR,1,0,0.642851377
+male,white,50-59,some college,AR,1,0,0.642851377
+male,white,60-69,4-year college,AR,1,0,0.642851377
+male,white,60-69,hs,AR,2,1,0.642851377
+male,white,70+,4-year college,AR,1,1,0.642851377
+male,white,70+,hs,AR,1,1,0.642851377
+male,black,18-29,some college,AZ,1,0,0.518900234
+male,black,50-59,no hs,AZ,1,0,0.518900234
+female,other,18-29,4-year college,AZ,3,1,0.518900234
+female,other,18-29,no hs,AZ,1,0,0.518900234
+female,other,18-29,post-grad,AZ,1,0,0.518900234
+female,other,18-29,some college,AZ,3,0,0.518900234
+female,other,30-39,4-year college,AZ,1,0,0.518900234
+female,other,30-39,hs,AZ,2,1,0.518900234
+female,other,30-39,no hs,AZ,1,1,0.518900234
+female,other,30-39,post-grad,AZ,1,1,0.518900234
+female,other,40-49,some college,AZ,1,0,0.518900234
+female,other,50-59,4-year college,AZ,1,1,0.518900234
+female,other,50-59,some college,AZ,1,0,0.518900234
+female,other,70+,4-year college,AZ,2,1,0.518900234
+female,other,70+,some college,AZ,1,1,0.518900234
+male,other,18-29,4-year college,AZ,2,0,0.518900234
+male,other,18-29,no hs,AZ,1,0,0.518900234
+male,other,18-29,some college,AZ,1,0,0.518900234
+male,other,30-39,some college,AZ,1,0,0.518900234
+male,other,40-49,4-year college,AZ,1,0,0.518900234
+male,other,40-49,post-grad,AZ,1,0,0.518900234
+male,other,40-49,some college,AZ,1,1,0.518900234
+male,other,50-59,4-year college,AZ,2,0,0.518900234
+male,other,50-59,some college,AZ,1,1,0.518900234
+female,white,18-29,hs,AZ,1,1,0.518900234
+female,white,30-39,4-year college,AZ,1,0,0.518900234
+female,white,30-39,hs,AZ,2,1,0.518900234
+female,white,30-39,some college,AZ,2,0,0.518900234
+female,white,40-49,4-year college,AZ,1,0,0.518900234
+female,white,40-49,hs,AZ,2,2,0.518900234
+female,white,40-49,post-grad,AZ,1,0,0.518900234
+female,white,40-49,some college,AZ,1,0,0.518900234
+female,white,50-59,4-year college,AZ,3,0,0.518900234
+female,white,50-59,hs,AZ,4,2,0.518900234
+female,white,50-59,no hs,AZ,2,1,0.518900234
+female,white,50-59,post-grad,AZ,1,1,0.518900234
+female,white,50-59,some college,AZ,8,5,0.518900234
+female,white,60-69,4-year college,AZ,3,1,0.518900234
+female,white,60-69,hs,AZ,5,3,0.518900234
+female,white,60-69,post-grad,AZ,1,0,0.518900234
+female,white,60-69,some college,AZ,4,2,0.518900234
+female,white,70+,4-year college,AZ,3,1,0.518900234
+female,white,70+,hs,AZ,4,2,0.518900234
+female,white,70+,post-grad,AZ,1,0,0.518900234
+female,white,70+,some college,AZ,2,1,0.518900234
+male,white,18-29,4-year college,AZ,2,1,0.518900234
+male,white,18-29,hs,AZ,1,1,0.518900234
+male,white,18-29,post-grad,AZ,1,0,0.518900234
+male,white,30-39,4-year college,AZ,2,1,0.518900234
+male,white,30-39,hs,AZ,2,1,0.518900234
+male,white,30-39,some college,AZ,1,0,0.518900234
+male,white,40-49,4-year college,AZ,2,1,0.518900234
+male,white,40-49,some college,AZ,3,1,0.518900234
+male,white,50-59,4-year college,AZ,2,2,0.518900234
+male,white,50-59,some college,AZ,2,1,0.518900234
+male,white,60-69,4-year college,AZ,3,1,0.518900234
+male,white,60-69,hs,AZ,2,0,0.518900234
+male,white,60-69,post-grad,AZ,2,1,0.518900234
+male,white,60-69,some college,AZ,6,6,0.518900234
+male,white,70+,4-year college,AZ,1,0,0.518900234
+male,white,70+,hs,AZ,2,1,0.518900234
+male,white,70+,no hs,AZ,1,1,0.518900234
+male,white,70+,post-grad,AZ,4,0,0.518900234
+male,white,70+,some college,AZ,2,2,0.518900234
+female,black,18-29,hs,CA,1,0,0.338717892
+female,black,18-29,no hs,CA,1,1,0.338717892
+female,black,18-29,some college,CA,4,1,0.338717892
+female,black,30-39,4-year college,CA,2,1,0.338717892
+female,black,30-39,post-grad,CA,1,1,0.338717892
+female,black,30-39,some college,CA,1,0,0.338717892
+female,black,40-49,4-year college,CA,2,1,0.338717892
+female,black,40-49,some college,CA,2,0,0.338717892
+female,black,50-59,some college,CA,5,2,0.338717892
+male,black,18-29,hs,CA,3,0,0.338717892
+male,black,18-29,some college,CA,2,1,0.338717892
+male,black,30-39,no hs,CA,1,1,0.338717892
+male,black,30-39,some college,CA,5,2,0.338717892
+male,black,40-49,4-year college,CA,1,1,0.338717892
+male,black,50-59,4-year college,CA,1,0,0.338717892
+male,black,50-59,hs,CA,2,0,0.338717892
+male,black,50-59,post-grad,CA,1,0,0.338717892
+male,black,60-69,4-year college,CA,1,0,0.338717892
+male,black,60-69,some college,CA,1,0,0.338717892
+male,black,70+,post-grad,CA,1,0,0.338717892
+female,other,18-29,4-year college,CA,12,5,0.338717892
+female,other,18-29,hs,CA,15,5,0.338717892
+female,other,18-29,no hs,CA,1,1,0.338717892
+female,other,18-29,post-grad,CA,5,3,0.338717892
+female,other,18-29,some college,CA,20,4,0.338717892
+female,other,30-39,4-year college,CA,5,3,0.338717892
+female,other,30-39,hs,CA,6,1,0.338717892
+female,other,30-39,post-grad,CA,3,0,0.338717892
+female,other,30-39,some college,CA,3,1,0.338717892
+female,other,40-49,4-year college,CA,4,3,0.338717892
+female,other,40-49,hs,CA,3,1,0.338717892
+female,other,40-49,post-grad,CA,1,0,0.338717892
+female,other,40-49,some college,CA,9,2,0.338717892
+female,other,50-59,4-year college,CA,1,0,0.338717892
+female,other,50-59,hs,CA,5,3,0.338717892
+female,other,50-59,post-grad,CA,1,0,0.338717892
+female,other,50-59,some college,CA,3,1,0.338717892
+female,other,60-69,4-year college,CA,1,0,0.338717892
+female,other,60-69,hs,CA,1,1,0.338717892
+female,other,60-69,some college,CA,3,1,0.338717892
+female,other,70+,post-grad,CA,1,0,0.338717892
+female,other,70+,some college,CA,1,1,0.338717892
+male,other,18-29,4-year college,CA,3,1,0.338717892
+male,other,18-29,hs,CA,3,1,0.338717892
+male,other,18-29,post-grad,CA,1,0,0.338717892
+male,other,18-29,some college,CA,18,9,0.338717892
+male,other,30-39,4-year college,CA,6,1,0.338717892
+male,other,30-39,hs,CA,3,1,0.338717892
+male,other,30-39,post-grad,CA,1,1,0.338717892
+male,other,30-39,some college,CA,8,2,0.338717892
+male,other,40-49,4-year college,CA,1,1,0.338717892
+male,other,40-49,post-grad,CA,2,1,0.338717892
+male,other,40-49,some college,CA,2,1,0.338717892
+male,other,50-59,4-year college,CA,2,1,0.338717892
+male,other,50-59,hs,CA,1,1,0.338717892
+male,other,50-59,post-grad,CA,2,0,0.338717892
+male,other,50-59,some college,CA,5,1,0.338717892
+male,other,60-69,hs,CA,3,0,0.338717892
+male,other,60-69,some college,CA,1,0,0.338717892
+male,other,70+,4-year college,CA,1,0,0.338717892
+male,other,70+,hs,CA,1,0,0.338717892
+male,other,70+,some college,CA,1,1,0.338717892
+female,white,18-29,4-year college,CA,9,2,0.338717892
+female,white,18-29,hs,CA,4,2,0.338717892
+female,white,18-29,no hs,CA,1,0,0.338717892
+female,white,18-29,post-grad,CA,4,1,0.338717892
+female,white,18-29,some college,CA,11,3,0.338717892
+female,white,30-39,4-year college,CA,5,0,0.338717892
+female,white,30-39,hs,CA,3,1,0.338717892
+female,white,30-39,post-grad,CA,5,0,0.338717892
+female,white,30-39,some college,CA,7,3,0.338717892
+female,white,40-49,4-year college,CA,4,2,0.338717892
+female,white,40-49,hs,CA,3,0,0.338717892
+female,white,40-49,post-grad,CA,1,0,0.338717892
+female,white,40-49,some college,CA,4,0,0.338717892
+female,white,50-59,4-year college,CA,3,0,0.338717892
+female,white,50-59,hs,CA,9,4,0.338717892
+female,white,50-59,no hs,CA,3,2,0.338717892
+female,white,50-59,post-grad,CA,4,0,0.338717892
+female,white,50-59,some college,CA,3,2,0.338717892
+female,white,60-69,4-year college,CA,9,3,0.338717892
+female,white,60-69,hs,CA,5,1,0.338717892
+female,white,60-69,no hs,CA,2,0,0.338717892
+female,white,60-69,post-grad,CA,6,1,0.338717892
+female,white,60-69,some college,CA,7,4,0.338717892
+female,white,70+,4-year college,CA,8,3,0.338717892
+female,white,70+,hs,CA,6,3,0.338717892
+female,white,70+,no hs,CA,1,1,0.338717892
+female,white,70+,post-grad,CA,1,0,0.338717892
+female,white,70+,some college,CA,10,6,0.338717892
+male,white,18-29,4-year college,CA,3,1,0.338717892
+male,white,18-29,hs,CA,4,0,0.338717892
+male,white,18-29,no hs,CA,1,0,0.338717892
+male,white,18-29,post-grad,CA,1,1,0.338717892
+male,white,18-29,some college,CA,6,5,0.338717892
+male,white,30-39,4-year college,CA,3,2,0.338717892
+male,white,30-39,hs,CA,3,3,0.338717892
+male,white,30-39,post-grad,CA,2,1,0.338717892
+male,white,30-39,some college,CA,5,3,0.338717892
+male,white,40-49,4-year college,CA,1,0,0.338717892
+male,white,40-49,hs,CA,2,0,0.338717892
+male,white,40-49,post-grad,CA,2,1,0.338717892
+male,white,40-49,some college,CA,2,2,0.338717892
+male,white,50-59,4-year college,CA,5,2,0.338717892
+male,white,50-59,hs,CA,7,4,0.338717892
+male,white,50-59,no hs,CA,1,0,0.338717892
+male,white,50-59,post-grad,CA,8,4,0.338717892
+male,white,50-59,some college,CA,5,1,0.338717892
+male,white,60-69,4-year college,CA,10,3,0.338717892
+male,white,60-69,hs,CA,4,4,0.338717892
+male,white,60-69,post-grad,CA,9,2,0.338717892
+male,white,60-69,some college,CA,6,2,0.338717892
+male,white,70+,4-year college,CA,9,3,0.338717892
+male,white,70+,hs,CA,3,1,0.338717892
+male,white,70+,post-grad,CA,7,4,0.338717892
+male,white,70+,some college,CA,13,11,0.338717892
+female,black,18-29,some college,CO,2,0,0.473166666
+female,black,40-49,4-year college,CO,1,0,0.473166666
+female,black,50-59,4-year college,CO,1,0,0.473166666
+male,black,30-39,hs,CO,1,1,0.473166666
+male,black,50-59,4-year college,CO,1,0,0.473166666
+female,other,30-39,4-year college,CO,2,0,0.473166666
+female,other,30-39,some college,CO,1,0,0.473166666
+female,other,40-49,4-year college,CO,1,1,0.473166666
+female,other,50-59,some college,CO,1,1,0.473166666
+female,other,60-69,hs,CO,1,0,0.473166666
+female,other,60-69,some college,CO,1,1,0.473166666
+female,other,70+,4-year college,CO,1,0,0.473166666
+male,other,18-29,some college,CO,1,0,0.473166666
+male,other,30-39,4-year college,CO,1,1,0.473166666
+male,other,50-59,hs,CO,1,0,0.473166666
+female,white,18-29,4-year college,CO,3,1,0.473166666
+female,white,18-29,post-grad,CO,1,0,0.473166666
+female,white,30-39,4-year college,CO,3,2,0.473166666
+female,white,30-39,hs,CO,1,1,0.473166666
+female,white,30-39,no hs,CO,1,0,0.473166666
+female,white,30-39,post-grad,CO,3,1,0.473166666
+female,white,30-39,some college,CO,2,2,0.473166666
+female,white,40-49,4-year college,CO,1,1,0.473166666
+female,white,40-49,hs,CO,1,0,0.473166666
+female,white,40-49,some college,CO,4,1,0.473166666
+female,white,50-59,4-year college,CO,1,0,0.473166666
+female,white,50-59,hs,CO,1,1,0.473166666
+female,white,50-59,post-grad,CO,2,0,0.473166666
+female,white,50-59,some college,CO,1,0,0.473166666
+female,white,60-69,4-year college,CO,1,1,0.473166666
+female,white,60-69,hs,CO,1,0,0.473166666
+female,white,60-69,post-grad,CO,1,1,0.473166666
+female,white,60-69,some college,CO,2,0,0.473166666
+female,white,70+,hs,CO,2,0,0.473166666
+male,white,30-39,4-year college,CO,1,0,0.473166666
+male,white,30-39,some college,CO,1,0,0.473166666
+male,white,40-49,4-year college,CO,1,0,0.473166666
+male,white,40-49,hs,CO,1,1,0.473166666
+male,white,40-49,some college,CO,1,0,0.473166666
+male,white,50-59,4-year college,CO,3,3,0.473166666
+male,white,50-59,hs,CO,1,1,0.473166666
+male,white,50-59,some college,CO,1,1,0.473166666
+male,white,60-69,4-year college,CO,3,1,0.473166666
+male,white,60-69,hs,CO,1,1,0.473166666
+male,white,60-69,post-grad,CO,2,2,0.473166666
+male,white,60-69,some college,CO,1,0,0.473166666
+male,white,70+,post-grad,CO,2,1,0.473166666
+male,white,70+,some college,CO,1,1,0.473166666
+female,black,18-29,some college,CT,1,0,0.428584525
+female,black,30-39,some college,CT,1,1,0.428584525
+female,black,40-49,post-grad,CT,1,0,0.428584525
+male,black,40-49,hs,CT,1,1,0.428584525
+male,black,50-59,4-year college,CT,1,0,0.428584525
+female,other,18-29,4-year college,CT,1,1,0.428584525
+female,other,18-29,some college,CT,1,0,0.428584525
+female,other,40-49,hs,CT,1,1,0.428584525
+female,other,60-69,hs,CT,1,0,0.428584525
+male,other,30-39,4-year college,CT,1,0,0.428584525
+male,other,30-39,post-grad,CT,1,0,0.428584525
+male,other,50-59,4-year college,CT,1,1,0.428584525
+male,other,50-59,some college,CT,1,0,0.428584525
+female,white,18-29,4-year college,CT,2,0,0.428584525
+female,white,18-29,post-grad,CT,1,0,0.428584525
+female,white,18-29,some college,CT,1,0,0.428584525
+female,white,30-39,4-year college,CT,2,0,0.428584525
+female,white,30-39,hs,CT,2,1,0.428584525
+female,white,30-39,some college,CT,1,1,0.428584525
+female,white,40-49,post-grad,CT,1,0,0.428584525
+female,white,40-49,some college,CT,3,1,0.428584525
+female,white,50-59,4-year college,CT,1,1,0.428584525
+female,white,50-59,hs,CT,1,0,0.428584525
+female,white,50-59,post-grad,CT,2,0,0.428584525
+female,white,50-59,some college,CT,1,1,0.428584525
+female,white,60-69,4-year college,CT,1,1,0.428584525
+female,white,60-69,hs,CT,2,0,0.428584525
+female,white,60-69,no hs,CT,1,1,0.428584525
+female,white,60-69,post-grad,CT,1,0,0.428584525
+female,white,60-69,some college,CT,1,0,0.428584525
+female,white,70+,some college,CT,1,1,0.428584525
+male,white,18-29,4-year college,CT,1,0,0.428584525
+male,white,18-29,hs,CT,1,1,0.428584525
+male,white,30-39,4-year college,CT,1,0,0.428584525
+male,white,30-39,some college,CT,1,1,0.428584525
+male,white,40-49,4-year college,CT,1,0,0.428584525
+male,white,40-49,hs,CT,2,1,0.428584525
+male,white,40-49,post-grad,CT,1,1,0.428584525
+male,white,50-59,4-year college,CT,1,0,0.428584525
+male,white,50-59,post-grad,CT,1,0,0.428584525
+male,white,50-59,some college,CT,1,0,0.428584525
+male,white,60-69,4-year college,CT,1,0,0.428584525
+male,white,60-69,hs,CT,2,1,0.428584525
+male,white,60-69,post-grad,CT,2,1,0.428584525
+male,white,70+,4-year college,CT,1,0,0.428584525
+male,white,70+,post-grad,CT,2,1,0.428584525
+male,white,70+,some college,CT,1,0,0.428584525
+male,black,18-29,some college,DE,1,1,0.440013786
+female,other,40-49,post-grad,DE,1,0,0.440013786
+male,other,50-59,some college,DE,1,0,0.440013786
+female,white,18-29,4-year college,DE,1,1,0.440013786
+female,white,30-39,hs,DE,1,0,0.440013786
+female,white,40-49,hs,DE,1,1,0.440013786
+female,white,50-59,no hs,DE,1,1,0.440013786
+female,white,50-59,post-grad,DE,1,1,0.440013786
+female,white,50-59,some college,DE,2,2,0.440013786
+female,white,70+,hs,DE,2,1,0.440013786
+male,white,40-49,4-year college,DE,1,1,0.440013786
+male,white,40-49,post-grad,DE,1,1,0.440013786
+male,white,40-49,some college,DE,1,1,0.440013786
+male,white,50-59,post-grad,DE,1,0,0.440013786
+male,white,50-59,some college,DE,1,1,0.440013786
+male,white,60-69,4-year college,DE,1,1,0.440013786
+male,white,70+,4-year college,DE,1,1,0.440013786
+male,white,70+,hs,DE,2,0,0.440013786
+female,black,18-29,hs,FL,1,1,0.506188355
+female,black,18-29,no hs,FL,1,0,0.506188355
+female,black,18-29,some college,FL,2,0,0.506188355
+female,black,30-39,post-grad,FL,1,0,0.506188355
+female,black,30-39,some college,FL,4,1,0.506188355
+female,black,40-49,4-year college,FL,1,1,0.506188355
+female,black,40-49,some college,FL,1,1,0.506188355
+female,black,60-69,some college,FL,1,0,0.506188355
+female,black,70+,hs,FL,1,0,0.506188355
+male,black,18-29,hs,FL,2,1,0.506188355
+male,black,18-29,some college,FL,1,0,0.506188355
+male,black,40-49,some college,FL,1,1,0.506188355
+male,black,50-59,4-year college,FL,1,0,0.506188355
+male,black,50-59,some college,FL,1,0,0.506188355
+male,black,60-69,some college,FL,2,0,0.506188355
+male,black,70+,some college,FL,1,0,0.506188355
+female,other,18-29,4-year college,FL,8,3,0.506188355
+female,other,18-29,hs,FL,4,2,0.506188355
+female,other,18-29,no hs,FL,2,1,0.506188355
+female,other,18-29,post-grad,FL,3,0,0.506188355
+female,other,18-29,some college,FL,5,3,0.506188355
+female,other,30-39,4-year college,FL,2,2,0.506188355
+female,other,30-39,no hs,FL,1,0,0.506188355
+female,other,30-39,some college,FL,4,0,0.506188355
+female,other,40-49,4-year college,FL,2,0,0.506188355
+female,other,40-49,hs,FL,1,1,0.506188355
+female,other,40-49,some college,FL,3,1,0.506188355
+female,other,50-59,4-year college,FL,1,0,0.506188355
+female,other,50-59,post-grad,FL,2,0,0.506188355
+female,other,50-59,some college,FL,2,1,0.506188355
+female,other,60-69,4-year college,FL,1,1,0.506188355
+female,other,60-69,hs,FL,1,1,0.506188355
+female,other,60-69,some college,FL,2,1,0.506188355
+female,other,70+,4-year college,FL,1,1,0.506188355
+female,other,70+,post-grad,FL,1,1,0.506188355
+female,other,70+,some college,FL,2,1,0.506188355
+male,other,18-29,4-year college,FL,1,0,0.506188355
+male,other,18-29,hs,FL,2,2,0.506188355
+male,other,18-29,post-grad,FL,1,0,0.506188355
+male,other,18-29,some college,FL,3,1,0.506188355
+male,other,30-39,4-year college,FL,1,0,0.506188355
+male,other,30-39,post-grad,FL,1,0,0.506188355
+male,other,30-39,some college,FL,2,0,0.506188355
+male,other,40-49,4-year college,FL,2,0,0.506188355
+male,other,40-49,hs,FL,1,0,0.506188355
+male,other,40-49,post-grad,FL,1,1,0.506188355
+male,other,40-49,some college,FL,2,1,0.506188355
+male,other,50-59,4-year college,FL,1,1,0.506188355
+male,other,50-59,post-grad,FL,1,1,0.506188355
+male,other,50-59,some college,FL,2,0,0.506188355
+male,other,60-69,4-year college,FL,3,1,0.506188355
+male,other,60-69,hs,FL,1,1,0.506188355
+male,other,60-69,some college,FL,2,2,0.506188355
+male,other,70+,post-grad,FL,1,1,0.506188355
+female,white,18-29,4-year college,FL,5,1,0.506188355
+female,white,18-29,hs,FL,8,3,0.506188355
+female,white,18-29,post-grad,FL,1,0,0.506188355
+female,white,18-29,some college,FL,6,2,0.506188355
+female,white,30-39,4-year college,FL,5,1,0.506188355
+female,white,30-39,hs,FL,2,1,0.506188355
+female,white,30-39,no hs,FL,1,0,0.506188355
+female,white,30-39,post-grad,FL,2,0,0.506188355
+female,white,30-39,some college,FL,3,1,0.506188355
+female,white,40-49,4-year college,FL,7,3,0.506188355
+female,white,40-49,hs,FL,4,2,0.506188355
+female,white,40-49,no hs,FL,2,1,0.506188355
+female,white,40-49,post-grad,FL,2,0,0.506188355
+female,white,40-49,some college,FL,3,0,0.506188355
+female,white,50-59,4-year college,FL,4,3,0.506188355
+female,white,50-59,hs,FL,11,4,0.506188355
+female,white,50-59,post-grad,FL,4,0,0.506188355
+female,white,50-59,some college,FL,12,7,0.506188355
+female,white,60-69,4-year college,FL,2,1,0.506188355
+female,white,60-69,hs,FL,12,7,0.506188355
+female,white,60-69,no hs,FL,1,0,0.506188355
+female,white,60-69,post-grad,FL,2,0,0.506188355
+female,white,60-69,some college,FL,11,6,0.506188355
+female,white,70+,4-year college,FL,7,5,0.506188355
+female,white,70+,hs,FL,10,6,0.506188355
+female,white,70+,no hs,FL,1,0,0.506188355
+female,white,70+,post-grad,FL,4,0,0.506188355
+female,white,70+,some college,FL,1,0,0.506188355
+male,white,18-29,4-year college,FL,4,3,0.506188355
+male,white,18-29,hs,FL,4,2,0.506188355
+male,white,18-29,no hs,FL,1,0,0.506188355
+male,white,18-29,some college,FL,6,3,0.506188355
+male,white,30-39,4-year college,FL,2,0,0.506188355
+male,white,30-39,hs,FL,2,0,0.506188355
+male,white,30-39,post-grad,FL,5,3,0.506188355
+male,white,30-39,some college,FL,6,2,0.506188355
+male,white,40-49,4-year college,FL,2,0,0.506188355
+male,white,40-49,hs,FL,1,1,0.506188355
+male,white,40-49,post-grad,FL,3,2,0.506188355
+male,white,40-49,some college,FL,1,1,0.506188355
+male,white,50-59,4-year college,FL,4,2,0.506188355
+male,white,50-59,hs,FL,6,4,0.506188355
+male,white,50-59,no hs,FL,1,0,0.506188355
+male,white,50-59,post-grad,FL,3,3,0.506188355
+male,white,50-59,some college,FL,5,1,0.506188355
+male,white,60-69,4-year college,FL,4,3,0.506188355
+male,white,60-69,hs,FL,7,3,0.506188355
+male,white,60-69,post-grad,FL,4,3,0.506188355
+male,white,60-69,some college,FL,7,1,0.506188355
+male,white,70+,4-year college,FL,5,4,0.506188355
+male,white,70+,hs,FL,6,5,0.506188355
+male,white,70+,no hs,FL,2,2,0.506188355
+male,white,70+,post-grad,FL,7,3,0.506188355
+male,white,70+,some college,FL,6,4,0.506188355
+female,black,18-29,4-year college,GA,3,3,0.526611726
+female,black,18-29,hs,GA,1,0,0.526611726
+female,black,18-29,post-grad,GA,1,1,0.526611726
+female,black,18-29,some college,GA,3,1,0.526611726
+female,black,30-39,4-year college,GA,1,1,0.526611726
+female,black,30-39,hs,GA,1,1,0.526611726
+female,black,30-39,no hs,GA,1,0,0.526611726
+female,black,30-39,some college,GA,3,2,0.526611726
+female,black,40-49,4-year college,GA,3,0,0.526611726
+female,black,40-49,post-grad,GA,1,0,0.526611726
+female,black,50-59,some college,GA,2,0,0.526611726
+female,black,60-69,4-year college,GA,2,1,0.526611726
+female,black,60-69,post-grad,GA,1,0,0.526611726
+female,black,60-69,some college,GA,2,1,0.526611726
+female,black,70+,4-year college,GA,1,0,0.526611726
+male,black,18-29,4-year college,GA,1,1,0.526611726
+male,black,18-29,some college,GA,2,1,0.526611726
+male,black,30-39,4-year college,GA,1,0,0.526611726
+male,black,30-39,hs,GA,3,2,0.526611726
+male,black,30-39,some college,GA,1,1,0.526611726
+male,black,40-49,4-year college,GA,1,1,0.526611726
+male,black,40-49,hs,GA,1,1,0.526611726
+male,black,40-49,some college,GA,3,0,0.526611726
+male,black,60-69,some college,GA,1,0,0.526611726
+female,other,18-29,4-year college,GA,1,0,0.526611726
+female,other,18-29,hs,GA,2,1,0.526611726
+female,other,30-39,4-year college,GA,3,1,0.526611726
+female,other,30-39,hs,GA,1,1,0.526611726
+female,other,30-39,no hs,GA,1,1,0.526611726
+female,other,30-39,some college,GA,1,1,0.526611726
+female,other,40-49,4-year college,GA,2,0,0.526611726
+male,other,18-29,4-year college,GA,2,0,0.526611726
+male,other,18-29,some college,GA,3,0,0.526611726
+male,other,30-39,4-year college,GA,2,1,0.526611726
+male,other,30-39,no hs,GA,1,1,0.526611726
+male,other,40-49,post-grad,GA,2,1,0.526611726
+male,other,70+,4-year college,GA,1,1,0.526611726
+female,white,18-29,4-year college,GA,2,1,0.526611726
+female,white,18-29,hs,GA,3,2,0.526611726
+female,white,18-29,no hs,GA,3,0,0.526611726
+female,white,18-29,post-grad,GA,1,1,0.526611726
+female,white,18-29,some college,GA,5,0,0.526611726
+female,white,30-39,4-year college,GA,1,0,0.526611726
+female,white,30-39,hs,GA,3,2,0.526611726
+female,white,30-39,no hs,GA,1,0,0.526611726
+female,white,30-39,post-grad,GA,1,0,0.526611726
+female,white,30-39,some college,GA,2,1,0.526611726
+female,white,40-49,4-year college,GA,3,3,0.526611726
+female,white,40-49,hs,GA,1,0,0.526611726
+female,white,40-49,post-grad,GA,1,0,0.526611726
+female,white,40-49,some college,GA,1,1,0.526611726
+female,white,50-59,4-year college,GA,3,2,0.526611726
+female,white,50-59,hs,GA,2,2,0.526611726
+female,white,50-59,post-grad,GA,2,2,0.526611726
+female,white,50-59,some college,GA,2,2,0.526611726
+female,white,60-69,4-year college,GA,3,1,0.526611726
+female,white,60-69,hs,GA,7,5,0.526611726
+female,white,60-69,post-grad,GA,4,3,0.526611726
+female,white,60-69,some college,GA,6,5,0.526611726
+female,white,70+,hs,GA,4,4,0.526611726
+female,white,70+,some college,GA,2,2,0.526611726
+male,white,18-29,4-year college,GA,1,0,0.526611726
+male,white,18-29,hs,GA,1,1,0.526611726
+male,white,18-29,some college,GA,4,3,0.526611726
+male,white,30-39,4-year college,GA,1,1,0.526611726
+male,white,30-39,hs,GA,2,2,0.526611726
+male,white,30-39,some college,GA,1,1,0.526611726
+male,white,40-49,no hs,GA,3,2,0.526611726
+male,white,40-49,post-grad,GA,3,2,0.526611726
+male,white,50-59,4-year college,GA,1,0,0.526611726
+male,white,50-59,hs,GA,1,0,0.526611726
+male,white,50-59,no hs,GA,1,1,0.526611726
+male,white,50-59,post-grad,GA,2,2,0.526611726
+male,white,60-69,4-year college,GA,3,2,0.526611726
+male,white,60-69,hs,GA,4,1,0.526611726
+male,white,60-69,post-grad,GA,2,1,0.526611726
+male,white,60-69,some college,GA,2,2,0.526611726
+male,white,70+,4-year college,GA,2,2,0.526611726
+male,white,70+,hs,GA,1,1,0.526611726
+male,white,70+,post-grad,GA,2,1,0.526611726
+male,white,70+,some college,GA,3,2,0.526611726
+female,other,30-39,4-year college,HI,1,0,0.325586625
+female,other,30-39,some college,HI,1,1,0.325586625
+female,other,40-49,hs,HI,2,0,0.325586625
+male,other,30-39,some college,HI,1,0,0.325586625
+male,other,40-49,4-year college,HI,1,0,0.325586625
+male,other,50-59,hs,HI,1,0,0.325586625
+male,other,70+,4-year college,HI,1,1,0.325586625
+female,white,18-29,some college,HI,1,0,0.325586625
+female,white,30-39,4-year college,HI,1,0,0.325586625
+female,white,50-59,some college,HI,2,2,0.325586625
+female,white,60-69,hs,HI,1,1,0.325586625
+female,white,60-69,some college,HI,1,1,0.325586625
+female,white,70+,4-year college,HI,1,1,0.325586625
+female,white,70+,hs,HI,1,1,0.325586625
+female,white,70+,some college,HI,1,0,0.325586625
+male,white,50-59,some college,HI,1,0,0.325586625
+male,white,60-69,post-grad,HI,2,1,0.325586625
+male,white,70+,post-grad,HI,2,1,0.325586625
+male,white,70+,some college,HI,1,1,0.325586625
+female,other,50-59,hs,IA,1,1,0.550635478
+female,other,50-59,no hs,IA,1,1,0.550635478
+female,white,18-29,4-year college,IA,2,1,0.550635478
+female,white,18-29,hs,IA,1,1,0.550635478
+female,white,18-29,post-grad,IA,1,0,0.550635478
+female,white,30-39,4-year college,IA,2,0,0.550635478
+female,white,30-39,post-grad,IA,1,0,0.550635478
+female,white,40-49,hs,IA,3,0,0.550635478
+female,white,40-49,post-grad,IA,2,1,0.550635478
+female,white,40-49,some college,IA,3,3,0.550635478
+female,white,50-59,hs,IA,2,1,0.550635478
+female,white,50-59,no hs,IA,1,0,0.550635478
+female,white,60-69,hs,IA,4,1,0.550635478
+female,white,60-69,some college,IA,1,0,0.550635478
+female,white,70+,4-year college,IA,1,1,0.550635478
+female,white,70+,no hs,IA,1,1,0.550635478
+female,white,70+,some college,IA,1,0,0.550635478
+male,white,18-29,4-year college,IA,1,0,0.550635478
+male,white,18-29,no hs,IA,1,0,0.550635478
+male,white,18-29,some college,IA,1,1,0.550635478
+male,white,30-39,hs,IA,1,1,0.550635478
+male,white,40-49,hs,IA,1,0,0.550635478
+male,white,50-59,4-year college,IA,1,0,0.550635478
+male,white,60-69,hs,IA,1,0,0.550635478
+male,white,60-69,some college,IA,2,0,0.550635478
+male,white,70+,4-year college,IA,1,1,0.550635478
+male,white,70+,hs,IA,1,0,0.550635478
+male,white,70+,post-grad,IA,2,0,0.550635478
+male,white,70+,some college,IA,1,1,0.550635478
+female,black,60-69,4-year college,ID,1,0,0.683101767
+female,other,18-29,hs,ID,1,0,0.683101767
+male,other,30-39,hs,ID,1,1,0.683101767
+female,white,18-29,4-year college,ID,1,0,0.683101767
+female,white,18-29,no hs,ID,1,1,0.683101767
+female,white,18-29,some college,ID,2,1,0.683101767
+female,white,40-49,post-grad,ID,1,1,0.683101767
+female,white,50-59,hs,ID,2,0,0.683101767
+female,white,50-59,some college,ID,1,1,0.683101767
+female,white,60-69,hs,ID,1,1,0.683101767
+female,white,70+,4-year college,ID,2,1,0.683101767
+female,white,70+,hs,ID,2,1,0.683101767
+male,white,30-39,some college,ID,1,1,0.683101767
+male,white,40-49,4-year college,ID,1,1,0.683101767
+male,white,40-49,hs,ID,1,1,0.683101767
+male,white,40-49,some college,ID,1,1,0.683101767
+male,white,50-59,4-year college,ID,1,0,0.683101767
+male,white,50-59,hs,ID,3,1,0.683101767
+male,white,60-69,hs,ID,1,0,0.683101767
+male,white,70+,4-year college,ID,1,1,0.683101767
+male,white,70+,post-grad,ID,2,1,0.683101767
+male,white,70+,some college,ID,2,2,0.683101767
+female,black,18-29,no hs,IL,1,0,0.409799486
+female,black,18-29,post-grad,IL,1,0,0.409799486
+female,black,18-29,some college,IL,2,1,0.409799486
+female,black,30-39,4-year college,IL,1,0,0.409799486
+female,black,30-39,some college,IL,3,1,0.409799486
+female,black,40-49,hs,IL,1,1,0.409799486
+female,black,40-49,some college,IL,1,0,0.409799486
+female,black,50-59,hs,IL,2,0,0.409799486
+female,black,50-59,post-grad,IL,3,0,0.409799486
+female,black,50-59,some college,IL,2,0,0.409799486
+female,black,70+,no hs,IL,1,0,0.409799486
+male,black,18-29,some college,IL,1,1,0.409799486
+male,black,30-39,4-year college,IL,3,0,0.409799486
+male,black,40-49,hs,IL,1,1,0.409799486
+male,black,60-69,hs,IL,1,0,0.409799486
+female,other,18-29,4-year college,IL,1,1,0.409799486
+female,other,18-29,no hs,IL,1,1,0.409799486
+female,other,18-29,post-grad,IL,2,1,0.409799486
+female,other,18-29,some college,IL,2,1,0.409799486
+female,other,30-39,4-year college,IL,1,0,0.409799486
+female,other,30-39,hs,IL,1,0,0.409799486
+female,other,30-39,no hs,IL,1,0,0.409799486
+female,other,30-39,some college,IL,1,0,0.409799486
+female,other,40-49,4-year college,IL,1,0,0.409799486
+female,other,40-49,some college,IL,1,0,0.409799486
+female,other,70+,hs,IL,1,1,0.409799486
+male,other,18-29,post-grad,IL,1,1,0.409799486
+male,other,18-29,some college,IL,1,1,0.409799486
+male,other,30-39,4-year college,IL,1,0,0.409799486
+male,other,30-39,post-grad,IL,1,0,0.409799486
+male,other,30-39,some college,IL,1,1,0.409799486
+male,other,40-49,4-year college,IL,1,1,0.409799486
+male,other,40-49,some college,IL,1,1,0.409799486
+male,other,50-59,post-grad,IL,1,0,0.409799486
+female,white,18-29,4-year college,IL,10,2,0.409799486
+female,white,18-29,hs,IL,1,1,0.409799486
+female,white,18-29,no hs,IL,1,0,0.409799486
+female,white,18-29,some college,IL,3,3,0.409799486
+female,white,30-39,4-year college,IL,5,0,0.409799486
+female,white,30-39,hs,IL,5,2,0.409799486
+female,white,30-39,post-grad,IL,2,0,0.409799486
+female,white,30-39,some college,IL,5,1,0.409799486
+female,white,40-49,4-year college,IL,4,2,0.409799486
+female,white,40-49,hs,IL,5,2,0.409799486
+female,white,40-49,post-grad,IL,4,1,0.409799486
+female,white,40-49,some college,IL,3,2,0.409799486
+female,white,50-59,4-year college,IL,2,1,0.409799486
+female,white,50-59,hs,IL,6,1,0.409799486
+female,white,50-59,no hs,IL,1,1,0.409799486
+female,white,50-59,post-grad,IL,3,1,0.409799486
+female,white,50-59,some college,IL,1,1,0.409799486
+female,white,60-69,4-year college,IL,1,1,0.409799486
+female,white,60-69,hs,IL,7,3,0.409799486
+female,white,60-69,no hs,IL,1,1,0.409799486
+female,white,60-69,post-grad,IL,2,0,0.409799486
+female,white,60-69,some college,IL,2,0,0.409799486
+female,white,70+,hs,IL,3,1,0.409799486
+female,white,70+,no hs,IL,1,1,0.409799486
+female,white,70+,some college,IL,3,1,0.409799486
+male,white,18-29,4-year college,IL,1,1,0.409799486
+male,white,18-29,hs,IL,2,2,0.409799486
+male,white,18-29,some college,IL,3,1,0.409799486
+male,white,30-39,4-year college,IL,5,1,0.409799486
+male,white,30-39,hs,IL,3,2,0.409799486
+male,white,30-39,post-grad,IL,1,0,0.409799486
+male,white,30-39,some college,IL,1,0,0.409799486
+male,white,40-49,4-year college,IL,1,0,0.409799486
+male,white,40-49,hs,IL,5,2,0.409799486
+male,white,40-49,post-grad,IL,1,0,0.409799486
+male,white,40-49,some college,IL,4,2,0.409799486
+male,white,50-59,4-year college,IL,4,2,0.409799486
+male,white,50-59,hs,IL,1,1,0.409799486
+male,white,50-59,post-grad,IL,1,1,0.409799486
+male,white,50-59,some college,IL,3,3,0.409799486
+male,white,60-69,4-year college,IL,1,1,0.409799486
+male,white,60-69,hs,IL,6,2,0.409799486
+male,white,60-69,no hs,IL,1,0,0.409799486
+male,white,60-69,some college,IL,8,4,0.409799486
+male,white,70+,4-year college,IL,3,2,0.409799486
+male,white,70+,post-grad,IL,3,2,0.409799486
+female,black,30-39,post-grad,IN,1,0,0.601173095
+female,black,30-39,some college,IN,3,0,0.601173095
+female,black,40-49,post-grad,IN,1,0,0.601173095
+female,black,40-49,some college,IN,1,1,0.601173095
+female,black,50-59,hs,IN,1,0,0.601173095
+female,black,50-59,some college,IN,1,0,0.601173095
+female,black,60-69,some college,IN,2,0,0.601173095
+male,black,30-39,hs,IN,1,0,0.601173095
+male,black,40-49,4-year college,IN,1,1,0.601173095
+male,black,50-59,hs,IN,1,1,0.601173095
+female,other,18-29,hs,IN,1,0,0.601173095
+female,other,18-29,some college,IN,2,1,0.601173095
+female,other,30-39,4-year college,IN,1,1,0.601173095
+female,other,30-39,hs,IN,1,1,0.601173095
+male,other,18-29,hs,IN,1,0,0.601173095
+male,other,50-59,some college,IN,1,1,0.601173095
+male,other,60-69,some college,IN,1,0,0.601173095
+male,other,70+,4-year college,IN,1,1,0.601173095
+female,white,18-29,4-year college,IN,2,1,0.601173095
+female,white,18-29,hs,IN,4,2,0.601173095
+female,white,18-29,post-grad,IN,1,1,0.601173095
+female,white,18-29,some college,IN,6,4,0.601173095
+female,white,30-39,4-year college,IN,4,4,0.601173095
+female,white,30-39,hs,IN,2,1,0.601173095
+female,white,30-39,no hs,IN,1,1,0.601173095
+female,white,30-39,post-grad,IN,1,0,0.601173095
+female,white,30-39,some college,IN,2,1,0.601173095
+female,white,40-49,4-year college,IN,1,0,0.601173095
+female,white,40-49,hs,IN,2,2,0.601173095
+female,white,40-49,no hs,IN,1,0,0.601173095
+female,white,40-49,post-grad,IN,1,1,0.601173095
+female,white,40-49,some college,IN,3,1,0.601173095
+female,white,50-59,4-year college,IN,1,0,0.601173095
+female,white,50-59,hs,IN,4,0,0.601173095
+female,white,50-59,no hs,IN,1,0,0.601173095
+female,white,50-59,post-grad,IN,1,0,0.601173095
+female,white,50-59,some college,IN,2,0,0.601173095
+female,white,60-69,4-year college,IN,1,1,0.601173095
+female,white,60-69,hs,IN,7,3,0.601173095
+female,white,60-69,post-grad,IN,2,2,0.601173095
+female,white,70+,4-year college,IN,1,1,0.601173095
+female,white,70+,hs,IN,3,0,0.601173095
+female,white,70+,no hs,IN,1,1,0.601173095
+female,white,70+,post-grad,IN,1,1,0.601173095
+male,white,18-29,hs,IN,3,2,0.601173095
+male,white,18-29,no hs,IN,1,1,0.601173095
+male,white,18-29,post-grad,IN,1,0,0.601173095
+male,white,18-29,some college,IN,2,1,0.601173095
+male,white,30-39,4-year college,IN,3,1,0.601173095
+male,white,30-39,hs,IN,1,1,0.601173095
+male,white,30-39,post-grad,IN,1,0,0.601173095
+male,white,30-39,some college,IN,6,3,0.601173095
+male,white,40-49,4-year college,IN,1,0,0.601173095
+male,white,40-49,hs,IN,2,1,0.601173095
+male,white,40-49,post-grad,IN,3,1,0.601173095
+male,white,40-49,some college,IN,2,0,0.601173095
+male,white,50-59,4-year college,IN,4,1,0.601173095
+male,white,50-59,hs,IN,1,1,0.601173095
+male,white,50-59,post-grad,IN,1,0,0.601173095
+male,white,50-59,some college,IN,1,0,0.601173095
+male,white,60-69,4-year college,IN,2,2,0.601173095
+male,white,60-69,hs,IN,3,2,0.601173095
+male,white,60-69,post-grad,IN,1,1,0.601173095
+male,white,60-69,some college,IN,3,3,0.601173095
+male,white,70+,hs,IN,2,1,0.601173095
+male,white,70+,post-grad,IN,2,2,0.601173095
+male,white,70+,some college,IN,6,2,0.601173095
+female,black,30-39,no hs,KS,1,1,0.611114703
+female,black,30-39,some college,KS,1,1,0.611114703
+female,black,40-49,4-year college,KS,1,0,0.611114703
+female,black,60-69,some college,KS,1,0,0.611114703
+female,other,30-39,post-grad,KS,1,0,0.611114703
+female,other,50-59,post-grad,KS,1,0,0.611114703
+female,white,18-29,4-year college,KS,2,2,0.611114703
+female,white,18-29,no hs,KS,1,0,0.611114703
+female,white,30-39,hs,KS,1,1,0.611114703
+female,white,30-39,post-grad,KS,1,0,0.611114703
+female,white,40-49,hs,KS,1,1,0.611114703
+female,white,40-49,post-grad,KS,1,1,0.611114703
+female,white,40-49,some college,KS,1,0,0.611114703
+female,white,50-59,hs,KS,1,0,0.611114703
+female,white,60-69,4-year college,KS,1,1,0.611114703
+female,white,60-69,hs,KS,1,0,0.611114703
+female,white,60-69,post-grad,KS,3,1,0.611114703
+female,white,70+,hs,KS,2,0,0.611114703
+female,white,70+,some college,KS,2,2,0.611114703
+male,white,18-29,4-year college,KS,1,1,0.611114703
+male,white,18-29,some college,KS,1,1,0.611114703
+male,white,30-39,4-year college,KS,1,0,0.611114703
+male,white,30-39,hs,KS,2,0,0.611114703
+male,white,40-49,hs,KS,1,0,0.611114703
+male,white,40-49,some college,KS,1,0,0.611114703
+male,white,50-59,4-year college,KS,2,1,0.611114703
+male,white,50-59,hs,KS,1,0,0.611114703
+male,white,50-59,post-grad,KS,1,0,0.611114703
+male,white,50-59,some college,KS,1,0,0.611114703
+male,white,60-69,4-year college,KS,1,1,0.611114703
+male,white,60-69,some college,KS,2,0,0.611114703
+male,white,70+,4-year college,KS,1,0,0.611114703
+male,white,70+,some college,KS,3,3,0.611114703
+female,black,60-69,hs,KY,1,0,0.65670629
+male,black,60-69,hs,KY,1,0,0.65670629
+female,other,18-29,hs,KY,1,0,0.65670629
+female,other,30-39,4-year college,KY,1,0,0.65670629
+female,other,30-39,some college,KY,1,1,0.65670629
+female,other,40-49,4-year college,KY,1,1,0.65670629
+female,other,50-59,some college,KY,1,1,0.65670629
+female,other,70+,post-grad,KY,1,1,0.65670629
+male,other,30-39,4-year college,KY,2,0,0.65670629
+female,white,18-29,4-year college,KY,2,0,0.65670629
+female,white,18-29,hs,KY,4,2,0.65670629
+female,white,18-29,post-grad,KY,1,0,0.65670629
+female,white,30-39,4-year college,KY,1,1,0.65670629
+female,white,30-39,hs,KY,1,1,0.65670629
+female,white,30-39,post-grad,KY,1,0,0.65670629
+female,white,30-39,some college,KY,2,2,0.65670629
+female,white,40-49,4-year college,KY,2,0,0.65670629
+female,white,40-49,hs,KY,1,0,0.65670629
+female,white,40-49,no hs,KY,1,0,0.65670629
+female,white,40-49,some college,KY,1,1,0.65670629
+female,white,50-59,hs,KY,1,0,0.65670629
+female,white,50-59,no hs,KY,1,1,0.65670629
+female,white,50-59,some college,KY,4,2,0.65670629
+female,white,60-69,hs,KY,6,2,0.65670629
+female,white,60-69,no hs,KY,1,0,0.65670629
+female,white,60-69,post-grad,KY,1,0,0.65670629
+female,white,60-69,some college,KY,4,4,0.65670629
+female,white,70+,hs,KY,1,1,0.65670629
+female,white,70+,no hs,KY,1,1,0.65670629
+female,white,70+,some college,KY,1,1,0.65670629
+male,white,18-29,hs,KY,2,0,0.65670629
+male,white,18-29,post-grad,KY,1,0,0.65670629
+male,white,18-29,some college,KY,3,1,0.65670629
+male,white,30-39,4-year college,KY,1,0,0.65670629
+male,white,30-39,hs,KY,1,0,0.65670629
+male,white,30-39,post-grad,KY,2,1,0.65670629
+male,white,30-39,some college,KY,3,1,0.65670629
+male,white,40-49,4-year college,KY,1,1,0.65670629
+male,white,40-49,hs,KY,1,0,0.65670629
+male,white,40-49,post-grad,KY,1,0,0.65670629
+male,white,40-49,some college,KY,2,1,0.65670629
+male,white,50-59,4-year college,KY,3,2,0.65670629
+male,white,50-59,hs,KY,3,2,0.65670629
+male,white,50-59,no hs,KY,1,0,0.65670629
+male,white,50-59,post-grad,KY,1,0,0.65670629
+male,white,50-59,some college,KY,1,0,0.65670629
+male,white,60-69,hs,KY,3,2,0.65670629
+male,white,60-69,no hs,KY,1,1,0.65670629
+male,white,60-69,post-grad,KY,1,0,0.65670629
+male,white,60-69,some college,KY,2,1,0.65670629
+male,white,70+,4-year college,KY,1,0,0.65670629
+male,white,70+,hs,KY,1,1,0.65670629
+male,white,70+,some college,KY,1,1,0.65670629
+female,black,18-29,hs,LA,1,0,0.601716772
+female,black,18-29,some college,LA,1,0,0.601716772
+female,black,30-39,hs,LA,2,1,0.601716772
+female,black,30-39,some college,LA,2,2,0.601716772
+female,black,40-49,4-year college,LA,1,0,0.601716772
+female,black,60-69,4-year college,LA,1,0,0.601716772
+male,black,18-29,hs,LA,1,1,0.601716772
+male,black,18-29,some college,LA,1,0,0.601716772
+male,black,30-39,hs,LA,1,0,0.601716772
+male,black,50-59,4-year college,LA,1,0,0.601716772
+male,black,60-69,some college,LA,1,1,0.601716772
+female,other,18-29,some college,LA,1,1,0.601716772
+female,other,30-39,some college,LA,1,0,0.601716772
+male,other,18-29,no hs,LA,1,1,0.601716772
+male,other,30-39,4-year college,LA,1,0,0.601716772
+male,other,50-59,post-grad,LA,1,1,0.601716772
+male,other,70+,post-grad,LA,1,1,0.601716772
+female,white,18-29,4-year college,LA,1,1,0.601716772
+female,white,18-29,post-grad,LA,1,1,0.601716772
+female,white,18-29,some college,LA,4,1,0.601716772
+female,white,30-39,4-year college,LA,2,1,0.601716772
+female,white,30-39,post-grad,LA,2,1,0.601716772
+female,white,30-39,some college,LA,1,1,0.601716772
+female,white,40-49,hs,LA,5,3,0.601716772
+female,white,50-59,4-year college,LA,1,1,0.601716772
+female,white,50-59,hs,LA,2,1,0.601716772
+female,white,50-59,some college,LA,3,1,0.601716772
+female,white,60-69,hs,LA,3,3,0.601716772
+female,white,60-69,some college,LA,1,1,0.601716772
+female,white,70+,some college,LA,2,2,0.601716772
+male,white,18-29,hs,LA,2,1,0.601716772
+male,white,18-29,no hs,LA,2,1,0.601716772
+male,white,18-29,some college,LA,1,1,0.601716772
+male,white,30-39,some college,LA,1,0,0.601716772
+male,white,50-59,some college,LA,1,1,0.601716772
+male,white,60-69,some college,LA,3,2,0.601716772
+male,white,70+,post-grad,LA,1,0,0.601716772
+female,black,18-29,hs,MA,1,1,0.353487213
+female,black,18-29,some college,MA,1,0,0.353487213
+female,black,30-39,post-grad,MA,1,0,0.353487213
+male,black,18-29,4-year college,MA,1,1,0.353487213
+female,other,18-29,no hs,MA,1,0,0.353487213
+female,other,18-29,post-grad,MA,1,1,0.353487213
+female,other,18-29,some college,MA,2,1,0.353487213
+female,other,30-39,4-year college,MA,1,1,0.353487213
+female,other,30-39,hs,MA,1,0,0.353487213
+female,other,30-39,post-grad,MA,1,0,0.353487213
+female,other,30-39,some college,MA,1,0,0.353487213
+female,other,40-49,4-year college,MA,1,0,0.353487213
+female,other,40-49,post-grad,MA,1,0,0.353487213
+male,other,40-49,no hs,MA,1,0,0.353487213
+male,other,40-49,some college,MA,1,0,0.353487213
+male,other,50-59,4-year college,MA,1,0,0.353487213
+female,white,18-29,4-year college,MA,3,0,0.353487213
+female,white,18-29,hs,MA,1,0,0.353487213
+female,white,18-29,no hs,MA,1,1,0.353487213
+female,white,18-29,post-grad,MA,1,0,0.353487213
+female,white,18-29,some college,MA,4,0,0.353487213
+female,white,30-39,4-year college,MA,1,0,0.353487213
+female,white,30-39,hs,MA,1,0,0.353487213
+female,white,30-39,post-grad,MA,2,1,0.353487213
+female,white,30-39,some college,MA,3,1,0.353487213
+female,white,40-49,4-year college,MA,1,0,0.353487213
+female,white,40-49,hs,MA,4,0,0.353487213
+female,white,40-49,some college,MA,2,1,0.353487213
+female,white,50-59,4-year college,MA,1,0,0.353487213
+female,white,50-59,hs,MA,6,2,0.353487213
+female,white,50-59,some college,MA,1,0,0.353487213
+female,white,60-69,4-year college,MA,4,0,0.353487213
+female,white,60-69,hs,MA,7,1,0.353487213
+female,white,60-69,post-grad,MA,2,0,0.353487213
+female,white,60-69,some college,MA,2,0,0.353487213
+female,white,70+,4-year college,MA,1,0,0.353487213
+female,white,70+,hs,MA,1,1,0.353487213
+female,white,70+,no hs,MA,1,1,0.353487213
+female,white,70+,post-grad,MA,3,0,0.353487213
+female,white,70+,some college,MA,1,0,0.353487213
+male,white,18-29,4-year college,MA,1,0,0.353487213
+male,white,18-29,post-grad,MA,1,1,0.353487213
+male,white,30-39,4-year college,MA,1,0,0.353487213
+male,white,30-39,post-grad,MA,3,1,0.353487213
+male,white,40-49,4-year college,MA,1,1,0.353487213
+male,white,40-49,hs,MA,4,0,0.353487213
+male,white,40-49,post-grad,MA,1,0,0.353487213
+male,white,40-49,some college,MA,1,0,0.353487213
+male,white,50-59,4-year college,MA,2,1,0.353487213
+male,white,50-59,hs,MA,1,1,0.353487213
+male,white,50-59,post-grad,MA,1,0,0.353487213
+male,white,50-59,some college,MA,1,1,0.353487213
+male,white,60-69,hs,MA,2,1,0.353487213
+male,white,60-69,post-grad,MA,2,2,0.353487213
+male,white,70+,4-year college,MA,2,1,0.353487213
+male,white,70+,post-grad,MA,1,0,0.353487213
+male,white,70+,some college,MA,2,1,0.353487213
+female,black,18-29,post-grad,MD,1,0,0.359837503
+female,black,30-39,4-year college,MD,1,0,0.359837503
+female,black,30-39,no hs,MD,1,0,0.359837503
+female,black,30-39,post-grad,MD,1,0,0.359837503
+female,black,40-49,4-year college,MD,4,1,0.359837503
+female,black,40-49,hs,MD,1,1,0.359837503
+female,black,40-49,post-grad,MD,1,0,0.359837503
+female,black,40-49,some college,MD,2,1,0.359837503
+female,black,50-59,4-year college,MD,1,1,0.359837503
+female,black,50-59,no hs,MD,1,1,0.359837503
+female,black,50-59,some college,MD,3,1,0.359837503
+female,black,60-69,some college,MD,1,0,0.359837503
+male,black,18-29,4-year college,MD,1,0,0.359837503
+male,black,30-39,4-year college,MD,1,1,0.359837503
+male,black,30-39,some college,MD,1,0,0.359837503
+male,black,70+,post-grad,MD,1,0,0.359837503
+female,other,30-39,post-grad,MD,1,0,0.359837503
+male,other,40-49,4-year college,MD,1,1,0.359837503
+male,other,50-59,some college,MD,1,1,0.359837503
+male,other,60-69,4-year college,MD,1,0,0.359837503
+female,white,18-29,4-year college,MD,1,0,0.359837503
+female,white,18-29,hs,MD,2,0,0.359837503
+female,white,18-29,some college,MD,1,0,0.359837503
+female,white,30-39,4-year college,MD,2,1,0.359837503
+female,white,30-39,hs,MD,1,0,0.359837503
+female,white,30-39,post-grad,MD,2,0,0.359837503
+female,white,30-39,some college,MD,1,0,0.359837503
+female,white,40-49,4-year college,MD,1,0,0.359837503
+female,white,40-49,some college,MD,1,0,0.359837503
+female,white,50-59,hs,MD,3,0,0.359837503
+female,white,50-59,post-grad,MD,3,1,0.359837503
+female,white,50-59,some college,MD,2,2,0.359837503
+female,white,60-69,4-year college,MD,3,1,0.359837503
+female,white,60-69,hs,MD,1,1,0.359837503
+female,white,60-69,no hs,MD,1,1,0.359837503
+female,white,60-69,post-grad,MD,3,3,0.359837503
+female,white,70+,4-year college,MD,1,0,0.359837503
+female,white,70+,hs,MD,2,1,0.359837503
+female,white,70+,post-grad,MD,2,1,0.359837503
+female,white,70+,some college,MD,1,0,0.359837503
+male,white,18-29,4-year college,MD,1,0,0.359837503
+male,white,18-29,hs,MD,2,2,0.359837503
+male,white,18-29,post-grad,MD,1,0,0.359837503
+male,white,18-29,some college,MD,1,0,0.359837503
+male,white,30-39,4-year college,MD,4,3,0.359837503
+male,white,30-39,post-grad,MD,3,1,0.359837503
+male,white,30-39,some college,MD,1,0,0.359837503
+male,white,40-49,4-year college,MD,1,1,0.359837503
+male,white,40-49,post-grad,MD,1,0,0.359837503
+male,white,40-49,some college,MD,2,1,0.359837503
+male,white,50-59,4-year college,MD,5,2,0.359837503
+male,white,50-59,hs,MD,2,1,0.359837503
+male,white,50-59,some college,MD,1,0,0.359837503
+male,white,60-69,4-year college,MD,1,0,0.359837503
+male,white,60-69,hs,MD,1,0,0.359837503
+male,white,60-69,post-grad,MD,4,2,0.359837503
+male,white,60-69,some college,MD,1,1,0.359837503
+male,white,70+,4-year college,MD,1,1,0.359837503
+male,white,70+,hs,MD,3,1,0.359837503
+male,white,70+,no hs,MD,1,1,0.359837503
+male,white,70+,some college,MD,2,2,0.359837503
+female,white,18-29,4-year college,ME,2,0,0.484032089
+female,white,18-29,hs,ME,4,1,0.484032089
+female,white,30-39,some college,ME,1,0,0.484032089
+female,white,40-49,no hs,ME,1,0,0.484032089
+female,white,50-59,hs,ME,2,0,0.484032089
+female,white,50-59,some college,ME,2,1,0.484032089
+female,white,60-69,hs,ME,1,0,0.484032089
+female,white,60-69,some college,ME,1,1,0.484032089
+female,white,70+,post-grad,ME,1,0,0.484032089
+male,white,40-49,4-year college,ME,1,0,0.484032089
+male,white,40-49,some college,ME,1,0,0.484032089
+male,white,70+,some college,ME,1,0,0.484032089
+female,black,18-29,some college,MI,2,0,0.501176682
+female,black,30-39,hs,MI,1,0,0.501176682
+female,black,40-49,4-year college,MI,1,0,0.501176682
+female,black,40-49,some college,MI,1,1,0.501176682
+female,black,50-59,4-year college,MI,1,0,0.501176682
+female,black,60-69,4-year college,MI,1,1,0.501176682
+female,black,60-69,hs,MI,1,0,0.501176682
+female,black,60-69,some college,MI,1,1,0.501176682
+female,black,70+,4-year college,MI,1,1,0.501176682
+female,black,70+,some college,MI,1,0,0.501176682
+male,black,18-29,no hs,MI,1,0,0.501176682
+male,black,60-69,4-year college,MI,1,0,0.501176682
+male,black,60-69,some college,MI,1,1,0.501176682
+female,other,18-29,4-year college,MI,1,0,0.501176682
+female,other,18-29,hs,MI,2,0,0.501176682
+female,other,18-29,some college,MI,1,0,0.501176682
+female,other,30-39,hs,MI,1,1,0.501176682
+female,other,30-39,some college,MI,1,0,0.501176682
+female,other,50-59,some college,MI,1,1,0.501176682
+male,other,18-29,4-year college,MI,1,0,0.501176682
+male,other,18-29,hs,MI,1,1,0.501176682
+male,other,18-29,post-grad,MI,1,0,0.501176682
+male,other,18-29,some college,MI,2,0,0.501176682
+male,other,40-49,some college,MI,1,0,0.501176682
+female,white,18-29,4-year college,MI,4,3,0.501176682
+female,white,18-29,hs,MI,6,0,0.501176682
+female,white,18-29,post-grad,MI,1,0,0.501176682
+female,white,18-29,some college,MI,6,1,0.501176682
+female,white,30-39,4-year college,MI,3,1,0.501176682
+female,white,30-39,hs,MI,2,0,0.501176682
+female,white,30-39,post-grad,MI,2,0,0.501176682
+female,white,30-39,some college,MI,6,2,0.501176682
+female,white,40-49,4-year college,MI,2,1,0.501176682
+female,white,40-49,hs,MI,1,0,0.501176682
+female,white,40-49,no hs,MI,2,0,0.501176682
+female,white,40-49,post-grad,MI,1,0,0.501176682
+female,white,40-49,some college,MI,4,3,0.501176682
+female,white,50-59,4-year college,MI,3,1,0.501176682
+female,white,50-59,no hs,MI,1,1,0.501176682
+female,white,50-59,post-grad,MI,1,1,0.501176682
+female,white,50-59,some college,MI,3,1,0.501176682
+female,white,60-69,4-year college,MI,7,3,0.501176682
+female,white,60-69,hs,MI,4,2,0.501176682
+female,white,60-69,no hs,MI,1,0,0.501176682
+female,white,60-69,post-grad,MI,1,0,0.501176682
+female,white,60-69,some college,MI,4,0,0.501176682
+female,white,70+,4-year college,MI,1,0,0.501176682
+female,white,70+,hs,MI,3,3,0.501176682
+female,white,70+,post-grad,MI,1,0,0.501176682
+female,white,70+,some college,MI,1,1,0.501176682
+male,white,18-29,4-year college,MI,1,1,0.501176682
+male,white,18-29,hs,MI,5,1,0.501176682
+male,white,18-29,some college,MI,1,0,0.501176682
+male,white,30-39,4-year college,MI,5,1,0.501176682
+male,white,30-39,post-grad,MI,5,1,0.501176682
+male,white,30-39,some college,MI,1,0,0.501176682
+male,white,40-49,4-year college,MI,2,1,0.501176682
+male,white,40-49,hs,MI,1,1,0.501176682
+male,white,40-49,some college,MI,2,0,0.501176682
+male,white,50-59,4-year college,MI,4,2,0.501176682
+male,white,50-59,hs,MI,1,0,0.501176682
+male,white,50-59,some college,MI,7,5,0.501176682
+male,white,60-69,4-year college,MI,3,3,0.501176682
+male,white,60-69,hs,MI,5,2,0.501176682
+male,white,60-69,post-grad,MI,2,0,0.501176682
+male,white,60-69,some college,MI,1,0,0.501176682
+male,white,70+,4-year college,MI,2,0,0.501176682
+male,white,70+,hs,MI,3,2,0.501176682
+male,white,70+,post-grad,MI,3,1,0.501176682
+male,white,70+,some college,MI,2,2,0.501176682
+female,black,18-29,4-year college,MN,1,0,0.491681431
+female,black,50-59,some college,MN,1,0,0.491681431
+female,other,18-29,some college,MN,2,0,0.491681431
+female,other,30-39,hs,MN,2,1,0.491681431
+female,other,30-39,post-grad,MN,1,0,0.491681431
+female,other,50-59,post-grad,MN,1,0,0.491681431
+male,other,18-29,some college,MN,1,0,0.491681431
+male,other,30-39,some college,MN,1,1,0.491681431
+male,other,40-49,4-year college,MN,1,1,0.491681431
+male,other,70+,some college,MN,1,1,0.491681431
+female,white,18-29,4-year college,MN,3,2,0.491681431
+female,white,18-29,hs,MN,1,0,0.491681431
+female,white,18-29,some college,MN,4,0,0.491681431
+female,white,30-39,post-grad,MN,1,1,0.491681431
+female,white,30-39,some college,MN,1,0,0.491681431
+female,white,40-49,4-year college,MN,1,1,0.491681431
+female,white,40-49,post-grad,MN,1,0,0.491681431
+female,white,40-49,some college,MN,2,2,0.491681431
+female,white,50-59,4-year college,MN,1,0,0.491681431
+female,white,50-59,hs,MN,3,1,0.491681431
+female,white,50-59,some college,MN,1,0,0.491681431
+female,white,60-69,hs,MN,4,2,0.491681431
+female,white,60-69,post-grad,MN,1,0,0.491681431
+female,white,60-69,some college,MN,1,0,0.491681431
+female,white,70+,hs,MN,2,1,0.491681431
+female,white,70+,post-grad,MN,1,1,0.491681431
+female,white,70+,some college,MN,1,1,0.491681431
+male,white,18-29,4-year college,MN,1,0,0.491681431
+male,white,18-29,hs,MN,1,1,0.491681431
+male,white,30-39,4-year college,MN,4,1,0.491681431
+male,white,30-39,post-grad,MN,2,1,0.491681431
+male,white,30-39,some college,MN,3,0,0.491681431
+male,white,40-49,4-year college,MN,2,2,0.491681431
+male,white,40-49,hs,MN,2,2,0.491681431
+male,white,40-49,some college,MN,1,1,0.491681431
+male,white,50-59,4-year college,MN,1,0,0.491681431
+male,white,50-59,hs,MN,1,0,0.491681431
+male,white,50-59,some college,MN,3,3,0.491681431
+male,white,60-69,hs,MN,1,0,0.491681431
+male,white,60-69,post-grad,MN,1,1,0.491681431
+male,white,70+,4-year college,MN,1,0,0.491681431
+male,white,70+,post-grad,MN,2,1,0.491681431
+male,white,70+,some college,MN,1,0,0.491681431
+female,black,30-39,4-year college,MO,1,0,0.59818561
+female,black,30-39,no hs,MO,1,0,0.59818561
+female,black,40-49,4-year college,MO,1,0,0.59818561
+female,black,50-59,hs,MO,1,1,0.59818561
+male,black,18-29,some college,MO,1,0,0.59818561
+male,black,50-59,4-year college,MO,1,0,0.59818561
+male,black,50-59,some college,MO,1,0,0.59818561
+female,other,30-39,4-year college,MO,1,1,0.59818561
+female,other,30-39,some college,MO,1,0,0.59818561
+male,other,18-29,hs,MO,2,1,0.59818561
+male,other,18-29,some college,MO,1,0,0.59818561
+male,other,40-49,some college,MO,1,1,0.59818561
+male,other,50-59,4-year college,MO,1,1,0.59818561
+male,other,60-69,hs,MO,1,0,0.59818561
+female,white,18-29,4-year college,MO,2,2,0.59818561
+female,white,18-29,hs,MO,3,0,0.59818561
+female,white,18-29,post-grad,MO,2,1,0.59818561
+female,white,18-29,some college,MO,6,4,0.59818561
+female,white,30-39,4-year college,MO,2,0,0.59818561
+female,white,30-39,hs,MO,2,1,0.59818561
+female,white,30-39,post-grad,MO,6,3,0.59818561
+female,white,30-39,some college,MO,3,1,0.59818561
+female,white,40-49,4-year college,MO,1,1,0.59818561
+female,white,40-49,some college,MO,3,2,0.59818561
+female,white,50-59,4-year college,MO,2,1,0.59818561
+female,white,50-59,hs,MO,4,2,0.59818561
+female,white,50-59,post-grad,MO,2,0,0.59818561
+female,white,50-59,some college,MO,3,2,0.59818561
+female,white,60-69,4-year college,MO,3,1,0.59818561
+female,white,60-69,hs,MO,6,4,0.59818561
+female,white,60-69,post-grad,MO,3,2,0.59818561
+female,white,60-69,some college,MO,5,4,0.59818561
+female,white,70+,hs,MO,4,3,0.59818561
+female,white,70+,post-grad,MO,1,0,0.59818561
+female,white,70+,some college,MO,2,1,0.59818561
+male,white,18-29,4-year college,MO,3,3,0.59818561
+male,white,18-29,hs,MO,1,1,0.59818561
+male,white,18-29,some college,MO,2,0,0.59818561
+male,white,30-39,post-grad,MO,2,0,0.59818561
+male,white,30-39,some college,MO,1,1,0.59818561
+male,white,40-49,hs,MO,2,1,0.59818561
+male,white,40-49,no hs,MO,1,1,0.59818561
+male,white,40-49,post-grad,MO,1,0,0.59818561
+male,white,40-49,some college,MO,2,0,0.59818561
+male,white,50-59,4-year college,MO,2,1,0.59818561
+male,white,50-59,hs,MO,3,2,0.59818561
+male,white,50-59,post-grad,MO,1,0,0.59818561
+male,white,50-59,some college,MO,4,1,0.59818561
+male,white,60-69,4-year college,MO,2,1,0.59818561
+male,white,60-69,hs,MO,2,0,0.59818561
+male,white,70+,4-year college,MO,2,2,0.59818561
+male,white,70+,hs,MO,4,2,0.59818561
+male,white,70+,post-grad,MO,4,2,0.59818561
+male,white,70+,some college,MO,2,1,0.59818561
+female,black,18-29,4-year college,MS,1,1,0.590898473
+female,black,18-29,no hs,MS,1,1,0.590898473
+female,black,30-39,hs,MS,1,0,0.590898473
+female,black,50-59,4-year college,MS,1,0,0.590898473
+female,black,50-59,some college,MS,1,1,0.590898473
+female,black,60-69,4-year college,MS,1,1,0.590898473
+male,black,18-29,some college,MS,1,1,0.590898473
+female,white,18-29,4-year college,MS,1,1,0.590898473
+female,white,18-29,some college,MS,4,4,0.590898473
+female,white,30-39,4-year college,MS,1,1,0.590898473
+female,white,30-39,some college,MS,1,1,0.590898473
+female,white,40-49,4-year college,MS,1,0,0.590898473
+female,white,50-59,hs,MS,2,1,0.590898473
+female,white,50-59,some college,MS,1,1,0.590898473
+female,white,60-69,hs,MS,1,0,0.590898473
+female,white,60-69,post-grad,MS,1,0,0.590898473
+female,white,70+,hs,MS,2,2,0.590898473
+female,white,70+,some college,MS,1,0,0.590898473
+male,white,18-29,hs,MS,1,1,0.590898473
+male,white,30-39,some college,MS,1,0,0.590898473
+male,white,50-59,4-year college,MS,1,1,0.590898473
+male,white,60-69,4-year college,MS,1,1,0.590898473
+male,white,60-69,no hs,MS,1,1,0.590898473
+male,white,60-69,post-grad,MS,1,1,0.590898473
+male,white,70+,4-year college,MS,1,1,0.590898473
+male,white,70+,some college,MS,1,1,0.590898473
+female,other,50-59,some college,MT,1,0,0.611096643
+male,other,50-59,4-year college,MT,1,1,0.611096643
+male,other,70+,hs,MT,1,1,0.611096643
+female,white,30-39,4-year college,MT,1,0,0.611096643
+female,white,30-39,post-grad,MT,1,0,0.611096643
+female,white,40-49,hs,MT,1,0,0.611096643
+female,white,40-49,some college,MT,2,2,0.611096643
+female,white,50-59,4-year college,MT,2,0,0.611096643
+female,white,60-69,4-year college,MT,1,1,0.611096643
+female,white,60-69,hs,MT,1,0,0.611096643
+female,white,60-69,post-grad,MT,1,0,0.611096643
+female,white,70+,hs,MT,1,1,0.611096643
+male,white,30-39,hs,MT,1,0,0.611096643
+male,white,30-39,post-grad,MT,1,1,0.611096643
+male,white,50-59,4-year college,MT,1,0,0.611096643
+male,white,50-59,some college,MT,1,1,0.611096643
+male,white,60-69,some college,MT,1,0,0.611096643
+male,white,70+,4-year college,MT,1,1,0.611096643
+female,black,18-29,hs,NC,2,2,0.519037458
+female,black,30-39,4-year college,NC,1,0,0.519037458
+female,black,30-39,post-grad,NC,1,0,0.519037458
+female,black,40-49,some college,NC,2,2,0.519037458
+female,black,50-59,4-year college,NC,1,0,0.519037458
+female,black,50-59,hs,NC,1,0,0.519037458
+female,black,50-59,post-grad,NC,1,0,0.519037458
+female,black,60-69,hs,NC,1,0,0.519037458
+female,black,70+,4-year college,NC,1,1,0.519037458
+female,black,70+,hs,NC,1,0,0.519037458
+female,black,70+,post-grad,NC,1,1,0.519037458
+male,black,18-29,hs,NC,2,2,0.519037458
+male,black,18-29,some college,NC,2,0,0.519037458
+male,black,30-39,4-year college,NC,1,1,0.519037458
+male,black,50-59,4-year college,NC,1,0,0.519037458
+male,black,50-59,some college,NC,1,0,0.519037458
+male,black,60-69,some college,NC,1,0,0.519037458
+female,other,18-29,4-year college,NC,1,0,0.519037458
+female,other,18-29,hs,NC,1,1,0.519037458
+female,other,18-29,some college,NC,1,1,0.519037458
+female,other,30-39,some college,NC,1,1,0.519037458
+female,other,40-49,4-year college,NC,1,0,0.519037458
+female,other,40-49,post-grad,NC,1,1,0.519037458
+female,other,50-59,some college,NC,1,0,0.519037458
+male,other,18-29,hs,NC,1,0,0.519037458
+male,other,30-39,4-year college,NC,1,0,0.519037458
+male,other,30-39,hs,NC,1,1,0.519037458
+male,other,30-39,post-grad,NC,2,0,0.519037458
+male,other,30-39,some college,NC,1,0,0.519037458
+male,other,50-59,4-year college,NC,1,0,0.519037458
+male,other,60-69,4-year college,NC,1,1,0.519037458
+female,white,18-29,hs,NC,5,3,0.519037458
+female,white,18-29,post-grad,NC,1,0,0.519037458
+female,white,18-29,some college,NC,7,2,0.519037458
+female,white,30-39,4-year college,NC,1,1,0.519037458
+female,white,30-39,hs,NC,2,1,0.519037458
+female,white,30-39,no hs,NC,2,0,0.519037458
+female,white,30-39,some college,NC,1,0,0.519037458
+female,white,40-49,4-year college,NC,1,1,0.519037458
+female,white,40-49,hs,NC,2,1,0.519037458
+female,white,40-49,post-grad,NC,1,0,0.519037458
+female,white,40-49,some college,NC,6,2,0.519037458
+female,white,50-59,4-year college,NC,2,1,0.519037458
+female,white,50-59,hs,NC,5,4,0.519037458
+female,white,50-59,post-grad,NC,1,0,0.519037458
+female,white,50-59,some college,NC,3,2,0.519037458
+female,white,60-69,4-year college,NC,3,0,0.519037458
+female,white,60-69,hs,NC,4,3,0.519037458
+female,white,60-69,post-grad,NC,2,0,0.519037458
+female,white,60-69,some college,NC,5,2,0.519037458
+female,white,70+,hs,NC,6,5,0.519037458
+female,white,70+,post-grad,NC,1,0,0.519037458
+female,white,70+,some college,NC,1,1,0.519037458
+male,white,18-29,4-year college,NC,3,1,0.519037458
+male,white,18-29,hs,NC,4,3,0.519037458
+male,white,18-29,some college,NC,2,2,0.519037458
+male,white,30-39,4-year college,NC,1,1,0.519037458
+male,white,30-39,hs,NC,2,1,0.519037458
+male,white,30-39,post-grad,NC,1,1,0.519037458
+male,white,30-39,some college,NC,3,0,0.519037458
+male,white,40-49,4-year college,NC,1,1,0.519037458
+male,white,40-49,hs,NC,3,1,0.519037458
+male,white,40-49,no hs,NC,1,1,0.519037458
+male,white,40-49,some college,NC,5,3,0.519037458
+male,white,50-59,4-year college,NC,3,2,0.519037458
+male,white,50-59,hs,NC,5,1,0.519037458
+male,white,50-59,post-grad,NC,1,1,0.519037458
+male,white,50-59,some college,NC,4,4,0.519037458
+male,white,60-69,4-year college,NC,1,0,0.519037458
+male,white,60-69,hs,NC,3,2,0.519037458
+male,white,60-69,no hs,NC,1,1,0.519037458
+male,white,60-69,some college,NC,3,2,0.519037458
+male,white,70+,4-year college,NC,1,1,0.519037458
+male,white,70+,hs,NC,5,3,0.519037458
+male,white,70+,no hs,NC,1,1,0.519037458
+male,white,70+,post-grad,NC,2,0,0.519037458
+male,white,70+,some college,NC,1,1,0.519037458
+female,other,30-39,post-grad,ND,1,0,0.698092429
+male,other,40-49,no hs,ND,1,1,0.698092429
+female,white,18-29,hs,ND,1,0,0.698092429
+female,white,18-29,some college,ND,1,1,0.698092429
+female,white,30-39,4-year college,ND,1,0,0.698092429
+female,white,30-39,some college,ND,1,0,0.698092429
+female,white,60-69,post-grad,ND,1,0,0.698092429
+female,white,60-69,some college,ND,1,0,0.698092429
+female,white,70+,4-year college,ND,1,1,0.698092429
+female,white,70+,hs,ND,1,0,0.698092429
+female,white,70+,some college,ND,1,0,0.698092429
+male,white,18-29,4-year college,ND,1,0,0.698092429
+male,white,18-29,some college,ND,1,0,0.698092429
+male,white,30-39,4-year college,ND,1,1,0.698092429
+male,white,30-39,hs,ND,1,1,0.698092429
+male,white,30-39,some college,ND,1,0,0.698092429
+male,white,50-59,hs,ND,1,1,0.698092429
+male,white,70+,some college,ND,1,1,0.698092429
+female,black,40-49,4-year college,NE,1,1,0.635476741
+female,black,50-59,some college,NE,1,0,0.635476741
+male,other,40-49,4-year college,NE,1,0,0.635476741
+female,white,18-29,post-grad,NE,1,0,0.635476741
+female,white,18-29,some college,NE,2,1,0.635476741
+female,white,30-39,hs,NE,1,0,0.635476741
+female,white,30-39,post-grad,NE,1,1,0.635476741
+female,white,40-49,4-year college,NE,1,1,0.635476741
+female,white,40-49,some college,NE,1,1,0.635476741
+female,white,50-59,hs,NE,1,0,0.635476741
+female,white,50-59,post-grad,NE,1,0,0.635476741
+female,white,50-59,some college,NE,1,0,0.635476741
+female,white,60-69,4-year college,NE,1,0,0.635476741
+female,white,60-69,hs,NE,2,1,0.635476741
+female,white,60-69,post-grad,NE,2,1,0.635476741
+female,white,60-69,some college,NE,3,2,0.635476741
+female,white,70+,hs,NE,3,1,0.635476741
+male,white,30-39,4-year college,NE,2,1,0.635476741
+male,white,40-49,post-grad,NE,1,0,0.635476741
+male,white,40-49,some college,NE,1,0,0.635476741
+male,white,60-69,hs,NE,1,1,0.635476741
+male,white,60-69,post-grad,NE,1,1,0.635476741
+male,white,70+,post-grad,NE,1,0,0.635476741
+male,white,70+,some college,NE,1,1,0.635476741
+female,other,40-49,post-grad,NH,1,0,0.498029716
+male,other,60-69,4-year college,NH,1,1,0.498029716
+female,white,18-29,4-year college,NH,1,0,0.498029716
+female,white,30-39,hs,NH,2,1,0.498029716
+female,white,30-39,no hs,NH,1,0,0.498029716
+female,white,50-59,4-year college,NH,1,0,0.498029716
+female,white,50-59,hs,NH,2,0,0.498029716
+female,white,50-59,post-grad,NH,1,0,0.498029716
+female,white,50-59,some college,NH,2,1,0.498029716
+female,white,60-69,some college,NH,1,0,0.498029716
+female,white,70+,hs,NH,1,0,0.498029716
+male,white,18-29,hs,NH,2,2,0.498029716
+male,white,18-29,post-grad,NH,1,1,0.498029716
+male,white,18-29,some college,NH,2,2,0.498029716
+male,white,30-39,4-year college,NH,2,1,0.498029716
+male,white,30-39,post-grad,NH,1,1,0.498029716
+male,white,30-39,some college,NH,1,1,0.498029716
+male,white,40-49,some college,NH,2,1,0.498029716
+male,white,50-59,hs,NH,1,1,0.498029716
+male,white,60-69,hs,NH,1,0,0.498029716
+male,white,70+,4-year college,NH,1,0,0.498029716
+male,white,70+,post-grad,NH,1,0,0.498029716
+female,black,18-29,4-year college,NJ,1,0,0.427158099
+female,black,30-39,4-year college,NJ,2,0,0.427158099
+female,black,30-39,post-grad,NJ,1,0,0.427158099
+female,black,30-39,some college,NJ,1,1,0.427158099
+female,black,40-49,4-year college,NJ,1,0,0.427158099
+female,black,40-49,some college,NJ,1,0,0.427158099
+female,black,50-59,hs,NJ,1,1,0.427158099
+female,black,70+,hs,NJ,1,0,0.427158099
+male,black,18-29,hs,NJ,3,2,0.427158099
+male,black,40-49,some college,NJ,1,1,0.427158099
+female,other,18-29,4-year college,NJ,2,0,0.427158099
+female,other,18-29,hs,NJ,1,1,0.427158099
+female,other,18-29,some college,NJ,1,0,0.427158099
+female,other,30-39,4-year college,NJ,2,0,0.427158099
+female,other,40-49,4-year college,NJ,2,1,0.427158099
+female,other,50-59,4-year college,NJ,1,0,0.427158099
+female,other,60-69,some college,NJ,1,0,0.427158099
+male,other,18-29,4-year college,NJ,1,0,0.427158099
+male,other,18-29,hs,NJ,1,0,0.427158099
+male,other,18-29,some college,NJ,2,0,0.427158099
+male,other,30-39,4-year college,NJ,1,1,0.427158099
+male,other,30-39,some college,NJ,1,1,0.427158099
+male,other,40-49,hs,NJ,1,0,0.427158099
+male,other,40-49,post-grad,NJ,2,1,0.427158099
+male,other,40-49,some college,NJ,1,0,0.427158099
+male,other,50-59,4-year college,NJ,1,0,0.427158099
+male,other,50-59,some college,NJ,1,1,0.427158099
+female,white,18-29,4-year college,NJ,4,1,0.427158099
+female,white,18-29,hs,NJ,2,0,0.427158099
+female,white,18-29,post-grad,NJ,1,0,0.427158099
+female,white,18-29,some college,NJ,6,1,0.427158099
+female,white,30-39,4-year college,NJ,3,1,0.427158099
+female,white,30-39,hs,NJ,2,1,0.427158099
+female,white,30-39,some college,NJ,1,1,0.427158099
+female,white,40-49,4-year college,NJ,2,1,0.427158099
+female,white,40-49,hs,NJ,5,3,0.427158099
+female,white,40-49,some college,NJ,2,1,0.427158099
+female,white,50-59,4-year college,NJ,4,2,0.427158099
+female,white,50-59,hs,NJ,5,2,0.427158099
+female,white,50-59,post-grad,NJ,4,2,0.427158099
+female,white,50-59,some college,NJ,1,0,0.427158099
+female,white,60-69,4-year college,NJ,5,2,0.427158099
+female,white,60-69,hs,NJ,3,2,0.427158099
+female,white,60-69,some college,NJ,1,1,0.427158099
+female,white,70+,4-year college,NJ,1,0,0.427158099
+female,white,70+,hs,NJ,4,1,0.427158099
+female,white,70+,post-grad,NJ,1,1,0.427158099
+male,white,18-29,hs,NJ,2,1,0.427158099
+male,white,18-29,some college,NJ,1,1,0.427158099
+male,white,30-39,4-year college,NJ,1,0,0.427158099
+male,white,30-39,hs,NJ,1,0,0.427158099
+male,white,30-39,post-grad,NJ,2,0,0.427158099
+male,white,30-39,some college,NJ,4,1,0.427158099
+male,white,40-49,4-year college,NJ,3,0,0.427158099
+male,white,40-49,some college,NJ,3,1,0.427158099
+male,white,50-59,4-year college,NJ,2,1,0.427158099
+male,white,50-59,hs,NJ,1,0,0.427158099
+male,white,50-59,post-grad,NJ,1,1,0.427158099
+male,white,50-59,some college,NJ,1,0,0.427158099
+male,white,60-69,4-year college,NJ,3,1,0.427158099
+male,white,60-69,hs,NJ,2,1,0.427158099
+male,white,60-69,no hs,NJ,1,1,0.427158099
+male,white,60-69,some college,NJ,1,0,0.427158099
+male,white,70+,4-year college,NJ,1,1,0.427158099
+male,white,70+,hs,NJ,2,2,0.427158099
+male,white,70+,some college,NJ,2,2,0.427158099
+female,black,18-29,hs,NM,1,0,0.453492051
+female,other,18-29,hs,NM,1,1,0.453492051
+female,other,30-39,4-year college,NM,1,0,0.453492051
+female,other,50-59,4-year college,NM,1,1,0.453492051
+male,other,18-29,some college,NM,1,1,0.453492051
+male,other,60-69,hs,NM,1,0,0.453492051
+male,other,60-69,some college,NM,1,0,0.453492051
+female,white,30-39,some college,NM,1,0,0.453492051
+female,white,40-49,4-year college,NM,2,0,0.453492051
+female,white,40-49,hs,NM,1,0,0.453492051
+female,white,40-49,some college,NM,1,1,0.453492051
+female,white,60-69,4-year college,NM,2,1,0.453492051
+female,white,70+,no hs,NM,1,1,0.453492051
+male,white,18-29,some college,NM,1,0,0.453492051
+male,white,30-39,hs,NM,1,0,0.453492051
+male,white,40-49,hs,NM,1,1,0.453492051
+male,white,50-59,4-year college,NM,1,0,0.453492051
+male,white,50-59,some college,NM,1,0,0.453492051
+male,white,60-69,4-year college,NM,2,0,0.453492051
+male,white,60-69,some college,NM,1,0,0.453492051
+male,white,70+,post-grad,NM,1,1,0.453492051
+male,white,70+,some college,NM,2,2,0.453492051
+male,black,18-29,hs,NV,2,0,0.487062906
+male,black,30-39,4-year college,NV,1,0,0.487062906
+male,black,30-39,some college,NV,1,1,0.487062906
+female,other,18-29,some college,NV,1,1,0.487062906
+female,other,30-39,some college,NV,1,1,0.487062906
+female,other,40-49,some college,NV,3,0,0.487062906
+female,other,60-69,4-year college,NV,1,1,0.487062906
+female,other,60-69,hs,NV,1,0,0.487062906
+male,other,18-29,hs,NV,1,1,0.487062906
+male,other,18-29,some college,NV,1,1,0.487062906
+male,other,30-39,4-year college,NV,1,1,0.487062906
+male,other,30-39,some college,NV,1,1,0.487062906
+male,other,40-49,some college,NV,1,0,0.487062906
+male,other,60-69,4-year college,NV,1,1,0.487062906
+female,white,30-39,4-year college,NV,1,0,0.487062906
+female,white,30-39,hs,NV,1,0,0.487062906
+female,white,30-39,some college,NV,1,1,0.487062906
+female,white,40-49,4-year college,NV,1,0,0.487062906
+female,white,40-49,some college,NV,1,0,0.487062906
+female,white,50-59,hs,NV,1,1,0.487062906
+female,white,50-59,some college,NV,1,0,0.487062906
+female,white,60-69,hs,NV,2,1,0.487062906
+female,white,60-69,post-grad,NV,1,1,0.487062906
+female,white,60-69,some college,NV,3,2,0.487062906
+female,white,70+,hs,NV,1,0,0.487062906
+female,white,70+,some college,NV,1,0,0.487062906
+male,white,18-29,4-year college,NV,1,0,0.487062906
+male,white,30-39,post-grad,NV,1,1,0.487062906
+male,white,50-59,hs,NV,2,0,0.487062906
+male,white,50-59,some college,NV,4,2,0.487062906
+male,white,60-69,4-year college,NV,2,2,0.487062906
+male,white,60-69,post-grad,NV,1,0,0.487062906
+male,white,60-69,some college,NV,2,1,0.487062906
+male,white,70+,hs,NV,1,1,0.487062906
+male,white,70+,post-grad,NV,2,2,0.487062906
+male,white,70+,some college,NV,1,1,0.487062906
+female,black,18-29,4-year college,NY,1,0,0.382275815
+female,black,18-29,hs,NY,2,0,0.382275815
+female,black,18-29,no hs,NY,1,0,0.382275815
+female,black,18-29,post-grad,NY,1,0,0.382275815
+female,black,18-29,some college,NY,1,1,0.382275815
+female,black,30-39,4-year college,NY,1,1,0.382275815
+female,black,30-39,no hs,NY,1,1,0.382275815
+female,black,30-39,some college,NY,2,1,0.382275815
+female,black,40-49,post-grad,NY,1,0,0.382275815
+female,black,40-49,some college,NY,1,0,0.382275815
+female,black,50-59,4-year college,NY,3,0,0.382275815
+female,black,50-59,hs,NY,3,1,0.382275815
+female,black,50-59,post-grad,NY,1,0,0.382275815
+female,black,50-59,some college,NY,1,0,0.382275815
+female,black,60-69,4-year college,NY,1,0,0.382275815
+female,black,60-69,hs,NY,1,0,0.382275815
+female,black,70+,4-year college,NY,1,0,0.382275815
+female,black,70+,post-grad,NY,1,0,0.382275815
+male,black,18-29,no hs,NY,1,0,0.382275815
+male,black,18-29,some college,NY,1,1,0.382275815
+male,black,30-39,4-year college,NY,1,0,0.382275815
+male,black,40-49,no hs,NY,1,0,0.382275815
+male,black,40-49,some college,NY,2,0,0.382275815
+male,black,50-59,4-year college,NY,1,0,0.382275815
+male,black,50-59,hs,NY,2,0,0.382275815
+male,black,50-59,some college,NY,2,0,0.382275815
+male,black,60-69,4-year college,NY,1,0,0.382275815
+female,other,18-29,4-year college,NY,5,2,0.382275815
+female,other,18-29,hs,NY,2,2,0.382275815
+female,other,18-29,no hs,NY,2,1,0.382275815
+female,other,18-29,some college,NY,1,0,0.382275815
+female,other,30-39,4-year college,NY,3,1,0.382275815
+female,other,30-39,hs,NY,1,0,0.382275815
+female,other,30-39,post-grad,NY,2,1,0.382275815
+female,other,30-39,some college,NY,2,0,0.382275815
+female,other,40-49,4-year college,NY,1,0,0.382275815
+female,other,40-49,hs,NY,1,0,0.382275815
+female,other,40-49,post-grad,NY,2,0,0.382275815
+female,other,40-49,some college,NY,2,1,0.382275815
+female,other,50-59,4-year college,NY,3,1,0.382275815
+female,other,50-59,hs,NY,1,1,0.382275815
+female,other,50-59,post-grad,NY,1,0,0.382275815
+female,other,60-69,hs,NY,1,0,0.382275815
+female,other,60-69,some college,NY,1,0,0.382275815
+male,other,18-29,hs,NY,1,0,0.382275815
+male,other,18-29,no hs,NY,1,0,0.382275815
+male,other,18-29,post-grad,NY,2,1,0.382275815
+male,other,18-29,some college,NY,3,1,0.382275815
+male,other,30-39,4-year college,NY,2,1,0.382275815
+male,other,30-39,hs,NY,2,1,0.382275815
+male,other,30-39,no hs,NY,1,0,0.382275815
+male,other,40-49,4-year college,NY,3,1,0.382275815
+male,other,40-49,hs,NY,2,1,0.382275815
+male,other,40-49,post-grad,NY,2,0,0.382275815
+male,other,50-59,hs,NY,1,0,0.382275815
+male,other,50-59,no hs,NY,1,1,0.382275815
+male,other,50-59,post-grad,NY,1,0,0.382275815
+male,other,50-59,some college,NY,1,0,0.382275815
+male,other,60-69,post-grad,NY,1,0,0.382275815
+male,other,60-69,some college,NY,1,1,0.382275815
+female,white,18-29,4-year college,NY,19,6,0.382275815
+female,white,18-29,hs,NY,3,1,0.382275815
+female,white,18-29,no hs,NY,1,0,0.382275815
+female,white,18-29,some college,NY,6,2,0.382275815
+female,white,30-39,4-year college,NY,3,2,0.382275815
+female,white,30-39,hs,NY,8,3,0.382275815
+female,white,30-39,no hs,NY,1,0,0.382275815
+female,white,30-39,post-grad,NY,4,1,0.382275815
+female,white,30-39,some college,NY,3,1,0.382275815
+female,white,40-49,4-year college,NY,4,1,0.382275815
+female,white,40-49,hs,NY,11,2,0.382275815
+female,white,40-49,post-grad,NY,1,0,0.382275815
+female,white,40-49,some college,NY,5,2,0.382275815
+female,white,50-59,4-year college,NY,4,0,0.382275815
+female,white,50-59,hs,NY,7,4,0.382275815
+female,white,50-59,no hs,NY,2,0,0.382275815
+female,white,50-59,post-grad,NY,2,1,0.382275815
+female,white,50-59,some college,NY,5,0,0.382275815
+female,white,60-69,4-year college,NY,1,0,0.382275815
+female,white,60-69,hs,NY,8,4,0.382275815
+female,white,60-69,post-grad,NY,2,0,0.382275815
+female,white,60-69,some college,NY,3,1,0.382275815
+female,white,70+,hs,NY,13,6,0.382275815
+female,white,70+,no hs,NY,1,1,0.382275815
+female,white,70+,post-grad,NY,4,1,0.382275815
+female,white,70+,some college,NY,5,2,0.382275815
+male,white,18-29,4-year college,NY,6,3,0.382275815
+male,white,18-29,hs,NY,5,1,0.382275815
+male,white,18-29,post-grad,NY,1,0,0.382275815
+male,white,18-29,some college,NY,2,1,0.382275815
+male,white,30-39,4-year college,NY,7,2,0.382275815
+male,white,30-39,hs,NY,4,2,0.382275815
+male,white,30-39,post-grad,NY,3,1,0.382275815
+male,white,30-39,some college,NY,2,1,0.382275815
+male,white,40-49,4-year college,NY,1,0,0.382275815
+male,white,40-49,hs,NY,8,0,0.382275815
+male,white,40-49,no hs,NY,1,0,0.382275815
+male,white,40-49,post-grad,NY,1,0,0.382275815
+male,white,40-49,some college,NY,4,1,0.382275815
+male,white,50-59,4-year college,NY,2,0,0.382275815
+male,white,50-59,hs,NY,6,1,0.382275815
+male,white,50-59,some college,NY,6,2,0.382275815
+male,white,60-69,4-year college,NY,4,3,0.382275815
+male,white,60-69,no hs,NY,1,1,0.382275815
+male,white,60-69,post-grad,NY,1,0,0.382275815
+male,white,60-69,some college,NY,3,0,0.382275815
+male,white,70+,4-year college,NY,5,2,0.382275815
+male,white,70+,hs,NY,4,1,0.382275815
+male,white,70+,post-grad,NY,5,1,0.382275815
+male,white,70+,some college,NY,1,1,0.382275815
+female,black,18-29,some college,OH,1,0,0.542676846
+female,black,30-39,4-year college,OH,4,3,0.542676846
+female,black,40-49,4-year college,OH,1,0,0.542676846
+female,black,40-49,hs,OH,1,0,0.542676846
+female,black,40-49,some college,OH,1,1,0.542676846
+female,black,60-69,hs,OH,1,1,0.542676846
+female,black,60-69,some college,OH,1,0,0.542676846
+male,black,40-49,4-year college,OH,1,0,0.542676846
+male,black,60-69,4-year college,OH,1,1,0.542676846
+female,other,18-29,4-year college,OH,1,0,0.542676846
+female,other,18-29,hs,OH,1,0,0.542676846
+female,other,18-29,post-grad,OH,1,0,0.542676846
+female,other,18-29,some college,OH,3,0,0.542676846
+female,other,30-39,hs,OH,1,0,0.542676846
+female,other,30-39,some college,OH,1,1,0.542676846
+female,other,40-49,4-year college,OH,1,0,0.542676846
+female,other,40-49,hs,OH,1,0,0.542676846
+female,other,40-49,post-grad,OH,1,0,0.542676846
+female,other,50-59,hs,OH,1,1,0.542676846
+female,other,50-59,some college,OH,1,1,0.542676846
+male,other,18-29,4-year college,OH,1,0,0.542676846
+male,other,18-29,post-grad,OH,1,0,0.542676846
+male,other,50-59,some college,OH,2,2,0.542676846
+male,other,70+,some college,OH,1,1,0.542676846
+female,white,18-29,4-year college,OH,6,1,0.542676846
+female,white,18-29,hs,OH,6,2,0.542676846
+female,white,18-29,no hs,OH,4,2,0.542676846
+female,white,18-29,post-grad,OH,1,0,0.542676846
+female,white,18-29,some college,OH,11,3,0.542676846
+female,white,30-39,4-year college,OH,4,2,0.542676846
+female,white,30-39,hs,OH,3,0,0.542676846
+female,white,30-39,post-grad,OH,4,1,0.542676846
+female,white,30-39,some college,OH,4,0,0.542676846
+female,white,40-49,4-year college,OH,2,0,0.542676846
+female,white,40-49,hs,OH,3,1,0.542676846
+female,white,40-49,post-grad,OH,4,1,0.542676846
+female,white,40-49,some college,OH,4,3,0.542676846
+female,white,50-59,4-year college,OH,1,0,0.542676846
+female,white,50-59,hs,OH,11,6,0.542676846
+female,white,50-59,no hs,OH,1,1,0.542676846
+female,white,50-59,post-grad,OH,5,1,0.542676846
+female,white,50-59,some college,OH,9,5,0.542676846
+female,white,60-69,4-year college,OH,2,0,0.542676846
+female,white,60-69,hs,OH,12,5,0.542676846
+female,white,60-69,no hs,OH,1,1,0.542676846
+female,white,60-69,post-grad,OH,2,2,0.542676846
+female,white,60-69,some college,OH,3,1,0.542676846
+female,white,70+,hs,OH,5,1,0.542676846
+female,white,70+,post-grad,OH,1,1,0.542676846
+male,white,18-29,4-year college,OH,2,0,0.542676846
+male,white,18-29,hs,OH,2,0,0.542676846
+male,white,18-29,no hs,OH,1,1,0.542676846
+male,white,18-29,post-grad,OH,1,0,0.542676846
+male,white,18-29,some college,OH,6,1,0.542676846
+male,white,30-39,4-year college,OH,4,2,0.542676846
+male,white,30-39,no hs,OH,1,1,0.542676846
+male,white,30-39,post-grad,OH,2,0,0.542676846
+male,white,30-39,some college,OH,6,2,0.542676846
+male,white,40-49,4-year college,OH,3,3,0.542676846
+male,white,40-49,hs,OH,3,1,0.542676846
+male,white,40-49,post-grad,OH,2,2,0.542676846
+male,white,40-49,some college,OH,1,1,0.542676846
+male,white,50-59,4-year college,OH,6,1,0.542676846
+male,white,50-59,hs,OH,5,3,0.542676846
+male,white,50-59,no hs,OH,1,1,0.542676846
+male,white,50-59,some college,OH,5,3,0.542676846
+male,white,60-69,4-year college,OH,3,2,0.542676846
+male,white,60-69,hs,OH,5,3,0.542676846
+male,white,60-69,no hs,OH,1,1,0.542676846
+male,white,60-69,some college,OH,6,2,0.542676846
+male,white,70+,4-year college,OH,2,1,0.542676846
+male,white,70+,hs,OH,4,2,0.542676846
+male,white,70+,post-grad,OH,1,1,0.542676846
+male,white,70+,some college,OH,2,1,0.542676846
+female,black,30-39,hs,OK,1,0,0.693047372
+female,black,50-59,some college,OK,1,0,0.693047372
+male,black,40-49,4-year college,OK,1,0,0.693047372
+female,other,18-29,4-year college,OK,1,0,0.693047372
+female,other,18-29,hs,OK,2,0,0.693047372
+female,other,18-29,some college,OK,1,1,0.693047372
+female,other,30-39,hs,OK,1,0,0.693047372
+female,other,40-49,some college,OK,1,0,0.693047372
+female,other,50-59,hs,OK,1,0,0.693047372
+male,other,18-29,no hs,OK,1,0,0.693047372
+male,other,40-49,some college,OK,1,1,0.693047372
+male,other,50-59,hs,OK,1,1,0.693047372
+male,other,70+,4-year college,OK,1,1,0.693047372
+male,other,70+,some college,OK,1,0,0.693047372
+female,white,18-29,4-year college,OK,2,1,0.693047372
+female,white,18-29,hs,OK,4,1,0.693047372
+female,white,30-39,4-year college,OK,1,1,0.693047372
+female,white,40-49,4-year college,OK,1,0,0.693047372
+female,white,40-49,hs,OK,1,1,0.693047372
+female,white,40-49,some college,OK,1,1,0.693047372
+female,white,50-59,4-year college,OK,1,0,0.693047372
+female,white,50-59,hs,OK,1,1,0.693047372
+female,white,50-59,post-grad,OK,2,0,0.693047372
+female,white,50-59,some college,OK,1,1,0.693047372
+female,white,60-69,hs,OK,2,1,0.693047372
+female,white,60-69,some college,OK,2,1,0.693047372
+female,white,70+,4-year college,OK,1,0,0.693047372
+female,white,70+,hs,OK,1,0,0.693047372
+female,white,70+,some college,OK,2,2,0.693047372
+male,white,18-29,hs,OK,2,1,0.693047372
+male,white,30-39,4-year college,OK,1,0,0.693047372
+male,white,30-39,some college,OK,1,1,0.693047372
+male,white,40-49,4-year college,OK,1,0,0.693047372
+male,white,40-49,some college,OK,1,1,0.693047372
+male,white,50-59,4-year college,OK,3,3,0.693047372
+male,white,50-59,hs,OK,1,0,0.693047372
+male,white,60-69,4-year college,OK,1,1,0.693047372
+male,white,70+,some college,OK,2,1,0.693047372
+female,other,18-29,4-year college,OR,1,0,0.438441611
+female,other,30-39,4-year college,OR,1,0,0.438441611
+female,other,60-69,hs,OR,1,0,0.438441611
+male,other,18-29,4-year college,OR,1,0,0.438441611
+male,other,60-69,post-grad,OR,1,1,0.438441611
+female,white,18-29,4-year college,OR,3,0,0.438441611
+female,white,18-29,no hs,OR,1,1,0.438441611
+female,white,18-29,some college,OR,1,0,0.438441611
+female,white,30-39,4-year college,OR,4,1,0.438441611
+female,white,30-39,hs,OR,1,1,0.438441611
+female,white,30-39,post-grad,OR,1,0,0.438441611
+female,white,30-39,some college,OR,1,0,0.438441611
+female,white,40-49,4-year college,OR,3,0,0.438441611
+female,white,40-49,hs,OR,1,1,0.438441611
+female,white,40-49,some college,OR,3,1,0.438441611
+female,white,50-59,hs,OR,3,2,0.438441611
+female,white,50-59,post-grad,OR,1,1,0.438441611
+female,white,50-59,some college,OR,1,0,0.438441611
+female,white,60-69,4-year college,OR,2,0,0.438441611
+female,white,60-69,hs,OR,4,1,0.438441611
+female,white,60-69,some college,OR,2,2,0.438441611
+female,white,70+,hs,OR,2,0,0.438441611
+female,white,70+,post-grad,OR,1,0,0.438441611
+female,white,70+,some college,OR,1,0,0.438441611
+male,white,18-29,no hs,OR,1,1,0.438441611
+male,white,30-39,4-year college,OR,1,1,0.438441611
+male,white,30-39,hs,OR,1,1,0.438441611
+male,white,40-49,4-year college,OR,2,1,0.438441611
+male,white,40-49,no hs,OR,1,1,0.438441611
+male,white,40-49,post-grad,OR,3,1,0.438441611
+male,white,50-59,hs,OR,3,1,0.438441611
+male,white,50-59,some college,OR,4,1,0.438441611
+male,white,60-69,4-year college,OR,1,1,0.438441611
+male,white,60-69,no hs,OR,1,0,0.438441611
+male,white,60-69,post-grad,OR,1,0,0.438441611
+male,white,60-69,some college,OR,1,0,0.438441611
+male,white,70+,hs,OR,1,0,0.438441611
+male,white,70+,post-grad,OR,2,1,0.438441611
+male,white,70+,some college,OR,1,0,0.438441611
+female,black,18-29,hs,PA,3,1,0.503755358
+female,black,18-29,some college,PA,1,0,0.503755358
+female,black,30-39,4-year college,PA,1,1,0.503755358
+female,black,30-39,no hs,PA,1,0,0.503755358
+female,black,40-49,some college,PA,1,1,0.503755358
+female,black,50-59,hs,PA,1,1,0.503755358
+female,black,50-59,post-grad,PA,2,0,0.503755358
+female,black,50-59,some college,PA,5,2,0.503755358
+female,black,60-69,hs,PA,1,0,0.503755358
+female,black,60-69,some college,PA,1,1,0.503755358
+male,black,18-29,some college,PA,2,1,0.503755358
+male,black,40-49,4-year college,PA,1,0,0.503755358
+male,black,40-49,hs,PA,1,1,0.503755358
+female,other,18-29,hs,PA,1,1,0.503755358
+female,other,18-29,no hs,PA,1,1,0.503755358
+female,other,30-39,post-grad,PA,2,0,0.503755358
+female,other,50-59,hs,PA,2,1,0.503755358
+female,other,50-59,some college,PA,1,1,0.503755358
+female,other,60-69,hs,PA,1,1,0.503755358
+male,other,18-29,hs,PA,1,1,0.503755358
+male,other,18-29,some college,PA,1,0,0.503755358
+male,other,30-39,4-year college,PA,2,1,0.503755358
+male,other,30-39,some college,PA,1,1,0.503755358
+male,other,50-59,4-year college,PA,2,1,0.503755358
+female,white,18-29,4-year college,PA,11,2,0.503755358
+female,white,18-29,hs,PA,11,4,0.503755358
+female,white,18-29,post-grad,PA,2,1,0.503755358
+female,white,18-29,some college,PA,7,2,0.503755358
+female,white,30-39,4-year college,PA,3,0,0.503755358
+female,white,30-39,hs,PA,6,3,0.503755358
+female,white,30-39,post-grad,PA,3,0,0.503755358
+female,white,30-39,some college,PA,5,1,0.503755358
+female,white,40-49,4-year college,PA,5,4,0.503755358
+female,white,40-49,hs,PA,5,5,0.503755358
+female,white,40-49,some college,PA,7,2,0.503755358
+female,white,50-59,4-year college,PA,1,1,0.503755358
+female,white,50-59,hs,PA,13,4,0.503755358
+female,white,50-59,no hs,PA,3,1,0.503755358
+female,white,50-59,post-grad,PA,4,3,0.503755358
+female,white,50-59,some college,PA,4,3,0.503755358
+female,white,60-69,4-year college,PA,2,2,0.503755358
+female,white,60-69,hs,PA,9,5,0.503755358
+female,white,60-69,post-grad,PA,2,1,0.503755358
+female,white,60-69,some college,PA,10,5,0.503755358
+female,white,70+,4-year college,PA,2,0,0.503755358
+female,white,70+,hs,PA,10,7,0.503755358
+female,white,70+,post-grad,PA,1,1,0.503755358
+female,white,70+,some college,PA,7,2,0.503755358
+male,white,18-29,4-year college,PA,2,0,0.503755358
+male,white,18-29,hs,PA,1,1,0.503755358
+male,white,18-29,some college,PA,6,2,0.503755358
+male,white,30-39,4-year college,PA,6,5,0.503755358
+male,white,30-39,hs,PA,3,3,0.503755358
+male,white,30-39,no hs,PA,2,1,0.503755358
+male,white,30-39,post-grad,PA,4,3,0.503755358
+male,white,30-39,some college,PA,4,0,0.503755358
+male,white,40-49,4-year college,PA,3,2,0.503755358
+male,white,40-49,hs,PA,2,1,0.503755358
+male,white,40-49,post-grad,PA,2,0,0.503755358
+male,white,40-49,some college,PA,1,1,0.503755358
+male,white,50-59,4-year college,PA,1,0,0.503755358
+male,white,50-59,hs,PA,7,2,0.503755358
+male,white,50-59,post-grad,PA,3,1,0.503755358
+male,white,50-59,some college,PA,4,2,0.503755358
+male,white,60-69,4-year college,PA,3,0,0.503755358
+male,white,60-69,hs,PA,12,8,0.503755358
+male,white,60-69,no hs,PA,3,1,0.503755358
+male,white,60-69,post-grad,PA,3,0,0.503755358
+male,white,60-69,some college,PA,7,3,0.503755358
+male,white,70+,4-year college,PA,2,2,0.503755358
+male,white,70+,hs,PA,3,2,0.503755358
+male,white,70+,no hs,PA,1,0,0.503755358
+male,white,70+,post-grad,PA,2,1,0.503755358
+male,white,70+,some college,PA,4,2,0.503755358
+female,other,18-29,4-year college,RI,1,0,0.416892959
+female,other,40-49,some college,RI,1,0,0.416892959
+male,other,50-59,4-year college,RI,1,0,0.416892959
+male,other,50-59,no hs,RI,1,1,0.416892959
+male,other,60-69,post-grad,RI,1,0,0.416892959
+female,white,18-29,4-year college,RI,1,0,0.416892959
+female,white,18-29,hs,RI,1,1,0.416892959
+female,white,18-29,some college,RI,2,0,0.416892959
+female,white,30-39,some college,RI,1,1,0.416892959
+female,white,40-49,hs,RI,1,1,0.416892959
+female,white,50-59,hs,RI,1,0,0.416892959
+female,white,60-69,hs,RI,2,0,0.416892959
+female,white,70+,hs,RI,1,1,0.416892959
+male,white,30-39,some college,RI,1,0,0.416892959
+male,white,50-59,some college,RI,1,0,0.416892959
+male,white,70+,4-year college,RI,1,1,0.416892959
+male,white,70+,hs,RI,1,0,0.416892959
+female,black,18-29,hs,SC,1,1,0.574602564
+female,black,18-29,some college,SC,1,0,0.574602564
+female,black,30-39,some college,SC,1,1,0.574602564
+female,black,50-59,4-year college,SC,2,1,0.574602564
+female,black,50-59,post-grad,SC,1,1,0.574602564
+female,black,60-69,hs,SC,2,1,0.574602564
+male,black,18-29,some college,SC,1,0,0.574602564
+male,black,40-49,hs,SC,1,0,0.574602564
+male,black,40-49,some college,SC,1,0,0.574602564
+female,other,18-29,hs,SC,1,1,0.574602564
+female,other,18-29,some college,SC,2,1,0.574602564
+male,other,70+,4-year college,SC,1,1,0.574602564
+female,white,18-29,4-year college,SC,1,0,0.574602564
+female,white,18-29,hs,SC,2,1,0.574602564
+female,white,18-29,some college,SC,2,1,0.574602564
+female,white,30-39,4-year college,SC,1,1,0.574602564
+female,white,30-39,hs,SC,1,1,0.574602564
+female,white,40-49,4-year college,SC,2,2,0.574602564
+female,white,40-49,hs,SC,3,2,0.574602564
+female,white,40-49,no hs,SC,2,1,0.574602564
+female,white,40-49,post-grad,SC,2,0,0.574602564
+female,white,40-49,some college,SC,1,0,0.574602564
+female,white,50-59,hs,SC,2,1,0.574602564
+female,white,50-59,some college,SC,1,0,0.574602564
+female,white,60-69,4-year college,SC,1,1,0.574602564
+female,white,60-69,hs,SC,4,4,0.574602564
+female,white,60-69,no hs,SC,1,0,0.574602564
+female,white,60-69,post-grad,SC,2,2,0.574602564
+female,white,70+,hs,SC,1,0,0.574602564
+female,white,70+,some college,SC,1,0,0.574602564
+male,white,30-39,4-year college,SC,1,1,0.574602564
+male,white,30-39,some college,SC,2,0,0.574602564
+male,white,40-49,hs,SC,2,2,0.574602564
+male,white,40-49,post-grad,SC,1,1,0.574602564
+male,white,50-59,4-year college,SC,1,0,0.574602564
+male,white,50-59,hs,SC,1,0,0.574602564
+male,white,50-59,post-grad,SC,1,1,0.574602564
+male,white,50-59,some college,SC,2,2,0.574602564
+male,white,60-69,hs,SC,2,0,0.574602564
+male,white,70+,4-year college,SC,1,1,0.574602564
+male,white,70+,post-grad,SC,1,1,0.574602564
+male,white,70+,some college,SC,1,1,0.574602564
+female,other,18-29,hs,SD,1,1,0.659718581
+female,white,18-29,some college,SD,1,0,0.659718581
+female,white,30-39,4-year college,SD,1,1,0.659718581
+female,white,60-69,some college,SD,1,0,0.659718581
+male,white,30-39,hs,SD,3,2,0.659718581
+male,white,40-49,4-year college,SD,1,0,0.659718581
+male,white,50-59,4-year college,SD,1,1,0.659718581
+male,white,50-59,hs,SD,1,0,0.659718581
+male,white,60-69,some college,SD,1,1,0.659718581
+female,black,18-29,some college,TN,3,1,0.63624343
+female,black,30-39,post-grad,TN,1,0,0.63624343
+female,black,40-49,no hs,TN,1,0,0.63624343
+female,black,40-49,some college,TN,1,0,0.63624343
+female,black,50-59,hs,TN,1,1,0.63624343
+female,black,60-69,no hs,TN,2,1,0.63624343
+female,black,70+,some college,TN,1,0,0.63624343
+male,black,18-29,some college,TN,1,0,0.63624343
+male,black,30-39,4-year college,TN,1,1,0.63624343
+male,black,40-49,post-grad,TN,1,0,0.63624343
+male,black,40-49,some college,TN,1,0,0.63624343
+female,other,18-29,hs,TN,1,0,0.63624343
+female,other,18-29,some college,TN,1,0,0.63624343
+female,other,30-39,hs,TN,1,1,0.63624343
+female,other,30-39,some college,TN,1,1,0.63624343
+female,other,60-69,4-year college,TN,1,0,0.63624343
+male,other,30-39,4-year college,TN,1,1,0.63624343
+male,other,40-49,post-grad,TN,1,0,0.63624343
+male,other,40-49,some college,TN,1,0,0.63624343
+male,other,60-69,4-year college,TN,1,1,0.63624343
+female,white,18-29,4-year college,TN,1,1,0.63624343
+female,white,18-29,hs,TN,2,1,0.63624343
+female,white,18-29,no hs,TN,1,0,0.63624343
+female,white,18-29,some college,TN,5,3,0.63624343
+female,white,30-39,4-year college,TN,2,1,0.63624343
+female,white,30-39,some college,TN,2,1,0.63624343
+female,white,40-49,hs,TN,6,4,0.63624343
+female,white,40-49,post-grad,TN,1,0,0.63624343
+female,white,40-49,some college,TN,4,3,0.63624343
+female,white,50-59,hs,TN,7,6,0.63624343
+female,white,50-59,no hs,TN,1,0,0.63624343
+female,white,50-59,post-grad,TN,1,0,0.63624343
+female,white,60-69,4-year college,TN,1,1,0.63624343
+female,white,60-69,hs,TN,2,1,0.63624343
+female,white,60-69,some college,TN,2,1,0.63624343
+female,white,70+,4-year college,TN,1,1,0.63624343
+female,white,70+,hs,TN,3,2,0.63624343
+male,white,18-29,some college,TN,2,0,0.63624343
+male,white,30-39,4-year college,TN,1,1,0.63624343
+male,white,30-39,hs,TN,1,1,0.63624343
+male,white,30-39,post-grad,TN,3,0,0.63624343
+male,white,30-39,some college,TN,5,2,0.63624343
+male,white,40-49,4-year college,TN,6,4,0.63624343
+male,white,40-49,hs,TN,2,1,0.63624343
+male,white,40-49,post-grad,TN,2,1,0.63624343
+male,white,40-49,some college,TN,3,0,0.63624343
+male,white,50-59,4-year college,TN,1,1,0.63624343
+male,white,50-59,hs,TN,4,2,0.63624343
+male,white,50-59,no hs,TN,1,0,0.63624343
+male,white,50-59,post-grad,TN,1,1,0.63624343
+male,white,50-59,some college,TN,2,2,0.63624343
+male,white,60-69,4-year college,TN,1,0,0.63624343
+male,white,60-69,hs,TN,3,2,0.63624343
+male,white,60-69,some college,TN,2,1,0.63624343
+male,white,70+,hs,TN,1,1,0.63624343
+male,white,70+,post-grad,TN,5,2,0.63624343
+male,white,70+,some college,TN,1,1,0.63624343
+female,black,18-29,4-year college,TX,1,1,0.547132256
+female,black,18-29,hs,TX,2,0,0.547132256
+female,black,18-29,some college,TX,3,1,0.547132256
+female,black,30-39,4-year college,TX,1,0,0.547132256
+female,black,30-39,some college,TX,4,1,0.547132256
+female,black,40-49,4-year college,TX,2,1,0.547132256
+female,black,40-49,hs,TX,1,0,0.547132256
+female,black,40-49,some college,TX,1,1,0.547132256
+female,black,50-59,4-year college,TX,3,0,0.547132256
+female,black,50-59,post-grad,TX,1,0,0.547132256
+female,black,50-59,some college,TX,1,0,0.547132256
+female,black,60-69,hs,TX,1,0,0.547132256
+female,black,60-69,some college,TX,1,0,0.547132256
+male,black,18-29,hs,TX,1,0,0.547132256
+male,black,18-29,no hs,TX,1,0,0.547132256
+male,black,18-29,some college,TX,2,1,0.547132256
+male,black,30-39,4-year college,TX,1,0,0.547132256
+male,black,30-39,some college,TX,2,0,0.547132256
+male,black,40-49,4-year college,TX,1,0,0.547132256
+male,black,40-49,some college,TX,1,1,0.547132256
+male,black,50-59,some college,TX,4,0,0.547132256
+male,black,60-69,hs,TX,1,0,0.547132256
+male,black,70+,some college,TX,1,1,0.547132256
+female,other,18-29,4-year college,TX,5,2,0.547132256
+female,other,18-29,hs,TX,6,1,0.547132256
+female,other,18-29,no hs,TX,2,2,0.547132256
+female,other,18-29,post-grad,TX,3,0,0.547132256
+female,other,18-29,some college,TX,10,4,0.547132256
+female,other,30-39,4-year college,TX,3,1,0.547132256
+female,other,30-39,hs,TX,7,2,0.547132256
+female,other,30-39,no hs,TX,1,1,0.547132256
+female,other,30-39,post-grad,TX,2,1,0.547132256
+female,other,30-39,some college,TX,9,5,0.547132256
+female,other,40-49,4-year college,TX,1,1,0.547132256
+female,other,40-49,hs,TX,4,3,0.547132256
+female,other,40-49,some college,TX,1,0,0.547132256
+female,other,50-59,4-year college,TX,3,0,0.547132256
+female,other,50-59,hs,TX,2,0,0.547132256
+female,other,50-59,no hs,TX,1,1,0.547132256
+female,other,50-59,some college,TX,6,3,0.547132256
+female,other,60-69,4-year college,TX,1,0,0.547132256
+female,other,60-69,hs,TX,2,2,0.547132256
+female,other,60-69,post-grad,TX,1,0,0.547132256
+female,other,70+,4-year college,TX,1,1,0.547132256
+female,other,70+,some college,TX,2,1,0.547132256
+male,other,18-29,4-year college,TX,5,0,0.547132256
+male,other,18-29,hs,TX,1,0,0.547132256
+male,other,18-29,post-grad,TX,1,0,0.547132256
+male,other,18-29,some college,TX,7,2,0.547132256
+male,other,30-39,4-year college,TX,3,2,0.547132256
+male,other,30-39,hs,TX,1,1,0.547132256
+male,other,30-39,post-grad,TX,1,1,0.547132256
+male,other,40-49,4-year college,TX,1,0,0.547132256
+male,other,40-49,hs,TX,2,1,0.547132256
+male,other,40-49,post-grad,TX,1,0,0.547132256
+male,other,40-49,some college,TX,2,1,0.547132256
+male,other,50-59,4-year college,TX,2,2,0.547132256
+male,other,50-59,hs,TX,1,0,0.547132256
+male,other,50-59,post-grad,TX,5,4,0.547132256
+male,other,60-69,4-year college,TX,1,0,0.547132256
+male,other,60-69,post-grad,TX,1,1,0.547132256
+male,other,60-69,some college,TX,1,0,0.547132256
+male,other,70+,4-year college,TX,2,2,0.547132256
+male,other,70+,post-grad,TX,2,1,0.547132256
+female,white,18-29,4-year college,TX,5,1,0.547132256
+female,white,18-29,hs,TX,7,4,0.547132256
+female,white,18-29,no hs,TX,1,1,0.547132256
+female,white,18-29,post-grad,TX,1,0,0.547132256
+female,white,18-29,some college,TX,13,5,0.547132256
+female,white,30-39,4-year college,TX,4,1,0.547132256
+female,white,30-39,hs,TX,11,9,0.547132256
+female,white,30-39,post-grad,TX,6,1,0.547132256
+female,white,30-39,some college,TX,2,0,0.547132256
+female,white,40-49,4-year college,TX,4,1,0.547132256
+female,white,40-49,hs,TX,4,3,0.547132256
+female,white,40-49,no hs,TX,1,1,0.547132256
+female,white,40-49,post-grad,TX,2,1,0.547132256
+female,white,40-49,some college,TX,5,4,0.547132256
+female,white,50-59,4-year college,TX,5,3,0.547132256
+female,white,50-59,hs,TX,2,1,0.547132256
+female,white,50-59,no hs,TX,1,1,0.547132256
+female,white,50-59,post-grad,TX,3,1,0.547132256
+female,white,50-59,some college,TX,9,4,0.547132256
+female,white,60-69,4-year college,TX,4,1,0.547132256
+female,white,60-69,hs,TX,7,6,0.547132256
+female,white,60-69,post-grad,TX,3,1,0.547132256
+female,white,60-69,some college,TX,10,8,0.547132256
+female,white,70+,4-year college,TX,4,3,0.547132256
+female,white,70+,hs,TX,5,3,0.547132256
+female,white,70+,post-grad,TX,2,1,0.547132256
+female,white,70+,some college,TX,5,3,0.547132256
+male,white,18-29,4-year college,TX,5,1,0.547132256
+male,white,18-29,hs,TX,3,1,0.547132256
+male,white,18-29,post-grad,TX,2,1,0.547132256
+male,white,18-29,some college,TX,3,0,0.547132256
+male,white,30-39,4-year college,TX,4,2,0.547132256
+male,white,30-39,hs,TX,2,2,0.547132256
+male,white,30-39,post-grad,TX,1,0,0.547132256
+male,white,30-39,some college,TX,4,0,0.547132256
+male,white,40-49,4-year college,TX,1,0,0.547132256
+male,white,40-49,hs,TX,3,0,0.547132256
+male,white,40-49,post-grad,TX,1,1,0.547132256
+male,white,40-49,some college,TX,5,3,0.547132256
+male,white,50-59,4-year college,TX,7,4,0.547132256
+male,white,50-59,hs,TX,6,4,0.547132256
+male,white,50-59,post-grad,TX,9,2,0.547132256
+male,white,50-59,some college,TX,6,6,0.547132256
+male,white,60-69,4-year college,TX,11,9,0.547132256
+male,white,60-69,hs,TX,1,0,0.547132256
+male,white,60-69,post-grad,TX,5,2,0.547132256
+male,white,60-69,some college,TX,4,3,0.547132256
+male,white,70+,4-year college,TX,5,3,0.547132256
+male,white,70+,hs,TX,4,3,0.547132256
+male,white,70+,no hs,TX,1,1,0.547132256
+male,white,70+,post-grad,TX,8,4,0.547132256
+male,white,70+,some college,TX,6,5,0.547132256
+female,black,30-39,4-year college,UT,1,0,0.623836582
+male,black,40-49,4-year college,UT,1,0,0.623836582
+male,black,50-59,hs,UT,1,0,0.623836582
+female,other,18-29,4-year college,UT,1,1,0.623836582
+female,other,18-29,some college,UT,1,0,0.623836582
+female,other,30-39,some college,UT,1,1,0.623836582
+female,other,40-49,4-year college,UT,1,1,0.623836582
+female,other,40-49,hs,UT,1,1,0.623836582
+female,other,40-49,some college,UT,1,0,0.623836582
+female,other,50-59,hs,UT,1,0,0.623836582
+male,other,18-29,4-year college,UT,1,0,0.623836582
+male,other,18-29,some college,UT,1,0,0.623836582
+female,white,18-29,4-year college,UT,1,0,0.623836582
+female,white,18-29,hs,UT,1,1,0.623836582
+female,white,18-29,some college,UT,3,3,0.623836582
+female,white,30-39,no hs,UT,1,0,0.623836582
+female,white,30-39,some college,UT,2,1,0.623836582
+female,white,40-49,some college,UT,1,1,0.623836582
+female,white,50-59,4-year college,UT,2,0,0.623836582
+female,white,50-59,hs,UT,2,1,0.623836582
+female,white,70+,hs,UT,2,1,0.623836582
+female,white,70+,no hs,UT,2,2,0.623836582
+female,white,70+,some college,UT,1,1,0.623836582
+male,white,18-29,some college,UT,1,0,0.623836582
+male,white,30-39,4-year college,UT,2,0,0.623836582
+male,white,30-39,post-grad,UT,1,1,0.623836582
+male,white,30-39,some college,UT,1,0,0.623836582
+male,white,40-49,4-year college,UT,1,0,0.623836582
+male,white,40-49,hs,UT,2,0,0.623836582
+male,white,40-49,some college,UT,1,1,0.623836582
+male,white,50-59,4-year college,UT,4,3,0.623836582
+male,white,50-59,post-grad,UT,1,1,0.623836582
+male,white,50-59,some college,UT,3,1,0.623836582
+male,white,60-69,4-year college,UT,2,1,0.623836582
+male,white,60-69,post-grad,UT,2,2,0.623836582
+male,white,60-69,some college,UT,1,0,0.623836582
+male,white,70+,4-year college,UT,2,1,0.623836582
+male,white,70+,no hs,UT,1,1,0.623836582
+male,white,70+,some college,UT,1,0,0.623836582
+female,black,18-29,4-year college,VA,2,0,0.471736237
+female,black,18-29,hs,VA,1,1,0.471736237
+female,black,30-39,hs,VA,3,1,0.471736237
+female,black,40-49,4-year college,VA,2,0,0.471736237
+female,black,40-49,hs,VA,2,0,0.471736237
+female,black,40-49,some college,VA,1,0,0.471736237
+female,black,50-59,hs,VA,3,2,0.471736237
+female,black,50-59,post-grad,VA,1,1,0.471736237
+female,black,50-59,some college,VA,2,0,0.471736237
+female,black,60-69,hs,VA,1,1,0.471736237
+female,black,60-69,no hs,VA,1,1,0.471736237
+female,black,60-69,some college,VA,1,0,0.471736237
+male,black,18-29,4-year college,VA,1,0,0.471736237
+male,black,40-49,hs,VA,1,1,0.471736237
+female,other,18-29,4-year college,VA,1,0,0.471736237
+female,other,18-29,some college,VA,1,0,0.471736237
+female,other,40-49,some college,VA,1,0,0.471736237
+female,other,50-59,post-grad,VA,1,1,0.471736237
+female,other,70+,hs,VA,1,1,0.471736237
+male,other,18-29,4-year college,VA,1,0,0.471736237
+male,other,18-29,hs,VA,1,0,0.471736237
+male,other,18-29,post-grad,VA,1,0,0.471736237
+male,other,18-29,some college,VA,1,0,0.471736237
+male,other,30-39,4-year college,VA,1,0,0.471736237
+male,other,30-39,post-grad,VA,1,1,0.471736237
+male,other,30-39,some college,VA,2,0,0.471736237
+male,other,40-49,post-grad,VA,1,1,0.471736237
+male,other,50-59,4-year college,VA,1,0,0.471736237
+male,other,60-69,hs,VA,2,2,0.471736237
+male,other,70+,post-grad,VA,1,1,0.471736237
+female,white,18-29,4-year college,VA,3,1,0.471736237
+female,white,18-29,hs,VA,4,2,0.471736237
+female,white,18-29,post-grad,VA,2,1,0.471736237
+female,white,18-29,some college,VA,5,1,0.471736237
+female,white,30-39,4-year college,VA,2,0,0.471736237
+female,white,30-39,hs,VA,4,2,0.471736237
+female,white,30-39,post-grad,VA,1,0,0.471736237
+female,white,30-39,some college,VA,2,1,0.471736237
+female,white,40-49,4-year college,VA,1,0,0.471736237
+female,white,40-49,hs,VA,2,0,0.471736237
+female,white,40-49,no hs,VA,1,1,0.471736237
+female,white,40-49,post-grad,VA,1,1,0.471736237
+female,white,40-49,some college,VA,4,2,0.471736237
+female,white,50-59,4-year college,VA,1,0,0.471736237
+female,white,50-59,hs,VA,1,1,0.471736237
+female,white,50-59,post-grad,VA,3,1,0.471736237
+female,white,60-69,4-year college,VA,1,0,0.471736237
+female,white,60-69,hs,VA,4,2,0.471736237
+female,white,60-69,post-grad,VA,2,0,0.471736237
+female,white,60-69,some college,VA,1,0,0.471736237
+female,white,70+,4-year college,VA,1,0,0.471736237
+female,white,70+,hs,VA,2,2,0.471736237
+female,white,70+,post-grad,VA,2,2,0.471736237
+female,white,70+,some college,VA,2,0,0.471736237
+male,white,18-29,4-year college,VA,2,1,0.471736237
+male,white,18-29,post-grad,VA,1,0,0.471736237
+male,white,18-29,some college,VA,4,3,0.471736237
+male,white,30-39,4-year college,VA,2,0,0.471736237
+male,white,30-39,hs,VA,1,0,0.471736237
+male,white,30-39,post-grad,VA,2,0,0.471736237
+male,white,30-39,some college,VA,4,2,0.471736237
+male,white,40-49,4-year college,VA,3,1,0.471736237
+male,white,40-49,hs,VA,2,0,0.471736237
+male,white,40-49,post-grad,VA,1,0,0.471736237
+male,white,40-49,some college,VA,1,0,0.471736237
+male,white,50-59,4-year college,VA,5,3,0.471736237
+male,white,50-59,hs,VA,1,1,0.471736237
+male,white,50-59,post-grad,VA,3,2,0.471736237
+male,white,50-59,some college,VA,3,2,0.471736237
+male,white,60-69,4-year college,VA,3,3,0.471736237
+male,white,60-69,hs,VA,2,2,0.471736237
+male,white,60-69,post-grad,VA,2,1,0.471736237
+male,white,60-69,some college,VA,5,2,0.471736237
+male,white,70+,4-year college,VA,2,2,0.471736237
+male,white,70+,hs,VA,2,1,0.471736237
+male,white,70+,post-grad,VA,3,2,0.471736237
+male,white,70+,some college,VA,1,1,0.471736237
+female,other,18-29,4-year college,VT,1,0,0.348135737
+female,white,18-29,some college,VT,1,0,0.348135737
+female,white,30-39,post-grad,VT,1,0,0.348135737
+female,white,50-59,some college,VT,1,1,0.348135737
+female,white,60-69,some college,VT,1,0,0.348135737
+female,white,70+,4-year college,VT,1,0,0.348135737
+male,white,18-29,hs,VT,1,1,0.348135737
+male,white,50-59,post-grad,VT,1,0,0.348135737
+male,white,70+,some college,VT,1,1,0.348135737
+male,black,40-49,post-grad,WA,1,0,0.412130688
+male,black,50-59,4-year college,WA,1,1,0.412130688
+female,other,18-29,4-year college,WA,1,0,0.412130688
+female,other,18-29,hs,WA,1,0,0.412130688
+female,other,18-29,post-grad,WA,2,0,0.412130688
+female,other,18-29,some college,WA,4,1,0.412130688
+female,other,30-39,4-year college,WA,2,1,0.412130688
+female,other,30-39,hs,WA,1,0,0.412130688
+female,other,30-39,some college,WA,2,0,0.412130688
+female,other,50-59,post-grad,WA,2,1,0.412130688
+male,other,18-29,some college,WA,1,0,0.412130688
+male,other,30-39,some college,WA,2,1,0.412130688
+male,other,40-49,hs,WA,1,0,0.412130688
+male,other,40-49,post-grad,WA,2,0,0.412130688
+male,other,40-49,some college,WA,1,1,0.412130688
+male,other,50-59,4-year college,WA,2,1,0.412130688
+male,other,50-59,some college,WA,1,1,0.412130688
+male,other,60-69,post-grad,WA,1,0,0.412130688
+male,other,70+,some college,WA,1,0,0.412130688
+female,white,18-29,4-year college,WA,2,0,0.412130688
+female,white,18-29,hs,WA,1,0,0.412130688
+female,white,18-29,no hs,WA,2,0,0.412130688
+female,white,30-39,4-year college,WA,5,1,0.412130688
+female,white,30-39,hs,WA,3,1,0.412130688
+female,white,30-39,post-grad,WA,3,0,0.412130688
+female,white,30-39,some college,WA,2,1,0.412130688
+female,white,40-49,4-year college,WA,2,1,0.412130688
+female,white,40-49,hs,WA,2,0,0.412130688
+female,white,40-49,post-grad,WA,1,0,0.412130688
+female,white,40-49,some college,WA,2,1,0.412130688
+female,white,50-59,hs,WA,1,1,0.412130688
+female,white,50-59,post-grad,WA,2,0,0.412130688
+female,white,50-59,some college,WA,4,1,0.412130688
+female,white,60-69,4-year college,WA,1,0,0.412130688
+female,white,60-69,hs,WA,2,0,0.412130688
+female,white,60-69,no hs,WA,1,0,0.412130688
+female,white,60-69,some college,WA,3,2,0.412130688
+female,white,70+,4-year college,WA,2,0,0.412130688
+female,white,70+,hs,WA,6,3,0.412130688
+female,white,70+,post-grad,WA,1,0,0.412130688
+female,white,70+,some college,WA,5,5,0.412130688
+male,white,18-29,hs,WA,5,1,0.412130688
+male,white,30-39,4-year college,WA,2,1,0.412130688
+male,white,30-39,hs,WA,2,0,0.412130688
+male,white,30-39,post-grad,WA,2,2,0.412130688
+male,white,30-39,some college,WA,1,1,0.412130688
+male,white,40-49,4-year college,WA,2,1,0.412130688
+male,white,40-49,hs,WA,2,2,0.412130688
+male,white,40-49,no hs,WA,1,1,0.412130688
+male,white,40-49,post-grad,WA,3,0,0.412130688
+male,white,50-59,4-year college,WA,3,1,0.412130688
+male,white,50-59,hs,WA,2,0,0.412130688
+male,white,50-59,post-grad,WA,1,1,0.412130688
+male,white,50-59,some college,WA,3,0,0.412130688
+male,white,60-69,4-year college,WA,3,2,0.412130688
+male,white,60-69,hs,WA,1,0,0.412130688
+male,white,60-69,post-grad,WA,1,0,0.412130688
+male,white,60-69,some college,WA,3,3,0.412130688
+male,white,70+,4-year college,WA,4,0,0.412130688
+male,white,70+,hs,WA,1,0,0.412130688
+male,white,70+,post-grad,WA,5,3,0.412130688
+male,white,70+,some college,WA,3,1,0.412130688
+female,black,50-59,some college,WI,1,0,0.50407989
+female,black,70+,post-grad,WI,1,0,0.50407989
+female,other,18-29,4-year college,WI,2,0,0.50407989
+female,other,18-29,some college,WI,1,0,0.50407989
+female,other,30-39,4-year college,WI,1,1,0.50407989
+female,other,30-39,post-grad,WI,1,0,0.50407989
+female,other,30-39,some college,WI,1,0,0.50407989
+male,other,18-29,hs,WI,1,1,0.50407989
+male,other,18-29,some college,WI,1,0,0.50407989
+male,other,30-39,hs,WI,1,1,0.50407989
+male,other,40-49,4-year college,WI,1,0,0.50407989
+female,white,18-29,4-year college,WI,5,0,0.50407989
+female,white,18-29,hs,WI,3,3,0.50407989
+female,white,18-29,post-grad,WI,1,0,0.50407989
+female,white,18-29,some college,WI,7,1,0.50407989
+female,white,30-39,4-year college,WI,2,0,0.50407989
+female,white,30-39,hs,WI,5,2,0.50407989
+female,white,30-39,post-grad,WI,1,0,0.50407989
+female,white,30-39,some college,WI,1,0,0.50407989
+female,white,40-49,4-year college,WI,3,1,0.50407989
+female,white,40-49,hs,WI,2,0,0.50407989
+female,white,50-59,4-year college,WI,1,1,0.50407989
+female,white,50-59,hs,WI,5,3,0.50407989
+female,white,50-59,some college,WI,8,2,0.50407989
+female,white,60-69,hs,WI,6,3,0.50407989
+female,white,60-69,some college,WI,4,1,0.50407989
+female,white,70+,hs,WI,4,3,0.50407989
+female,white,70+,some college,WI,2,0,0.50407989
+male,white,18-29,4-year college,WI,1,0,0.50407989
+male,white,18-29,hs,WI,1,1,0.50407989
+male,white,18-29,some college,WI,1,0,0.50407989
+male,white,30-39,4-year college,WI,4,2,0.50407989
+male,white,30-39,some college,WI,2,0,0.50407989
+male,white,40-49,hs,WI,1,1,0.50407989
+male,white,40-49,post-grad,WI,1,0,0.50407989
+male,white,40-49,some college,WI,3,1,0.50407989
+male,white,50-59,4-year college,WI,2,1,0.50407989
+male,white,50-59,post-grad,WI,2,1,0.50407989
+male,white,50-59,some college,WI,2,1,0.50407989
+male,white,60-69,4-year college,WI,1,1,0.50407989
+male,white,60-69,hs,WI,2,0,0.50407989
+male,white,60-69,post-grad,WI,2,1,0.50407989
+male,white,70+,4-year college,WI,1,0,0.50407989
+male,white,70+,hs,WI,3,2,0.50407989
+male,white,70+,post-grad,WI,2,0,0.50407989
+male,white,70+,some college,WI,1,1,0.50407989
+female,black,50-59,post-grad,WV,1,0,0.721610523
+female,black,50-59,some college,WV,1,0,0.721610523
+female,other,50-59,some college,WV,1,0,0.721610523
+male,other,40-49,some college,WV,2,2,0.721610523
+male,other,60-69,4-year college,WV,1,1,0.721610523
+female,white,18-29,4-year college,WV,1,1,0.721610523
+female,white,18-29,hs,WV,4,1,0.721610523
+female,white,18-29,no hs,WV,1,1,0.721610523
+female,white,18-29,post-grad,WV,1,0,0.721610523
+female,white,18-29,some college,WV,3,1,0.721610523
+female,white,30-39,hs,WV,1,1,0.721610523
+female,white,40-49,hs,WV,1,1,0.721610523
+female,white,40-49,some college,WV,1,0,0.721610523
+female,white,50-59,4-year college,WV,1,0,0.721610523
+female,white,50-59,hs,WV,2,2,0.721610523
+female,white,50-59,post-grad,WV,1,0,0.721610523
+female,white,60-69,hs,WV,2,1,0.721610523
+female,white,60-69,no hs,WV,1,0,0.721610523
+female,white,60-69,some college,WV,1,1,0.721610523
+female,white,70+,hs,WV,1,0,0.721610523
+female,white,70+,some college,WV,2,0,0.721610523
+male,white,18-29,4-year college,WV,1,1,0.721610523
+male,white,30-39,hs,WV,2,0,0.721610523
+male,white,30-39,some college,WV,1,1,0.721610523
+male,white,50-59,hs,WV,2,2,0.721610523
+male,white,50-59,post-grad,WV,1,1,0.721610523
+male,white,50-59,some college,WV,1,1,0.721610523
+male,white,60-69,hs,WV,2,2,0.721610523
+male,white,60-69,some college,WV,1,1,0.721610523
+male,white,70+,post-grad,WV,1,1,0.721610523
+male,white,70+,some college,WV,1,1,0.721610523
+female,other,18-29,hs,WY,1,0,0.757053196
+male,other,50-59,some college,WY,1,1,0.757053196
+female,white,30-39,hs,WY,1,1,0.757053196
+female,white,40-49,4-year college,WY,1,1,0.757053196
+female,white,40-49,no hs,WY,1,1,0.757053196
+female,white,40-49,some college,WY,2,1,0.757053196
+female,white,50-59,4-year college,WY,1,0,0.757053196
+female,white,50-59,some college,WY,1,0,0.757053196
+female,white,60-69,4-year college,WY,1,1,0.757053196
+male,white,40-49,post-grad,WY,1,1,0.757053196
+male,white,50-59,hs,WY,1,1,0.757053196
+male,white,60-69,4-year college,WY,1,0,0.757053196

--- a/inst/extdata/CES_data_individual.csv
+++ b/inst/extdata/CES_data_individual.csv
@@ -1,5001 +1,5001 @@
-sex,race,age,edu,state,repvote,region,response
-male,white,38,some college,NY,0.382275815,2,0
-female,white,65,hs,KY,0.65670629,3,0
-male,white,61,hs,GA,0.526611726,3,0
-male,white,39,4-year college,NE,0.635476741,1,1
-male,white,36,some college,WI,0.50407989,1,0
-female,white,36,hs,WI,0.50407989,1,1
-male,other,85,4-year college,SC,0.574602564,3,1
-female,white,73,post-grad,FL,0.506188355,3,0
-male,white,58,4-year college,KY,0.65670629,3,0
-male,white,97,hs,FL,0.506188355,3,1
-female,black,21,hs,MA,0.353487213,2,1
-male,white,37,some college,NJ,0.427158099,2,0
-female,black,56,some college,CA,0.338717892,4,0
-female,other,38,hs,CA,0.338717892,4,0
-female,white,72,hs,IL,0.409799486,1,0
-female,black,30,some college,LA,0.601716772,3,1
-male,white,18,post-grad,TX,0.547132256,3,0
-male,white,67,some college,OH,0.542676846,1,1
-male,white,52,some college,OH,0.542676846,1,1
-male,white,67,post-grad,CA,0.338717892,4,1
-female,other,49,hs,UT,0.623836582,4,1
-female,white,19,4-year college,IL,0.409799486,1,0
-male,white,41,4-year college,MN,0.491681431,1,1
-male,white,36,post-grad,NY,0.382275815,2,0
-male,white,64,some college,AZ,0.518900234,4,1
-male,white,66,some college,GA,0.526611726,3,1
-female,other,28,some college,FL,0.506188355,3,1
-female,white,49,some college,IA,0.550635478,1,1
-female,white,59,some college,NC,0.519037458,3,0
-female,white,55,some college,AZ,0.518900234,4,1
-female,other,36,no hs,FL,0.506188355,3,0
-male,white,43,hs,NY,0.382275815,2,0
-female,other,54,post-grad,FL,0.506188355,3,0
-female,white,42,hs,AR,0.642851377,3,1
-male,white,90,post-grad,CA,0.338717892,4,0
-female,white,77,hs,IL,0.409799486,1,0
-female,white,77,some college,CA,0.338717892,4,1
-male,white,98,hs,VA,0.471736237,3,1
-female,white,53,post-grad,NH,0.498029716,2,0
-female,white,41,some college,IL,0.409799486,1,0
-male,white,59,4-year college,WA,0.412130688,4,1
-female,white,34,4-year college,SD,0.659718581,1,1
-male,white,30,post-grad,OH,0.542676846,1,0
-female,white,35,4-year college,NY,0.382275815,2,1
-female,black,56,4-year college,NC,0.519037458,3,0
-male,other,20,no hs,NY,0.382275815,2,0
-female,white,79,4-year college,AZ,0.518900234,4,0
-female,white,52,post-grad,NC,0.519037458,3,0
-female,black,26,hs,PA,0.503755358,2,0
-female,white,20,hs,SC,0.574602564,3,1
-male,white,50,4-year college,MO,0.59818561,1,1
-female,white,69,hs,MN,0.491681431,1,0
-male,white,70,some college,OK,0.693047372,3,0
-female,white,53,hs,PA,0.503755358,2,0
-female,white,57,some college,NY,0.382275815,2,0
-female,white,27,hs,CA,0.338717892,4,0
-female,white,48,some college,NC,0.519037458,3,0
-female,white,28,4-year college,VA,0.471736237,3,0
-female,white,19,hs,NY,0.382275815,2,0
-female,black,23,hs,SC,0.574602564,3,1
-male,white,88,some college,OK,0.693047372,3,1
-male,white,97,some college,CA,0.338717892,4,1
-female,white,57,hs,NJ,0.427158099,2,0
-female,white,26,4-year college,TN,0.63624343,3,1
-female,white,56,some college,FL,0.506188355,3,1
-male,white,50,hs,PA,0.503755358,2,0
-male,white,37,post-grad,MA,0.353487213,2,1
-female,white,91,hs,WA,0.412130688,4,0
-male,white,66,hs,VA,0.471736237,3,1
-male,white,69,4-year college,MD,0.359837503,3,0
-female,white,36,some college,IN,0.601173095,1,0
-female,white,60,hs,IN,0.601173095,1,0
-male,other,56,4-year college,AK,0.583856547,4,1
-male,white,34,hs,IL,0.409799486,1,0
-female,other,37,hs,AZ,0.518900234,4,1
-male,white,52,no hs,KY,0.65670629,3,0
-female,white,65,hs,CA,0.338717892,4,1
-female,white,48,hs,CA,0.338717892,4,0
-female,white,63,4-year college,NE,0.635476741,1,0
-male,white,46,post-grad,DE,0.440013786,3,1
-female,other,25,4-year college,CA,0.338717892,4,0
-male,white,62,hs,NC,0.519037458,3,0
-female,other,23,some college,WA,0.412130688,4,0
-male,white,44,4-year college,UT,0.623836582,4,0
-male,other,55,post-grad,TX,0.547132256,3,1
-male,other,19,some college,CA,0.338717892,4,1
-female,white,36,some college,FL,0.506188355,3,1
-female,white,54,post-grad,IL,0.409799486,1,1
-female,black,37,some college,IL,0.409799486,1,0
-male,white,33,post-grad,NY,0.382275815,2,0
-female,black,44,some college,CA,0.338717892,4,0
-female,white,38,4-year college,MO,0.59818561,1,0
-male,white,65,post-grad,FL,0.506188355,3,1
-female,white,56,hs,IL,0.409799486,1,0
-male,white,61,some college,IL,0.409799486,1,1
-female,white,60,no hs,AL,0.643741436,3,0
-male,white,31,some college,CA,0.338717892,4,0
-male,white,19,hs,IL,0.409799486,1,1
-female,other,78,hs,VA,0.471736237,3,1
-female,white,30,4-year college,FL,0.506188355,3,0
-male,white,18,4-year college,PA,0.503755358,2,0
-male,black,49,4-year college,PA,0.503755358,2,0
-female,white,45,hs,VA,0.471736237,3,0
-male,other,29,some college,WI,0.50407989,1,0
-female,white,30,4-year college,NJ,0.427158099,2,1
-male,other,41,post-grad,NJ,0.427158099,2,0
-female,other,30,some college,WI,0.50407989,1,0
-female,other,31,no hs,IL,0.409799486,1,0
-female,white,53,some college,GA,0.526611726,3,1
-female,white,68,4-year college,CT,0.428584525,2,1
-male,white,50,hs,MO,0.59818561,1,1
-female,black,42,some college,MD,0.359837503,3,0
-male,white,65,no hs,NY,0.382275815,2,1
-female,white,52,some college,FL,0.506188355,3,1
-female,white,91,some college,GA,0.526611726,3,1
-female,white,18,hs,TX,0.547132256,3,1
-female,white,33,post-grad,OH,0.542676846,1,1
-male,other,37,4-year college,FL,0.506188355,3,0
-female,other,26,some college,CA,0.338717892,4,0
-female,white,55,4-year college,AZ,0.518900234,4,0
-female,white,41,hs,TX,0.547132256,3,0
-female,other,18,some college,WA,0.412130688,4,0
-female,white,64,hs,MO,0.59818561,1,1
-female,black,100,4-year college,NY,0.382275815,2,0
-female,white,89,hs,WA,0.412130688,4,1
-female,white,24,some college,WI,0.50407989,1,0
-female,white,35,hs,IL,0.409799486,1,0
-female,white,50,hs,LA,0.601716772,3,0
-male,white,46,hs,NY,0.382275815,2,0
-female,other,23,4-year college,AZ,0.518900234,4,0
-male,white,62,post-grad,TX,0.547132256,3,0
-female,white,79,hs,KS,0.611114703,1,0
-female,white,18,some college,WI,0.50407989,1,0
-female,white,60,hs,TX,0.547132256,3,0
-female,white,23,some college,TN,0.63624343,3,1
-male,white,35,hs,SD,0.659718581,1,1
-female,white,98,hs,PA,0.503755358,2,0
-male,other,22,some college,TX,0.547132256,3,0
-male,white,32,some college,WV,0.721610523,3,1
-male,white,66,hs,IL,0.409799486,1,1
-male,white,86,4-year college,GA,0.526611726,3,1
-male,white,36,4-year college,MI,0.501176682,1,0
-female,white,57,some college,ME,0.484032089,2,1
-male,white,68,some college,PA,0.503755358,2,0
-female,white,60,some college,FL,0.506188355,3,0
-female,white,88,hs,OK,0.693047372,3,0
-female,white,31,post-grad,CA,0.338717892,4,0
-male,white,68,post-grad,VA,0.471736237,3,0
-female,white,20,hs,IN,0.601173095,1,0
-female,white,64,some college,FL,0.506188355,3,0
-male,white,58,hs,OK,0.693047372,3,0
-male,black,60,4-year college,NY,0.382275815,2,0
-male,white,83,post-grad,NC,0.519037458,3,0
-male,white,38,no hs,AR,0.642851377,3,0
-female,white,19,hs,MI,0.501176682,1,0
-female,white,26,no hs,KS,0.611114703,1,0
-female,other,28,some college,IN,0.601173095,1,0
-male,white,30,some college,TN,0.63624343,3,1
-female,black,39,post-grad,NJ,0.427158099,2,0
-male,other,29,some college,TX,0.547132256,3,1
-male,white,84,hs,NC,0.519037458,3,1
-male,white,99,post-grad,NY,0.382275815,2,1
-male,white,51,some college,MN,0.491681431,1,1
-male,white,70,4-year college,VA,0.471736237,3,1
-female,white,47,some college,TX,0.547132256,3,1
-female,white,27,4-year college,TX,0.547132256,3,0
-male,white,65,post-grad,KY,0.65670629,3,0
-male,white,54,some college,TX,0.547132256,3,1
-female,white,67,post-grad,VA,0.471736237,3,0
-female,white,64,some college,NE,0.635476741,1,1
-female,white,59,hs,MN,0.491681431,1,1
-male,white,61,4-year college,NJ,0.427158099,2,1
-male,white,67,some college,NC,0.519037458,3,1
-male,white,58,some college,DE,0.440013786,3,1
-female,white,51,hs,OH,0.542676846,1,0
-female,black,34,4-year college,OH,0.542676846,1,1
-female,white,95,no hs,KY,0.65670629,3,1
-female,white,90,some college,SC,0.574602564,3,0
-male,other,66,hs,NM,0.453492051,4,0
-male,white,85,some college,IN,0.601173095,1,0
-male,white,91,4-year college,WA,0.412130688,4,0
-female,white,18,some college,VA,0.471736237,3,0
-female,white,65,some college,MO,0.59818561,1,1
-female,white,60,some college,MI,0.501176682,1,0
-female,other,29,some college,SC,0.574602564,3,1
-male,white,29,some college,TN,0.63624343,3,0
-male,other,27,some college,TX,0.547132256,3,0
-female,other,31,4-year college,WI,0.50407989,1,1
-female,white,68,hs,OH,0.542676846,1,1
-female,other,26,some college,TX,0.547132256,3,0
-male,white,92,some college,FL,0.506188355,3,1
-male,white,54,some college,NV,0.487062906,4,1
-female,white,57,some college,OH,0.542676846,1,1
-female,white,28,4-year college,NY,0.382275815,2,1
-female,white,31,no hs,IN,0.601173095,1,1
-female,white,54,some college,NY,0.382275815,2,0
-male,black,44,post-grad,WA,0.412130688,4,0
-female,white,38,4-year college,TN,0.63624343,3,0
-female,white,80,post-grad,TX,0.547132256,3,0
-male,other,18,some college,TX,0.547132256,3,1
-female,other,19,4-year college,NY,0.382275815,2,0
-male,black,58,no hs,AZ,0.518900234,4,0
-female,white,30,4-year college,TX,0.547132256,3,0
-female,other,18,some college,TX,0.547132256,3,1
-female,white,24,some college,AR,0.642851377,3,1
-male,white,93,4-year college,CT,0.428584525,2,0
-female,other,27,4-year college,GA,0.526611726,3,0
-female,white,28,some college,OH,0.542676846,1,0
-male,white,64,4-year college,CA,0.338717892,4,0
-male,white,48,4-year college,ID,0.683101767,4,1
-female,white,63,4-year college,PA,0.503755358,2,1
-female,white,19,4-year college,PA,0.503755358,2,0
-female,white,22,4-year college,RI,0.416892959,2,0
-female,white,24,hs,OH,0.542676846,1,0
-female,white,56,4-year college,NC,0.519037458,3,0
-female,white,56,some college,OH,0.542676846,1,1
-male,white,57,no hs,GA,0.526611726,3,1
-male,white,30,4-year college,OH,0.542676846,1,1
-male,white,52,some college,FL,0.506188355,3,0
-female,black,21,some college,PA,0.503755358,2,0
-female,white,51,post-grad,OH,0.542676846,1,0
-female,white,20,some college,LA,0.601716772,3,0
-female,other,49,4-year college,CA,0.338717892,4,1
-male,white,35,post-grad,KY,0.65670629,3,0
-male,black,20,hs,NJ,0.427158099,2,1
-male,white,55,4-year college,TN,0.63624343,3,1
-male,black,59,hs,UT,0.623836582,4,0
-female,white,89,hs,TN,0.63624343,3,1
-female,other,39,hs,MA,0.353487213,2,0
-female,white,59,post-grad,GA,0.526611726,3,1
-female,white,65,hs,GA,0.526611726,3,1
-female,white,24,hs,FL,0.506188355,3,0
-male,white,41,hs,IL,0.409799486,1,0
-male,other,98,post-grad,FL,0.506188355,3,1
-male,white,18,hs,NJ,0.427158099,2,1
-male,white,27,4-year college,AZ,0.518900234,4,1
-female,white,69,hs,GA,0.526611726,3,1
-male,white,64,post-grad,WI,0.50407989,1,0
-male,white,43,post-grad,FL,0.506188355,3,1
-female,other,53,4-year college,TX,0.547132256,3,0
-male,white,37,4-year college,WA,0.412130688,4,1
-female,white,81,hs,PA,0.503755358,2,1
-female,white,29,some college,LA,0.601716772,3,0
-female,white,51,post-grad,PA,0.503755358,2,1
-female,other,30,4-year college,NM,0.453492051,4,0
-male,other,57,no hs,NY,0.382275815,2,1
-male,white,63,post-grad,CA,0.338717892,4,0
-female,white,69,hs,CT,0.428584525,2,0
-male,white,65,hs,MI,0.501176682,1,1
-female,black,33,4-year college,OH,0.542676846,1,1
-female,white,66,post-grad,CA,0.338717892,4,0
-female,other,35,some college,FL,0.506188355,3,0
-female,white,43,hs,OH,0.542676846,1,0
-male,white,56,post-grad,NJ,0.427158099,2,1
-female,white,100,hs,FL,0.506188355,3,1
-male,white,53,4-year college,VA,0.471736237,3,0
-female,white,40,some college,TN,0.63624343,3,1
-female,other,27,hs,CA,0.338717892,4,0
-female,white,51,hs,OH,0.542676846,1,1
-female,white,51,no hs,IA,0.550635478,1,0
-male,white,57,no hs,TN,0.63624343,3,0
-female,white,30,hs,CA,0.338717892,4,1
-male,white,45,post-grad,KY,0.65670629,3,0
-female,white,63,4-year college,WY,0.757053196,4,1
-female,white,25,hs,KY,0.65670629,3,1
-female,white,21,hs,WV,0.721610523,3,0
-female,white,62,hs,IA,0.550635478,1,0
-male,white,32,hs,CA,0.338717892,4,1
-female,white,23,hs,PA,0.503755358,2,1
-male,white,53,some college,VA,0.471736237,3,0
-male,white,18,4-year college,IA,0.550635478,1,0
-male,white,42,hs,NC,0.519037458,3,0
-male,white,59,some college,CA,0.338717892,4,1
-male,black,38,some college,NV,0.487062906,4,1
-female,white,45,hs,AZ,0.518900234,4,1
-male,white,42,4-year college,CA,0.338717892,4,0
-male,white,46,hs,PA,0.503755358,2,1
-female,white,35,hs,KS,0.611114703,1,1
-female,white,19,some college,NY,0.382275815,2,0
-male,other,21,4-year college,OR,0.438441611,4,0
-male,white,41,some college,TN,0.63624343,3,0
-female,white,77,hs,MO,0.59818561,1,0
-male,white,46,some college,TX,0.547132256,3,0
-female,white,65,hs,NV,0.487062906,4,1
-male,white,79,4-year college,FL,0.506188355,3,1
-female,black,33,some college,GA,0.526611726,3,1
-female,white,28,some college,CA,0.338717892,4,1
-female,white,79,hs,MN,0.491681431,1,1
-male,black,23,some college,MO,0.59818561,1,0
-male,white,33,post-grad,MO,0.59818561,1,0
-male,white,28,4-year college,NC,0.519037458,3,0
-female,black,22,some college,FL,0.506188355,3,0
-female,white,25,hs,NC,0.519037458,3,1
-female,white,61,hs,GA,0.526611726,3,0
-female,black,54,some college,CA,0.338717892,4,1
-male,other,26,no hs,AZ,0.518900234,4,0
-female,white,63,hs,NC,0.519037458,3,0
-female,white,18,some college,MO,0.59818561,1,1
-male,white,35,4-year college,AL,0.643741436,3,0
-female,white,64,hs,MO,0.59818561,1,0
-female,white,69,4-year college,WA,0.412130688,4,0
-male,black,52,4-year college,FL,0.506188355,3,0
-male,white,64,4-year college,CA,0.338717892,4,0
-female,white,49,no hs,AL,0.643741436,3,1
-male,white,69,4-year college,WA,0.412130688,4,0
-male,white,29,hs,CA,0.338717892,4,0
-female,white,29,4-year college,NY,0.382275815,2,1
-female,white,49,some college,CO,0.473166666,4,0
-female,white,25,4-year college,PA,0.503755358,2,0
-female,white,21,post-grad,CA,0.338717892,4,0
-female,black,36,post-grad,NC,0.519037458,3,0
-male,white,36,4-year college,PA,0.503755358,2,1
-female,black,64,hs,KY,0.65670629,3,0
-male,white,53,some college,IL,0.409799486,1,1
-female,white,26,4-year college,IN,0.601173095,1,0
-female,white,52,post-grad,TX,0.547132256,3,1
-male,black,18,some college,NC,0.519037458,3,0
-male,white,78,hs,CA,0.338717892,4,0
-female,white,24,4-year college,NY,0.382275815,2,1
-female,white,54,hs,IN,0.601173095,1,0
-female,white,62,4-year college,AZ,0.518900234,4,0
-female,white,88,some college,CA,0.338717892,4,0
-female,white,42,4-year college,MO,0.59818561,1,1
-male,black,66,some college,LA,0.601716772,3,1
-female,white,57,hs,WA,0.412130688,4,1
-female,black,45,post-grad,CT,0.428584525,2,0
-male,other,47,some college,MI,0.501176682,1,0
-female,white,23,hs,AL,0.643741436,3,0
-female,black,24,some college,GA,0.526611726,3,0
-male,other,20,post-grad,IL,0.409799486,1,1
-male,black,30,some college,CA,0.338717892,4,0
-male,black,55,hs,NY,0.382275815,2,0
-female,white,64,4-year college,NJ,0.427158099,2,0
-male,white,47,some college,NJ,0.427158099,2,0
-male,other,20,4-year college,MI,0.501176682,1,0
-male,white,36,post-grad,NY,0.382275815,2,1
-male,white,35,4-year college,MN,0.491681431,1,0
-male,white,94,post-grad,WA,0.412130688,4,0
-female,white,57,hs,OH,0.542676846,1,1
-male,white,31,some college,CA,0.338717892,4,1
-female,white,19,hs,CA,0.338717892,4,1
-female,white,50,hs,AZ,0.518900234,4,0
-female,white,30,hs,WI,0.50407989,1,0
-female,other,24,no hs,MA,0.353487213,2,0
-female,white,94,hs,FL,0.506188355,3,1
-female,white,68,some college,PA,0.503755358,2,1
-female,white,29,some college,UT,0.623836582,4,1
-female,white,20,4-year college,VA,0.471736237,3,1
-male,other,51,4-year college,CA,0.338717892,4,0
-male,white,30,some college,PA,0.503755358,2,0
-male,white,93,post-grad,TN,0.63624343,3,1
-female,white,18,4-year college,IL,0.409799486,1,0
-female,white,66,4-year college,MA,0.353487213,2,0
-male,white,29,some college,IN,0.601173095,1,0
-female,black,39,no hs,GA,0.526611726,3,0
-female,white,51,hs,MN,0.491681431,1,0
-male,white,67,4-year college,FL,0.506188355,3,1
-female,white,34,some college,AL,0.643741436,3,1
-female,white,65,4-year college,CA,0.338717892,4,0
-female,black,52,some college,CA,0.338717892,4,1
-male,white,65,hs,WV,0.721610523,3,1
-male,white,75,post-grad,TX,0.547132256,3,1
-female,white,67,hs,NY,0.382275815,2,0
-female,white,28,some college,NY,0.382275815,2,0
-female,white,44,post-grad,GA,0.526611726,3,0
-female,other,29,4-year college,FL,0.506188355,3,1
-female,black,94,post-grad,NY,0.382275815,2,0
-male,white,67,4-year college,NV,0.487062906,4,1
-female,white,28,post-grad,CA,0.338717892,4,1
-female,white,67,hs,HI,0.325586625,4,1
-male,white,19,post-grad,KY,0.65670629,3,0
-female,white,42,some college,MI,0.501176682,1,0
-female,white,62,some college,CA,0.338717892,4,1
-male,white,52,4-year college,OH,0.542676846,1,0
-male,white,68,some college,CA,0.338717892,4,0
-male,white,39,post-grad,MA,0.353487213,2,0
-female,other,20,some college,WA,0.412130688,4,0
-female,white,50,some college,WI,0.50407989,1,0
-female,white,64,hs,PA,0.503755358,2,0
-female,black,41,4-year college,KS,0.611114703,1,0
-male,black,23,hs,NC,0.519037458,3,1
-male,white,30,hs,TX,0.547132256,3,1
-female,white,26,some college,IN,0.601173095,1,1
-female,white,60,4-year college,NC,0.519037458,3,0
-female,black,57,post-grad,NY,0.382275815,2,0
-male,white,51,post-grad,PA,0.503755358,2,0
-male,other,68,some college,FL,0.506188355,3,1
-male,white,28,hs,NY,0.382275815,2,0
-male,black,43,some college,GA,0.526611726,3,0
-female,white,62,no hs,CA,0.338717892,4,0
-female,other,28,some college,MN,0.491681431,1,0
-female,white,30,some college,MI,0.501176682,1,0
-female,black,60,hs,NC,0.519037458,3,0
-female,white,43,some college,OH,0.542676846,1,1
-female,white,62,some college,NC,0.519037458,3,0
-male,white,65,4-year college,UT,0.623836582,4,0
-female,white,36,post-grad,WA,0.412130688,4,0
-female,white,18,hs,PA,0.503755358,2,0
-female,white,22,4-year college,PA,0.503755358,2,0
-female,other,38,4-year college,CA,0.338717892,4,1
-male,white,38,4-year college,PA,0.503755358,2,1
-female,white,27,some college,MA,0.353487213,2,0
-male,white,56,hs,NV,0.487062906,4,0
-male,white,56,some college,CT,0.428584525,2,0
-female,white,26,4-year college,NY,0.382275815,2,0
-male,white,22,4-year college,MO,0.59818561,1,1
-female,white,65,4-year college,GA,0.526611726,3,0
-male,white,25,hs,WA,0.412130688,4,0
-female,white,19,no hs,IL,0.409799486,1,0
-female,white,94,4-year college,FL,0.506188355,3,1
-female,black,33,some college,FL,0.506188355,3,0
-female,other,67,hs,FL,0.506188355,3,1
-female,white,69,hs,MN,0.491681431,1,0
-female,other,39,hs,CA,0.338717892,4,0
-female,white,22,4-year college,MI,0.501176682,1,1
-female,white,56,post-grad,IL,0.409799486,1,0
-female,white,69,4-year college,NM,0.453492051,4,0
-male,other,32,some college,WA,0.412130688,4,0
-male,white,53,4-year college,MD,0.359837503,3,0
-female,black,19,no hs,CA,0.338717892,4,1
-female,white,71,hs,CA,0.338717892,4,0
-male,white,91,post-grad,NV,0.487062906,4,1
-male,white,49,post-grad,FL,0.506188355,3,0
-female,white,62,hs,MT,0.611096643,4,0
-female,other,52,hs,TX,0.547132256,3,0
-male,white,100,hs,VA,0.471736237,3,0
-male,white,82,some college,TN,0.63624343,3,1
-female,white,23,4-year college,WI,0.50407989,1,0
-female,white,62,some college,CT,0.428584525,2,0
-female,white,30,4-year college,OR,0.438441611,4,0
-male,white,18,hs,NJ,0.427158099,2,0
-male,white,46,hs,MO,0.59818561,1,0
-female,white,51,post-grad,PA,0.503755358,2,0
-male,white,56,4-year college,ID,0.683101767,4,0
-male,white,62,post-grad,IN,0.601173095,1,1
-male,white,20,some college,MD,0.359837503,3,0
-female,white,28,hs,PA,0.503755358,2,1
-female,white,89,some college,PA,0.503755358,2,0
-male,white,98,no hs,FL,0.506188355,3,1
-female,white,86,hs,WV,0.721610523,3,0
-female,other,33,4-year college,GA,0.526611726,3,1
-male,other,37,post-grad,CA,0.338717892,4,1
-male,other,68,post-grad,TX,0.547132256,3,1
-female,white,23,hs,TN,0.63624343,3,0
-female,white,43,no hs,KY,0.65670629,3,0
-female,white,96,some college,PA,0.503755358,2,0
-female,white,82,post-grad,MA,0.353487213,2,0
-male,other,45,some college,CA,0.338717892,4,1
-male,white,66,hs,TN,0.63624343,3,0
-female,white,31,some college,PA,0.503755358,2,1
-female,white,74,some college,AR,0.642851377,3,0
-male,white,34,some college,NC,0.519037458,3,0
-male,other,47,4-year college,CA,0.338717892,4,1
-male,white,64,4-year college,FL,0.506188355,3,1
-male,white,56,hs,FL,0.506188355,3,0
-female,other,25,4-year college,WI,0.50407989,1,0
-female,white,27,some college,LA,0.601716772,3,0
-male,white,55,hs,FL,0.506188355,3,0
-female,white,39,4-year college,PA,0.503755358,2,0
-female,white,20,some college,TX,0.547132256,3,0
-female,white,88,hs,TX,0.547132256,3,0
-male,white,98,post-grad,IA,0.550635478,1,0
-female,other,44,some college,CA,0.338717892,4,1
-female,white,49,hs,NJ,0.427158099,2,1
-female,white,28,hs,GA,0.526611726,3,1
-male,white,57,hs,PA,0.503755358,2,0
-male,white,69,some college,AZ,0.518900234,4,1
-female,white,46,some college,MT,0.611096643,4,1
-female,white,30,4-year college,WI,0.50407989,1,0
-male,white,87,hs,NY,0.382275815,2,0
-female,white,31,hs,TX,0.547132256,3,1
-male,white,94,4-year college,TX,0.547132256,3,1
-male,white,69,hs,GA,0.526611726,3,1
-female,white,27,4-year college,IL,0.409799486,1,0
-male,white,37,post-grad,MI,0.501176682,1,0
-female,white,22,4-year college,AR,0.642851377,3,0
-female,white,78,some college,AL,0.643741436,3,0
-male,white,67,4-year college,TX,0.547132256,3,1
-female,white,62,hs,WI,0.50407989,1,0
-female,other,46,4-year college,UT,0.623836582,4,1
-male,white,45,some college,NJ,0.427158099,2,1
-male,white,35,some college,PA,0.503755358,2,0
-female,other,28,4-year college,RI,0.416892959,2,0
-female,other,52,hs,CA,0.338717892,4,0
-female,other,29,4-year college,CA,0.338717892,4,0
-female,white,65,hs,MN,0.491681431,1,1
-female,black,49,4-year college,MD,0.359837503,3,1
-male,white,28,some college,NC,0.519037458,3,1
-female,white,32,hs,CA,0.338717892,4,0
-female,white,70,hs,RI,0.416892959,2,1
-male,white,50,some college,LA,0.601716772,3,1
-female,white,69,post-grad,SC,0.574602564,3,1
-female,white,64,hs,IA,0.550635478,1,0
-female,white,75,hs,WA,0.412130688,4,0
-male,black,65,some college,GA,0.526611726,3,0
-female,other,33,some college,CA,0.338717892,4,0
-female,white,29,some college,NJ,0.427158099,2,0
-female,white,62,hs,PA,0.503755358,2,1
-female,white,58,4-year college,NJ,0.427158099,2,0
-male,white,54,hs,SD,0.659718581,1,0
-male,white,39,post-grad,NJ,0.427158099,2,0
-female,black,38,hs,GA,0.526611726,3,1
-female,white,52,some college,PA,0.503755358,2,1
-male,other,58,4-year college,TX,0.547132256,3,1
-female,other,27,4-year college,FL,0.506188355,3,0
-male,other,62,hs,VA,0.471736237,3,1
-female,white,54,no hs,CA,0.338717892,4,1
-female,other,27,4-year college,MI,0.501176682,1,0
-female,white,53,some college,OK,0.693047372,3,1
-female,white,44,hs,IL,0.409799486,1,1
-female,white,39,4-year college,CT,0.428584525,2,0
-female,white,84,no hs,MA,0.353487213,2,1
-female,white,29,4-year college,WV,0.721610523,3,1
-male,white,42,4-year college,OK,0.693047372,3,0
-female,white,28,some college,IL,0.409799486,1,1
-female,other,40,some college,NY,0.382275815,2,0
-female,white,21,hs,OK,0.693047372,3,1
-female,other,21,4-year college,CA,0.338717892,4,0
-male,white,52,4-year college,CO,0.473166666,4,1
-male,other,35,4-year college,CA,0.338717892,4,0
-male,white,58,some college,SC,0.574602564,3,1
-female,white,62,some college,PA,0.503755358,2,0
-male,other,18,some college,CA,0.338717892,4,1
-male,white,46,4-year college,NJ,0.427158099,2,0
-male,white,83,post-grad,CT,0.428584525,2,0
-female,white,37,some college,TX,0.547132256,3,0
-female,white,53,4-year college,NC,0.519037458,3,1
-male,white,52,some college,TX,0.547132256,3,1
-male,black,49,some college,NY,0.382275815,2,0
-male,white,57,4-year college,VA,0.471736237,3,1
-male,other,48,hs,WA,0.412130688,4,0
-female,black,34,no hs,KS,0.611114703,1,1
-female,white,55,post-grad,DE,0.440013786,3,1
-female,white,26,some college,FL,0.506188355,3,0
-female,white,25,post-grad,CO,0.473166666,4,0
-male,black,58,4-year college,CO,0.473166666,4,0
-female,white,72,some college,AL,0.643741436,3,1
-female,white,58,4-year college,LA,0.601716772,3,1
-female,white,91,4-year college,FL,0.506188355,3,0
-female,other,29,hs,TX,0.547132256,3,0
-female,white,58,hs,CA,0.338717892,4,1
-female,white,62,no hs,WV,0.721610523,3,0
-female,white,56,some college,FL,0.506188355,3,1
-male,white,69,some college,OH,0.542676846,1,0
-female,other,39,4-year college,CA,0.338717892,4,0
-female,white,90,hs,GA,0.526611726,3,1
-female,white,85,post-grad,NC,0.519037458,3,0
-female,white,54,4-year college,WI,0.50407989,1,1
-female,white,24,some college,TX,0.547132256,3,0
-male,black,68,hs,KY,0.65670629,3,0
-female,white,36,4-year college,VA,0.471736237,3,0
-male,other,44,post-grad,NJ,0.427158099,2,1
-male,white,52,post-grad,IN,0.601173095,1,0
-male,white,64,4-year college,VA,0.471736237,3,1
-female,white,31,4-year college,LA,0.601716772,3,1
-male,white,40,post-grad,MD,0.359837503,3,0
-female,white,77,no hs,IA,0.550635478,1,1
-female,white,59,some college,GA,0.526611726,3,1
-male,white,63,4-year college,FL,0.506188355,3,0
-female,white,64,some college,VA,0.471736237,3,0
-male,white,20,hs,GA,0.526611726,3,1
-male,white,96,4-year college,MI,0.501176682,1,0
-female,black,52,some college,OK,0.693047372,3,0
-male,white,63,4-year college,CO,0.473166666,4,0
-male,white,87,post-grad,AL,0.643741436,3,1
-female,black,53,some college,PA,0.503755358,2,1
-female,white,18,some college,FL,0.506188355,3,1
-male,white,47,some college,AL,0.643741436,3,1
-male,white,40,some college,NC,0.519037458,3,0
-female,white,92,some college,TX,0.547132256,3,0
-female,white,34,post-grad,MO,0.59818561,1,1
-female,white,55,4-year college,GA,0.526611726,3,1
-female,white,65,post-grad,MD,0.359837503,3,1
-female,other,36,no hs,GA,0.526611726,3,1
-male,white,93,post-grad,IN,0.601173095,1,1
-female,white,42,some college,TN,0.63624343,3,1
-female,white,32,some college,AZ,0.518900234,4,0
-female,black,58,some college,PA,0.503755358,2,0
-female,white,50,post-grad,IN,0.601173095,1,0
-female,other,21,hs,FL,0.506188355,3,1
-male,white,39,post-grad,VA,0.471736237,3,0
-female,black,34,some college,IN,0.601173095,1,0
-male,white,50,some college,UT,0.623836582,4,0
-female,white,57,hs,CA,0.338717892,4,1
-female,white,24,hs,MD,0.359837503,3,0
-female,white,59,4-year college,IN,0.601173095,1,0
-female,white,66,post-grad,CA,0.338717892,4,0
-female,white,51,post-grad,NJ,0.427158099,2,1
-female,white,42,some college,IN,0.601173095,1,0
-female,other,28,some college,NV,0.487062906,4,1
-male,white,57,post-grad,TN,0.63624343,3,1
-male,white,62,hs,MA,0.353487213,2,1
-female,white,81,post-grad,FL,0.506188355,3,0
-male,white,34,post-grad,FL,0.506188355,3,1
-male,white,59,post-grad,TX,0.547132256,3,0
-female,white,89,post-grad,MO,0.59818561,1,0
-female,black,64,hs,VA,0.471736237,3,1
-female,white,25,4-year college,IN,0.601173095,1,1
-female,white,52,post-grad,NY,0.382275815,2,0
-female,white,21,4-year college,OH,0.542676846,1,0
-male,white,52,4-year college,SC,0.574602564,3,0
-female,white,80,hs,KS,0.611114703,1,0
-female,white,60,hs,CO,0.473166666,4,0
-female,black,30,some college,CA,0.338717892,4,0
-female,white,57,some college,TX,0.547132256,3,1
-male,white,62,post-grad,WA,0.412130688,4,0
-male,white,37,4-year college,MD,0.359837503,3,1
-female,other,34,4-year college,FL,0.506188355,3,1
-male,white,61,4-year college,AZ,0.518900234,4,0
-female,white,24,some college,AL,0.643741436,3,0
-female,other,22,some college,MN,0.491681431,1,0
-female,white,22,post-grad,PA,0.503755358,2,1
-male,white,72,some college,CA,0.338717892,4,0
-male,white,22,some college,UT,0.623836582,4,0
-female,black,19,hs,TX,0.547132256,3,0
-male,white,47,4-year college,NJ,0.427158099,2,0
-female,white,65,some college,KY,0.65670629,3,1
-male,white,21,4-year college,NY,0.382275815,2,1
-female,white,61,some college,MI,0.501176682,1,0
-female,white,58,4-year college,TX,0.547132256,3,0
-female,black,36,4-year college,NC,0.519037458,3,0
-female,white,31,some college,ME,0.484032089,2,0
-male,white,85,4-year college,TX,0.547132256,3,1
-female,other,37,some college,MO,0.59818561,1,0
-male,black,68,some college,CA,0.338717892,4,0
-female,white,32,post-grad,VA,0.471736237,3,0
-female,white,60,hs,NC,0.519037458,3,1
-female,black,28,some college,LA,0.601716772,3,0
-male,white,19,hs,TX,0.547132256,3,0
-female,white,73,hs,MS,0.590898473,3,1
-male,white,67,some college,KS,0.611114703,1,0
-male,white,44,some college,ID,0.683101767,4,1
-female,black,53,4-year college,MS,0.590898473,3,0
-female,white,66,some college,TX,0.547132256,3,1
-male,white,32,some college,OH,0.542676846,1,1
-male,other,26,some college,NY,0.382275815,2,1
-male,white,38,hs,PA,0.503755358,2,1
-female,white,61,some college,WA,0.412130688,4,1
-male,white,74,4-year college,TX,0.547132256,3,0
-female,other,23,hs,GA,0.526611726,3,1
-male,white,26,some college,OH,0.542676846,1,0
-female,white,28,some college,GA,0.526611726,3,0
-male,white,53,hs,OH,0.542676846,1,1
-male,white,60,hs,WI,0.50407989,1,0
-female,white,40,some college,MI,0.501176682,1,1
-female,white,25,hs,MO,0.59818561,1,0
-female,white,66,some college,CA,0.338717892,4,1
-male,white,23,hs,MI,0.501176682,1,0
-female,white,56,4-year college,TX,0.547132256,3,1
-male,white,66,hs,CA,0.338717892,4,1
-male,white,70,some college,MD,0.359837503,3,1
-female,white,30,4-year college,NJ,0.427158099,2,0
-female,white,30,no hs,NH,0.498029716,2,0
-female,other,20,some college,MA,0.353487213,2,1
-female,white,59,some college,ME,0.484032089,2,0
-male,white,30,some college,CA,0.338717892,4,0
-male,other,36,4-year college,LA,0.601716772,3,0
-male,white,37,4-year college,CA,0.338717892,4,1
-female,white,31,some college,CA,0.338717892,4,1
-male,other,48,some college,TX,0.547132256,3,0
-male,white,36,some college,IN,0.601173095,1,0
-female,black,24,4-year college,TX,0.547132256,3,1
-male,white,64,hs,FL,0.506188355,3,0
-male,white,66,some college,TX,0.547132256,3,1
-female,black,56,post-grad,AL,0.643741436,3,0
-male,white,22,post-grad,NH,0.498029716,2,1
-male,white,68,4-year college,GA,0.526611726,3,1
-female,white,88,hs,NY,0.382275815,2,1
-male,other,30,some college,CA,0.338717892,4,0
-male,white,51,post-grad,NC,0.519037458,3,1
-male,white,52,some college,MN,0.491681431,1,1
-female,white,47,some college,CT,0.428584525,2,0
-female,white,93,hs,AZ,0.518900234,4,0
-male,white,37,some college,IN,0.601173095,1,0
-male,black,41,some college,NJ,0.427158099,2,1
-male,white,58,some college,MD,0.359837503,3,0
-male,other,26,some college,GA,0.526611726,3,0
-male,white,61,4-year college,TX,0.547132256,3,0
-female,white,27,hs,MI,0.501176682,1,0
-female,white,61,hs,IN,0.601173095,1,1
-female,white,56,some college,MI,0.501176682,1,0
-male,white,38,hs,KS,0.611114703,1,0
-male,other,72,4-year college,IN,0.601173095,1,1
-female,white,100,some college,GA,0.526611726,3,1
-male,white,35,some college,OH,0.542676846,1,0
-male,black,38,4-year college,NV,0.487062906,4,0
-male,black,37,some college,CA,0.338717892,4,1
-female,white,67,hs,IL,0.409799486,1,1
-female,white,42,some college,WA,0.412130688,4,0
-female,white,87,some college,MN,0.491681431,1,1
-female,white,48,4-year college,TX,0.547132256,3,1
-female,white,60,hs,MI,0.501176682,1,1
-female,other,21,hs,CA,0.338717892,4,0
-female,white,58,hs,FL,0.506188355,3,1
-female,white,63,4-year college,CA,0.338717892,4,0
-male,white,43,4-year college,IN,0.601173095,1,0
-female,white,38,post-grad,VT,0.348135737,2,0
-male,black,30,4-year college,IL,0.409799486,1,0
-female,white,19,some college,MS,0.590898473,3,1
-female,white,23,hs,NC,0.519037458,3,0
-male,white,88,4-year college,ID,0.683101767,4,1
-female,black,43,some college,MD,0.359837503,3,1
-female,white,66,some college,HI,0.325586625,4,1
-female,white,57,4-year college,AZ,0.518900234,4,0
-male,white,31,hs,WA,0.412130688,4,0
-female,other,52,some college,CA,0.338717892,4,0
-female,white,35,hs,NY,0.382275815,2,1
-male,white,41,some college,FL,0.506188355,3,1
-female,white,59,hs,MO,0.59818561,1,1
-female,white,21,no hs,TX,0.547132256,3,1
-male,black,69,4-year college,CA,0.338717892,4,0
-male,white,48,some college,IL,0.409799486,1,0
-female,white,65,post-grad,MA,0.353487213,2,0
-male,black,25,some college,GA,0.526611726,3,1
-female,white,40,some college,TX,0.547132256,3,0
-male,white,53,post-grad,CA,0.338717892,4,1
-male,black,37,some college,AR,0.642851377,3,1
-female,white,94,hs,NJ,0.427158099,2,1
-female,other,53,some college,WV,0.721610523,3,0
-female,white,63,some college,LA,0.601716772,3,1
-female,white,51,post-grad,TN,0.63624343,3,0
-female,black,69,no hs,TN,0.63624343,3,1
-male,white,37,4-year college,OR,0.438441611,4,1
-male,white,99,4-year college,MT,0.611096643,4,1
-female,other,29,some college,NC,0.519037458,3,1
-male,other,43,4-year college,WI,0.50407989,1,0
-female,black,34,post-grad,FL,0.506188355,3,0
-male,white,68,hs,NE,0.635476741,1,1
-male,black,54,hs,CA,0.338717892,4,0
-female,white,52,hs,MA,0.353487213,2,0
-female,white,64,some college,AZ,0.518900234,4,1
-male,white,76,no hs,TX,0.547132256,3,1
-female,white,56,some college,AR,0.642851377,3,0
-female,white,25,some college,TN,0.63624343,3,1
-female,other,24,hs,TN,0.63624343,3,0
-female,other,49,4-year college,GA,0.526611726,3,0
-male,white,49,4-year college,PA,0.503755358,2,1
-female,black,53,post-grad,SC,0.574602564,3,1
-female,white,21,4-year college,MN,0.491681431,1,1
-male,white,65,post-grad,PA,0.503755358,2,0
-female,other,59,some college,KY,0.65670629,3,1
-male,white,27,some college,FL,0.506188355,3,1
-male,white,45,post-grad,IN,0.601173095,1,0
-female,white,61,hs,AR,0.642851377,3,1
-female,white,88,hs,NC,0.519037458,3,1
-male,white,34,post-grad,NJ,0.427158099,2,0
-female,white,27,4-year college,IL,0.409799486,1,0
-male,other,20,some college,FL,0.506188355,3,1
-female,white,40,hs,FL,0.506188355,3,1
-male,white,70,post-grad,MI,0.501176682,1,1
-female,white,43,hs,NY,0.382275815,2,0
-male,white,31,post-grad,PA,0.503755358,2,1
-female,white,68,hs,VA,0.471736237,3,1
-female,white,29,some college,TX,0.547132256,3,0
-female,other,24,4-year college,CA,0.338717892,4,1
-female,other,30,some college,WA,0.412130688,4,0
-female,black,57,some college,IN,0.601173095,1,0
-female,white,59,some college,FL,0.506188355,3,0
-male,white,57,4-year college,CA,0.338717892,4,1
-female,other,61,some college,NJ,0.427158099,2,0
-female,black,57,some college,NY,0.382275815,2,0
-female,white,19,4-year college,OH,0.542676846,1,0
-male,white,89,some college,MD,0.359837503,3,1
-male,white,48,some college,IN,0.601173095,1,0
-female,white,37,4-year college,AL,0.643741436,3,0
-female,other,26,4-year college,NY,0.382275815,2,1
-female,other,40,hs,NY,0.382275815,2,0
-female,white,45,4-year college,MN,0.491681431,1,1
-female,white,18,hs,SC,0.574602564,3,0
-female,white,66,post-grad,IL,0.409799486,1,0
-male,white,48,4-year college,FL,0.506188355,3,0
-female,white,37,hs,KY,0.65670629,3,1
-female,white,64,4-year college,CA,0.338717892,4,0
-male,white,67,4-year college,WY,0.757053196,4,0
-female,white,62,some college,PA,0.503755358,2,0
-male,white,64,4-year college,TX,0.547132256,3,1
-male,white,39,4-year college,NY,0.382275815,2,1
-female,black,49,hs,AL,0.643741436,3,1
-male,other,32,post-grad,NC,0.519037458,3,0
-female,white,76,hs,WI,0.50407989,1,1
-female,other,35,4-year college,IL,0.409799486,1,0
-male,white,74,4-year college,UT,0.623836582,4,1
-female,white,24,hs,ME,0.484032089,2,1
-female,other,26,hs,CA,0.338717892,4,1
-female,white,19,some college,HI,0.325586625,4,0
-male,white,58,hs,MO,0.59818561,1,0
-female,white,57,4-year college,OH,0.542676846,1,0
-female,white,38,post-grad,NY,0.382275815,2,1
-female,white,44,4-year college,MI,0.501176682,1,1
-male,white,72,hs,PA,0.503755358,2,1
-female,white,32,4-year college,GA,0.526611726,3,0
-female,white,29,4-year college,NY,0.382275815,2,0
-female,white,53,4-year college,IL,0.409799486,1,1
-female,black,45,4-year college,NE,0.635476741,1,1
-female,white,45,hs,NM,0.453492051,4,0
-female,black,30,some college,TX,0.547132256,3,0
-female,white,64,4-year college,MI,0.501176682,1,1
-female,other,60,hs,PA,0.503755358,2,1
-male,white,76,post-grad,CA,0.338717892,4,0
-male,white,57,post-grad,TX,0.547132256,3,0
-female,white,67,post-grad,CT,0.428584525,2,0
-female,white,53,some college,MO,0.59818561,1,1
-female,white,28,some college,UT,0.623836582,4,1
-male,other,31,4-year college,NY,0.382275815,2,0
-male,white,41,hs,WI,0.50407989,1,1
-female,white,52,4-year college,FL,0.506188355,3,1
-male,white,32,hs,IL,0.409799486,1,1
-female,white,51,post-grad,NJ,0.427158099,2,1
-male,white,56,some college,NV,0.487062906,4,1
-male,white,42,some college,MD,0.359837503,3,1
-male,white,41,4-year college,OR,0.438441611,4,0
-female,white,81,hs,NY,0.382275815,2,0
-female,black,52,some college,WV,0.721610523,3,0
-female,white,34,hs,GA,0.526611726,3,1
-female,white,20,some college,IN,0.601173095,1,1
-female,white,80,hs,WA,0.412130688,4,1
-female,white,37,some college,MI,0.501176682,1,0
-female,white,57,no hs,IL,0.409799486,1,1
-female,black,36,hs,LA,0.601716772,3,1
-female,white,23,hs,AL,0.643741436,3,0
-female,other,25,some college,CA,0.338717892,4,0
-female,white,63,hs,FL,0.506188355,3,1
-female,white,68,hs,OK,0.693047372,3,1
-male,white,32,4-year college,OH,0.542676846,1,1
-female,white,62,some college,OR,0.438441611,4,1
-female,white,65,hs,PA,0.503755358,2,1
-female,black,20,some college,CA,0.338717892,4,1
-female,white,46,4-year college,WY,0.757053196,4,1
-female,white,27,hs,IN,0.601173095,1,1
-male,black,55,some college,MO,0.59818561,1,0
-female,white,25,some college,MI,0.501176682,1,1
-male,white,43,hs,CO,0.473166666,4,1
-male,white,74,post-grad,NY,0.382275815,2,0
-male,other,37,4-year college,KY,0.65670629,3,0
-female,white,21,some college,NY,0.382275815,2,0
-male,white,38,4-year college,TN,0.63624343,3,1
-female,white,63,post-grad,KY,0.65670629,3,0
-male,white,37,no hs,PA,0.503755358,2,1
-male,white,84,4-year college,AZ,0.518900234,4,0
-male,white,30,4-year college,UT,0.623836582,4,0
-female,white,48,hs,OK,0.693047372,3,1
-female,black,39,some college,IL,0.409799486,1,0
-female,white,46,hs,WV,0.721610523,3,1
-female,other,21,some college,TX,0.547132256,3,0
-male,white,29,some college,FL,0.506188355,3,0
-male,white,72,4-year college,AL,0.643741436,3,1
-female,white,55,4-year college,CA,0.338717892,4,0
-male,other,94,some college,MN,0.491681431,1,1
-female,other,22,some college,IL,0.409799486,1,0
-male,white,38,4-year college,MD,0.359837503,3,1
-female,white,23,some college,WI,0.50407989,1,0
-female,white,18,some college,TN,0.63624343,3,1
-female,white,48,4-year college,NM,0.453492051,4,0
-male,black,53,hs,CA,0.338717892,4,0
-female,white,32,4-year college,NY,0.382275815,2,0
-female,black,53,4-year college,CO,0.473166666,4,0
-female,white,63,4-year college,MI,0.501176682,1,0
-female,white,61,hs,WA,0.412130688,4,0
-female,white,52,4-year college,FL,0.506188355,3,1
-male,white,78,4-year college,AR,0.642851377,3,1
-male,white,100,hs,TX,0.547132256,3,1
-female,white,42,some college,KS,0.611114703,1,0
-male,white,53,some college,MI,0.501176682,1,1
-female,black,45,4-year college,VA,0.471736237,3,0
-female,other,20,4-year college,OR,0.438441611,4,0
-female,white,53,some college,WI,0.50407989,1,1
-male,white,69,hs,GA,0.526611726,3,0
-female,white,51,4-year college,OK,0.693047372,3,0
-male,white,51,4-year college,OH,0.542676846,1,0
-male,white,53,4-year college,MA,0.353487213,2,0
-male,other,42,some college,TN,0.63624343,3,0
-male,black,43,4-year college,UT,0.623836582,4,0
-male,black,42,some college,TN,0.63624343,3,0
-male,white,50,4-year college,GA,0.526611726,3,0
-female,white,83,some college,OK,0.693047372,3,1
-male,other,18,hs,TX,0.547132256,3,0
-female,white,31,4-year college,CO,0.473166666,4,1
-female,white,86,some college,HI,0.325586625,4,0
-male,other,33,4-year college,PA,0.503755358,2,0
-female,white,20,4-year college,IL,0.409799486,1,0
-male,white,29,hs,OK,0.693047372,3,0
-female,white,65,post-grad,MA,0.353487213,2,0
-male,white,31,hs,ND,0.698092429,1,1
-female,white,42,4-year college,NE,0.635476741,1,1
-male,white,52,hs,TN,0.63624343,3,1
-female,black,35,hs,MS,0.590898473,3,0
-female,white,90,some college,KY,0.65670629,3,1
-male,white,44,post-grad,WA,0.412130688,4,0
-male,other,38,some college,CA,0.338717892,4,0
-male,white,39,4-year college,FL,0.506188355,3,0
-female,white,99,hs,TX,0.547132256,3,0
-female,white,26,some college,AR,0.642851377,3,1
-female,white,39,hs,OH,0.542676846,1,0
-male,other,58,hs,TX,0.547132256,3,0
-male,other,33,some college,WA,0.412130688,4,1
-female,black,55,some college,CA,0.338717892,4,0
-female,white,38,some college,CA,0.338717892,4,0
-female,black,38,no hs,MO,0.59818561,1,0
-female,white,35,hs,NC,0.519037458,3,1
-male,black,68,some college,NC,0.519037458,3,0
-male,white,30,post-grad,VA,0.471736237,3,0
-male,white,30,post-grad,FL,0.506188355,3,0
-female,other,24,4-year college,TX,0.547132256,3,0
-male,other,40,some college,WV,0.721610523,3,1
-female,white,86,some college,NC,0.519037458,3,1
-male,white,52,some college,MO,0.59818561,1,0
-male,other,56,4-year college,MO,0.59818561,1,1
-female,white,22,some college,NC,0.519037458,3,0
-male,white,59,some college,TX,0.547132256,3,1
-male,white,78,hs,PA,0.503755358,2,0
-female,other,21,no hs,TX,0.547132256,3,1
-female,black,85,some college,AR,0.642851377,3,0
-male,white,38,4-year college,NY,0.382275815,2,1
-female,other,75,4-year college,AZ,0.518900234,4,1
-female,white,53,some college,FL,0.506188355,3,1
-female,white,68,some college,GA,0.526611726,3,1
-male,other,32,some college,CA,0.338717892,4,1
-female,other,48,some college,CA,0.338717892,4,1
-male,white,37,some college,FL,0.506188355,3,0
-female,other,32,some college,CA,0.338717892,4,1
-female,white,74,hs,NY,0.382275815,2,1
-female,white,53,hs,ME,0.484032089,2,0
-female,white,65,hs,OH,0.542676846,1,0
-female,white,43,some college,IL,0.409799486,1,1
-female,white,58,post-grad,OH,0.542676846,1,0
-female,white,75,4-year college,AZ,0.518900234,4,1
-female,white,99,4-year college,IN,0.601173095,1,1
-male,white,91,some college,MA,0.353487213,2,1
-male,white,53,hs,NY,0.382275815,2,0
-female,white,62,hs,MA,0.353487213,2,1
-female,other,29,hs,ID,0.683101767,4,0
-male,white,56,hs,TN,0.63624343,3,1
-male,white,29,4-year college,AL,0.643741436,3,1
-male,white,43,hs,IL,0.409799486,1,1
-female,white,47,some college,PA,0.503755358,2,0
-female,white,54,some college,AZ,0.518900234,4,0
-male,white,25,post-grad,NY,0.382275815,2,0
-female,white,28,4-year college,MO,0.59818561,1,1
-male,white,55,hs,NC,0.519037458,3,0
-male,white,40,post-grad,IL,0.409799486,1,0
-male,other,41,4-year college,TX,0.547132256,3,0
-male,white,70,hs,IA,0.550635478,1,0
-male,white,50,4-year college,IN,0.601173095,1,0
-male,white,47,4-year college,VA,0.471736237,3,0
-male,white,65,post-grad,CA,0.338717892,4,0
-male,white,41,some college,MI,0.501176682,1,0
-male,other,32,4-year college,TX,0.547132256,3,1
-male,white,68,4-year college,CO,0.473166666,4,1
-female,white,38,hs,WA,0.412130688,4,0
-male,white,57,hs,KY,0.65670629,3,1
-male,white,62,some college,IN,0.601173095,1,1
-male,other,36,4-year college,GA,0.526611726,3,1
-female,black,40,some college,PA,0.503755358,2,1
-female,white,53,hs,NY,0.382275815,2,1
-male,white,61,some college,KY,0.65670629,3,1
-female,white,54,4-year college,NJ,0.427158099,2,1
-female,white,39,4-year college,FL,0.506188355,3,0
-female,white,30,hs,IL,0.409799486,1,1
-male,other,37,hs,CA,0.338717892,4,0
-male,white,30,some college,MI,0.501176682,1,0
-female,white,49,hs,PA,0.503755358,2,1
-male,white,48,some college,MD,0.359837503,3,0
-female,white,19,4-year college,OR,0.438441611,4,0
-female,white,70,some college,CA,0.338717892,4,1
-female,white,24,4-year college,NY,0.382275815,2,0
-female,white,65,some college,PA,0.503755358,2,1
-male,white,30,4-year college,AZ,0.518900234,4,0
-male,other,67,post-grad,RI,0.416892959,2,0
-female,black,63,some college,GA,0.526611726,3,0
-female,black,45,4-year college,GA,0.526611726,3,0
-female,other,25,hs,NY,0.382275815,2,1
-female,white,24,4-year college,NY,0.382275815,2,1
-male,white,66,no hs,KY,0.65670629,3,1
-male,other,53,4-year college,NC,0.519037458,3,0
-female,white,34,4-year college,IA,0.550635478,1,0
-male,white,47,4-year college,FL,0.506188355,3,0
-male,white,48,no hs,MO,0.59818561,1,1
-male,white,64,4-year college,AZ,0.518900234,4,1
-female,white,22,4-year college,KS,0.611114703,1,1
-female,other,57,some college,FL,0.506188355,3,0
-female,black,59,hs,NY,0.382275815,2,1
-male,white,53,4-year college,KS,0.611114703,1,0
-female,white,61,4-year college,SC,0.574602564,3,1
-female,white,19,hs,MD,0.359837503,3,0
-female,black,52,post-grad,WV,0.721610523,3,0
-male,white,69,4-year college,OH,0.542676846,1,0
-male,other,46,4-year college,AZ,0.518900234,4,0
-female,white,89,some college,PA,0.503755358,2,1
-male,white,56,post-grad,VA,0.471736237,3,1
-female,white,46,post-grad,NY,0.382275815,2,0
-female,black,54,some college,VA,0.471736237,3,0
-male,white,22,4-year college,FL,0.506188355,3,1
-female,other,25,no hs,IL,0.409799486,1,1
-female,other,19,hs,FL,0.506188355,3,1
-male,white,40,4-year college,AZ,0.518900234,4,1
-female,white,48,some college,OH,0.542676846,1,1
-female,white,67,some college,NJ,0.427158099,2,1
-male,white,39,some college,SC,0.574602564,3,0
-male,white,72,hs,OH,0.542676846,1,1
-male,black,35,4-year college,NY,0.382275815,2,0
-male,white,73,some college,CA,0.338717892,4,1
-female,white,87,hs,PA,0.503755358,2,1
-male,white,91,hs,CA,0.338717892,4,1
-male,white,33,some college,KY,0.65670629,3,0
-male,white,46,some college,KY,0.65670629,3,0
-male,white,42,4-year college,IL,0.409799486,1,0
-male,white,41,some college,OK,0.693047372,3,1
-female,white,47,post-grad,OH,0.542676846,1,0
-female,white,46,hs,KY,0.65670629,3,0
-male,white,67,post-grad,MN,0.491681431,1,1
-female,white,43,hs,TN,0.63624343,3,1
-female,white,32,post-grad,TX,0.547132256,3,0
-female,white,83,some college,MO,0.59818561,1,0
-male,other,37,4-year college,VA,0.471736237,3,0
-female,white,86,post-grad,NY,0.382275815,2,0
-female,white,46,hs,WA,0.412130688,4,0
-male,black,31,4-year college,IL,0.409799486,1,0
-female,white,24,4-year college,ID,0.683101767,4,0
-male,white,42,some college,IN,0.601173095,1,0
-male,white,30,hs,TN,0.63624343,3,1
-male,other,35,4-year college,CA,0.338717892,4,0
-female,white,34,4-year college,TX,0.547132256,3,0
-female,white,32,4-year college,HI,0.325586625,4,0
-male,white,20,hs,OK,0.693047372,3,1
-female,white,37,some college,VA,0.471736237,3,1
-male,white,53,hs,CA,0.338717892,4,0
-female,white,86,some college,WA,0.412130688,4,1
-female,white,42,hs,NY,0.382275815,2,0
-female,other,54,hs,PA,0.503755358,2,1
-male,white,59,hs,NY,0.382275815,2,0
-female,black,90,4-year college,MI,0.501176682,1,1
-female,white,70,hs,CA,0.338717892,4,1
-male,white,21,some college,PA,0.503755358,2,0
-male,white,38,some college,FL,0.506188355,3,1
-female,other,20,4-year college,NY,0.382275815,2,0
-male,other,69,some college,TX,0.547132256,3,0
-male,white,67,hs,OH,0.542676846,1,0
-female,white,41,hs,PA,0.503755358,2,1
-female,white,31,4-year college,WA,0.412130688,4,0
-female,white,46,4-year college,IN,0.601173095,1,0
-female,white,43,hs,FL,0.506188355,3,1
-male,white,37,some college,ID,0.683101767,4,1
-female,white,63,post-grad,GA,0.526611726,3,0
-female,white,51,hs,AZ,0.518900234,4,1
-female,white,64,some college,SD,0.659718581,1,0
-male,black,19,some college,NY,0.382275815,2,1
-female,other,24,hs,KY,0.65670629,3,0
-female,black,26,some college,CA,0.338717892,4,0
-female,white,81,post-grad,MN,0.491681431,1,1
-female,black,50,some college,AL,0.643741436,3,0
-female,white,57,some college,FL,0.506188355,3,0
-female,white,59,post-grad,CT,0.428584525,2,0
-male,white,78,hs,OH,0.542676846,1,0
-female,white,76,4-year college,CA,0.338717892,4,1
-female,black,50,hs,VA,0.471736237,3,0
-male,white,26,hs,KY,0.65670629,3,0
-female,white,58,post-grad,OH,0.542676846,1,0
-female,white,70,4-year college,CA,0.338717892,4,0
-male,white,36,4-year college,NY,0.382275815,2,0
-female,white,86,some college,MS,0.590898473,3,0
-female,white,26,some college,OR,0.438441611,4,0
-male,white,28,post-grad,TX,0.547132256,3,1
-female,white,78,hs,CO,0.473166666,4,0
-male,white,76,4-year college,NY,0.382275815,2,0
-male,black,62,hs,TX,0.547132256,3,0
-male,other,42,some college,AZ,0.518900234,4,1
-female,black,52,4-year college,TX,0.547132256,3,0
-female,white,48,hs,MA,0.353487213,2,0
-female,other,47,some college,VA,0.471736237,3,0
-female,other,35,4-year college,CA,0.338717892,4,1
-female,other,30,4-year college,FL,0.506188355,3,1
-female,white,49,some college,TX,0.547132256,3,1
-female,white,50,some college,MD,0.359837503,3,1
-male,white,26,hs,WA,0.412130688,4,1
-female,black,54,4-year college,SC,0.574602564,3,0
-male,white,32,post-grad,TX,0.547132256,3,0
-female,white,26,4-year college,IL,0.409799486,1,0
-female,other,34,some college,FL,0.506188355,3,0
-female,white,64,4-year college,MD,0.359837503,3,1
-male,white,78,some college,TX,0.547132256,3,1
-female,other,51,4-year college,CA,0.338717892,4,0
-male,white,79,4-year college,KY,0.65670629,3,0
-female,white,46,some college,PA,0.503755358,2,0
-male,white,73,some college,MA,0.353487213,2,0
-male,other,57,some college,NY,0.382275815,2,0
-female,white,23,hs,MI,0.501176682,1,0
-male,white,54,some college,MA,0.353487213,2,1
-male,white,42,4-year college,TX,0.547132256,3,0
-female,white,38,some college,WA,0.412130688,4,0
-female,white,77,hs,OH,0.542676846,1,0
-male,white,50,some college,AL,0.643741436,3,1
-male,white,23,hs,FL,0.506188355,3,1
-female,black,27,some college,SC,0.574602564,3,0
-female,white,52,some college,TX,0.547132256,3,0
-male,white,65,some college,NV,0.487062906,4,0
-male,white,51,hs,TX,0.547132256,3,0
-male,white,50,hs,NC,0.519037458,3,0
-female,white,32,some college,TX,0.547132256,3,0
-female,black,60,some college,IN,0.601173095,1,0
-male,white,82,some college,MI,0.501176682,1,1
-male,white,19,post-grad,OH,0.542676846,1,0
-female,other,77,post-grad,FL,0.506188355,3,1
-male,other,55,some college,WA,0.412130688,4,1
-female,other,31,some college,TX,0.547132256,3,1
-male,white,100,4-year college,WA,0.412130688,4,0
-male,white,57,some college,PA,0.503755358,2,1
-male,white,73,post-grad,TX,0.547132256,3,0
-male,other,39,4-year college,NV,0.487062906,4,1
-female,white,35,no hs,NY,0.382275815,2,0
-male,white,63,post-grad,PA,0.503755358,2,0
-male,white,51,post-grad,VA,0.471736237,3,1
-male,white,63,some college,NY,0.382275815,2,0
-male,white,63,hs,PA,0.503755358,2,1
-female,white,42,4-year college,TX,0.547132256,3,0
-female,white,27,4-year college,MS,0.590898473,3,1
-female,other,20,some college,CA,0.338717892,4,0
-male,white,33,some college,VA,0.471736237,3,1
-female,white,99,hs,HI,0.325586625,4,1
-male,white,62,some college,WA,0.412130688,4,1
-female,white,82,some college,TX,0.547132256,3,0
-female,other,18,4-year college,TX,0.547132256,3,0
-female,white,38,some college,IL,0.409799486,1,0
-male,white,48,hs,IL,0.409799486,1,0
-male,white,37,post-grad,WA,0.412130688,4,1
-female,white,50,post-grad,NJ,0.427158099,2,0
-female,white,28,4-year college,NY,0.382275815,2,0
-female,white,63,some college,FL,0.506188355,3,0
-male,white,76,4-year college,NY,0.382275815,2,1
-female,white,25,some college,ND,0.698092429,1,1
-female,white,35,4-year college,NC,0.519037458,3,1
-female,black,57,some college,PA,0.503755358,2,1
-female,white,22,hs,VA,0.471736237,3,1
-female,white,41,hs,LA,0.601716772,3,1
-female,white,65,hs,IL,0.409799486,1,1
-male,white,94,some college,MI,0.501176682,1,1
-female,white,93,some college,NY,0.382275815,2,1
-male,white,39,post-grad,FL,0.506188355,3,1
-female,other,21,4-year college,UT,0.623836582,4,1
-male,black,24,some college,TX,0.547132256,3,1
-female,white,69,post-grad,CA,0.338717892,4,0
-male,other,20,4-year college,TX,0.547132256,3,0
-female,white,38,post-grad,NE,0.635476741,1,1
-female,white,39,some college,MI,0.501176682,1,1
-female,white,53,hs,UT,0.623836582,4,0
-female,white,30,some college,NY,0.382275815,2,1
-male,white,63,4-year college,GA,0.526611726,3,0
-female,white,27,4-year college,IL,0.409799486,1,0
-male,white,59,4-year college,NJ,0.427158099,2,1
-female,other,40,some college,NV,0.487062906,4,0
-female,other,38,4-year college,IN,0.601173095,1,1
-male,white,39,4-year college,IL,0.409799486,1,0
-male,white,61,4-year college,TX,0.547132256,3,1
-male,white,31,hs,AZ,0.518900234,4,0
-female,white,60,post-grad,IN,0.601173095,1,1
-female,white,52,hs,KS,0.611114703,1,0
-male,white,54,4-year college,CA,0.338717892,4,0
-male,other,22,hs,CA,0.338717892,4,1
-female,other,39,no hs,TX,0.547132256,3,1
-female,white,33,some college,NC,0.519037458,3,0
-female,white,68,hs,MO,0.59818561,1,0
-female,white,61,some college,WA,0.412130688,4,1
-male,white,64,post-grad,AZ,0.518900234,4,1
-female,white,47,some college,OH,0.542676846,1,1
-female,black,63,hs,SC,0.574602564,3,1
-male,white,33,some college,WA,0.412130688,4,1
-female,other,26,no hs,FL,0.506188355,3,1
-male,white,44,some college,VA,0.471736237,3,0
-male,white,39,some college,TN,0.63624343,3,0
-male,other,28,some college,TX,0.547132256,3,0
-male,white,58,some college,MO,0.59818561,1,0
-female,white,26,4-year college,MA,0.353487213,2,0
-male,white,39,hs,SD,0.659718581,1,1
-male,white,25,hs,IN,0.601173095,1,1
-male,other,33,4-year college,TX,0.547132256,3,0
-male,white,68,hs,PA,0.503755358,2,0
-female,white,87,no hs,IN,0.601173095,1,1
-female,other,29,post-grad,TX,0.547132256,3,0
-female,white,57,4-year college,AR,0.642851377,3,0
-female,white,22,some college,WI,0.50407989,1,0
-female,black,26,some college,TX,0.547132256,3,0
-female,white,18,some college,GA,0.526611726,3,0
-male,white,64,some college,IL,0.409799486,1,1
-male,white,65,some college,CA,0.338717892,4,1
-female,white,58,4-year college,AR,0.642851377,3,1
-female,black,36,some college,CT,0.428584525,2,1
-female,other,39,4-year college,HI,0.325586625,4,0
-female,white,64,some college,FL,0.506188355,3,1
-female,white,54,some college,LA,0.601716772,3,0
-female,white,20,no hs,OR,0.438441611,4,1
-male,white,61,post-grad,TX,0.547132256,3,1
-female,white,50,some college,OH,0.542676846,1,1
-female,white,22,4-year college,NJ,0.427158099,2,0
-female,black,23,some college,TX,0.547132256,3,0
-male,other,31,some college,VA,0.471736237,3,0
-male,white,18,some college,TX,0.547132256,3,0
-female,white,55,4-year college,CT,0.428584525,2,1
-male,other,55,hs,OK,0.693047372,3,1
-male,white,76,4-year college,NJ,0.427158099,2,1
-male,white,67,4-year college,OH,0.542676846,1,1
-female,white,61,some college,CA,0.338717892,4,1
-male,other,26,4-year college,GA,0.526611726,3,0
-female,white,68,hs,IN,0.601173095,1,1
-male,white,31,4-year college,CA,0.338717892,4,0
-female,other,52,post-grad,CA,0.338717892,4,0
-male,white,48,4-year college,OH,0.542676846,1,1
-male,white,48,4-year college,WA,0.412130688,4,0
-male,white,43,some college,IL,0.409799486,1,1
-male,white,20,some college,AK,0.583856547,4,0
-male,other,25,post-grad,VA,0.471736237,3,0
-female,white,33,hs,SC,0.574602564,3,1
-female,other,20,some college,OH,0.542676846,1,0
-female,white,50,some college,MD,0.359837503,3,1
-male,other,64,4-year college,MD,0.359837503,3,0
-female,white,41,hs,NJ,0.427158099,2,0
-female,white,65,some college,VT,0.348135737,2,0
-male,white,23,some college,IA,0.550635478,1,1
-female,other,30,4-year college,TX,0.547132256,3,1
-male,white,89,4-year college,IL,0.409799486,1,0
-female,black,32,some college,SC,0.574602564,3,1
-female,white,19,hs,ME,0.484032089,2,0
-male,white,51,4-year college,NC,0.519037458,3,1
-female,white,25,some college,PA,0.503755358,2,0
-male,white,38,some college,NJ,0.427158099,2,0
-female,other,23,some college,CA,0.338717892,4,0
-female,white,67,4-year college,OR,0.438441611,4,0
-female,other,32,post-grad,CA,0.338717892,4,0
-female,black,23,no hs,MS,0.590898473,3,1
-female,other,69,hs,NV,0.487062906,4,0
-male,white,57,4-year college,TX,0.547132256,3,1
-male,other,41,4-year college,NY,0.382275815,2,0
-female,other,36,some college,CA,0.338717892,4,0
-female,white,37,4-year college,TN,0.63624343,3,1
-female,white,18,4-year college,CA,0.338717892,4,0
-male,white,76,4-year college,AL,0.643741436,3,1
-female,white,69,hs,NV,0.487062906,4,0
-female,white,63,no hs,OH,0.542676846,1,1
-female,other,54,hs,PA,0.503755358,2,0
-male,white,78,post-grad,TN,0.63624343,3,0
-female,white,58,some college,OH,0.542676846,1,1
-male,black,28,hs,NV,0.487062906,4,0
-female,white,50,hs,AL,0.643741436,3,1
-female,black,33,hs,AL,0.643741436,3,0
-female,white,42,4-year college,IL,0.409799486,1,0
-male,other,68,4-year college,NV,0.487062906,4,1
-male,white,66,4-year college,TN,0.63624343,3,0
-female,white,40,4-year college,IL,0.409799486,1,1
-male,white,87,some college,FL,0.506188355,3,1
-female,white,38,post-grad,CA,0.338717892,4,0
-male,white,76,post-grad,TX,0.547132256,3,1
-male,white,61,post-grad,MI,0.501176682,1,0
-female,white,55,hs,TN,0.63624343,3,1
-female,white,63,hs,SC,0.574602564,3,1
-female,other,78,post-grad,CA,0.338717892,4,0
-female,white,22,hs,PA,0.503755358,2,0
-male,other,54,post-grad,TX,0.547132256,3,1
-male,white,58,4-year college,IL,0.409799486,1,0
-male,white,51,hs,FL,0.506188355,3,1
-female,black,50,some college,PA,0.503755358,2,0
-male,white,58,hs,AL,0.643741436,3,1
-male,white,44,no hs,AR,0.642851377,3,0
-female,white,67,hs,IN,0.601173095,1,0
-female,white,44,post-grad,KS,0.611114703,1,1
-female,white,48,hs,TN,0.63624343,3,1
-female,white,41,hs,IL,0.409799486,1,1
-female,white,85,no hs,NM,0.453492051,4,1
-female,white,90,hs,MO,0.59818561,1,1
-male,other,64,4-year college,FL,0.506188355,3,1
-female,black,25,some college,TX,0.547132256,3,1
-female,black,48,hs,VA,0.471736237,3,0
-female,white,87,hs,GA,0.526611726,3,1
-male,white,51,hs,OH,0.542676846,1,0
-female,other,47,hs,HI,0.325586625,4,0
-female,white,66,hs,SC,0.574602564,3,1
-male,white,24,hs,CA,0.338717892,4,0
-male,white,18,some college,CA,0.338717892,4,1
-female,black,53,hs,PA,0.503755358,2,1
-female,white,57,hs,MS,0.590898473,3,1
-female,white,59,4-year college,MI,0.501176682,1,0
-male,other,48,some college,WA,0.412130688,4,1
-female,black,28,some college,TN,0.63624343,3,0
-male,white,64,hs,CT,0.428584525,2,1
-male,white,84,post-grad,TX,0.547132256,3,1
-female,white,46,4-year college,WA,0.412130688,4,0
-female,white,41,4-year college,FL,0.506188355,3,0
-female,white,57,post-grad,PA,0.503755358,2,1
-female,white,23,post-grad,WI,0.50407989,1,0
-male,other,34,hs,CA,0.338717892,4,1
-female,white,29,4-year college,NY,0.382275815,2,0
-female,other,39,4-year college,NJ,0.427158099,2,0
-male,other,50,some college,AR,0.642851377,3,1
-female,black,40,some college,NY,0.382275815,2,0
-male,white,84,hs,MO,0.59818561,1,0
-female,black,24,some college,CA,0.338717892,4,0
-male,white,35,4-year college,PA,0.503755358,2,1
-female,white,66,4-year college,OR,0.438441611,4,0
-female,white,96,hs,AZ,0.518900234,4,1
-female,white,67,hs,OR,0.438441611,4,0
-female,white,47,4-year college,AZ,0.518900234,4,0
-female,black,81,some college,MI,0.501176682,1,0
-male,black,50,4-year college,WA,0.412130688,4,1
-male,white,86,post-grad,WA,0.412130688,4,0
-female,white,63,post-grad,MI,0.501176682,1,0
-female,white,45,4-year college,OR,0.438441611,4,0
-female,white,42,hs,NY,0.382275815,2,0
-male,black,24,hs,NJ,0.427158099,2,1
-male,white,37,4-year college,TX,0.547132256,3,0
-female,white,53,hs,NE,0.635476741,1,0
-male,white,36,4-year college,IL,0.409799486,1,0
-male,white,79,post-grad,ID,0.683101767,4,1
-female,black,49,post-grad,IN,0.601173095,1,0
-female,white,60,4-year college,CA,0.338717892,4,0
-female,other,34,4-year college,NY,0.382275815,2,0
-female,white,94,some college,WV,0.721610523,3,0
-female,white,38,post-grad,MO,0.59818561,1,1
-female,white,55,some college,FL,0.506188355,3,0
-female,white,54,post-grad,CO,0.473166666,4,0
-female,other,18,hs,WY,0.757053196,4,0
-female,white,31,some college,CO,0.473166666,4,1
-female,white,62,post-grad,MD,0.359837503,3,1
-female,white,68,hs,LA,0.601716772,3,1
-male,white,59,some college,VA,0.471736237,3,1
-female,other,49,4-year college,OH,0.542676846,1,0
-male,white,46,hs,SC,0.574602564,3,1
-female,other,21,post-grad,OH,0.542676846,1,0
-female,white,26,hs,MI,0.501176682,1,0
-female,white,29,no hs,OH,0.542676846,1,1
-male,black,82,post-grad,CA,0.338717892,4,0
-female,white,28,some college,AR,0.642851377,3,1
-male,white,54,post-grad,VA,0.471736237,3,0
-female,white,56,post-grad,CO,0.473166666,4,0
-male,other,64,4-year college,NC,0.519037458,3,1
-female,white,38,post-grad,KS,0.611114703,1,0
-female,white,100,hs,AZ,0.518900234,4,1
-female,other,25,hs,CA,0.338717892,4,0
-male,white,25,hs,MI,0.501176682,1,0
-female,black,30,4-year college,IL,0.409799486,1,0
-male,white,18,hs,NC,0.519037458,3,0
-female,white,73,some college,PA,0.503755358,2,0
-female,white,47,hs,IA,0.550635478,1,0
-male,other,32,4-year college,CA,0.338717892,4,0
-male,other,40,some college,MA,0.353487213,2,0
-female,white,88,some college,NY,0.382275815,2,1
-female,white,61,4-year college,CA,0.338717892,4,1
-male,white,55,some college,KS,0.611114703,1,0
-female,white,47,hs,PA,0.503755358,2,1
-female,white,21,some college,OH,0.542676846,1,0
-female,white,35,some college,ND,0.698092429,1,0
-male,other,95,4-year college,GA,0.526611726,3,1
-male,white,83,post-grad,FL,0.506188355,3,1
-female,black,43,some college,FL,0.506188355,3,1
-male,white,58,hs,NY,0.382275815,2,0
-female,white,86,no hs,IL,0.409799486,1,1
-female,white,54,some college,NE,0.635476741,1,0
-female,white,33,hs,NJ,0.427158099,2,0
-female,black,68,some college,IN,0.601173095,1,0
-female,black,19,hs,VA,0.471736237,3,1
-female,white,70,hs,OH,0.542676846,1,0
-female,white,23,4-year college,NY,0.382275815,2,0
-male,white,72,hs,FL,0.506188355,3,1
-male,white,40,post-grad,CT,0.428584525,2,1
-female,white,69,hs,KY,0.65670629,3,0
-male,white,28,some college,PA,0.503755358,2,0
-female,other,42,4-year college,NC,0.519037458,3,0
-female,white,51,some college,OR,0.438441611,4,0
-female,black,67,some college,AR,0.642851377,3,0
-female,other,42,some college,FL,0.506188355,3,1
-female,white,54,hs,PA,0.503755358,2,1
-male,other,27,some college,MI,0.501176682,1,0
-male,white,52,4-year college,MD,0.359837503,3,1
-male,white,56,4-year college,OH,0.542676846,1,0
-female,white,44,some college,MO,0.59818561,1,1
-female,white,39,post-grad,OH,0.542676846,1,0
-female,white,28,some college,LA,0.601716772,3,1
-male,white,59,some college,WV,0.721610523,3,1
-male,white,23,hs,CA,0.338717892,4,0
-male,white,25,4-year college,TX,0.547132256,3,0
-male,white,18,hs,NH,0.498029716,2,1
-male,white,24,4-year college,NY,0.382275815,2,1
-female,white,18,some college,OH,0.542676846,1,0
-female,white,21,hs,ND,0.698092429,1,0
-male,white,51,4-year college,IN,0.601173095,1,1
-female,white,65,hs,KY,0.65670629,3,1
-female,white,30,4-year college,OR,0.438441611,4,1
-female,white,30,post-grad,IA,0.550635478,1,0
-female,other,23,hs,NC,0.519037458,3,1
-female,white,48,no hs,FL,0.506188355,3,0
-female,white,31,no hs,CO,0.473166666,4,0
-male,white,86,post-grad,NH,0.498029716,2,0
-female,white,69,4-year college,AL,0.643741436,3,0
-female,white,24,hs,FL,0.506188355,3,0
-female,white,66,hs,FL,0.506188355,3,1
-male,white,66,no hs,OH,0.542676846,1,1
-female,white,94,hs,AL,0.643741436,3,1
-female,white,39,some college,LA,0.601716772,3,1
-male,black,50,hs,IN,0.601173095,1,1
-male,white,50,some college,NJ,0.427158099,2,0
-female,white,96,no hs,UT,0.623836582,4,1
-male,white,59,hs,TX,0.547132256,3,0
-male,white,63,hs,NJ,0.427158099,2,0
-male,white,79,hs,TX,0.547132256,3,1
-female,white,49,4-year college,IL,0.409799486,1,0
-female,white,30,some college,MA,0.353487213,2,0
-female,white,61,hs,WI,0.50407989,1,1
-male,white,67,some college,UT,0.623836582,4,0
-male,white,45,post-grad,GA,0.526611726,3,0
-female,white,57,4-year college,MT,0.611096643,4,0
-female,white,64,hs,MI,0.501176682,1,0
-female,black,45,no hs,TN,0.63624343,3,0
-male,white,45,hs,MI,0.501176682,1,1
-female,white,31,no hs,FL,0.506188355,3,0
-female,black,64,some college,MD,0.359837503,3,0
-male,other,40,some college,CA,0.338717892,4,0
-male,black,44,some college,AL,0.643741436,3,1
-male,white,18,some college,IL,0.409799486,1,0
-female,black,40,some college,AL,0.643741436,3,0
-male,white,57,4-year college,MD,0.359837503,3,1
-female,white,19,hs,WI,0.50407989,1,1
-female,white,42,hs,FL,0.506188355,3,0
-male,white,38,4-year college,MA,0.353487213,2,0
-female,white,46,some college,MI,0.501176682,1,1
-male,white,97,post-grad,MI,0.501176682,1,0
-male,white,18,hs,AZ,0.518900234,4,1
-female,white,24,some college,IL,0.409799486,1,1
-male,white,86,post-grad,SC,0.574602564,3,1
-male,white,47,hs,NC,0.519037458,3,1
-female,white,53,4-year college,MI,0.501176682,1,0
-male,white,36,some college,ND,0.698092429,1,0
-female,white,34,4-year college,AL,0.643741436,3,1
-female,other,29,4-year college,AZ,0.518900234,4,0
-male,white,75,some college,FL,0.506188355,3,1
-male,white,33,4-year college,OH,0.542676846,1,0
-female,white,23,4-year college,KS,0.611114703,1,1
-male,other,54,some college,DE,0.440013786,3,0
-female,other,31,some college,GA,0.526611726,3,1
-female,white,52,hs,PA,0.503755358,2,0
-male,white,85,hs,AZ,0.518900234,4,0
-female,white,22,hs,OK,0.693047372,3,0
-male,black,29,some college,PA,0.503755358,2,0
-male,white,42,hs,KS,0.611114703,1,0
-female,other,21,some college,CA,0.338717892,4,0
-male,white,45,post-grad,OR,0.438441611,4,0
-male,other,31,post-grad,FL,0.506188355,3,0
-male,white,50,some college,MI,0.501176682,1,1
-male,other,34,some college,AZ,0.518900234,4,0
-female,white,21,some college,NJ,0.427158099,2,0
-male,white,72,4-year college,IL,0.409799486,1,1
-male,black,40,some college,TX,0.547132256,3,1
-male,white,24,some college,CA,0.338717892,4,0
-female,white,50,some college,WI,0.50407989,1,1
-male,white,85,post-grad,MO,0.59818561,1,1
-male,other,18,some college,TX,0.547132256,3,0
-male,white,53,some college,OH,0.542676846,1,1
-female,white,44,some college,NC,0.519037458,3,0
-female,white,67,some college,AZ,0.518900234,4,0
-female,white,66,no hs,AL,0.643741436,3,0
-female,white,59,some college,FL,0.506188355,3,1
-female,white,32,post-grad,OH,0.542676846,1,0
-male,white,49,some college,TX,0.547132256,3,0
-female,other,26,hs,TX,0.547132256,3,0
-female,white,18,hs,OH,0.542676846,1,0
-female,other,35,some college,TX,0.547132256,3,1
-female,other,68,post-grad,TX,0.547132256,3,0
-female,white,49,4-year college,PA,0.503755358,2,1
-female,black,18,some college,AL,0.643741436,3,0
-female,other,64,some college,NY,0.382275815,2,0
-male,white,69,post-grad,TX,0.547132256,3,0
-female,other,19,some college,TX,0.547132256,3,1
-male,other,20,some college,NY,0.382275815,2,0
-male,white,61,post-grad,MD,0.359837503,3,0
-female,white,24,post-grad,MA,0.353487213,2,0
-female,white,22,hs,PA,0.503755358,2,0
-male,white,71,some college,TX,0.547132256,3,1
-female,white,22,some college,NY,0.382275815,2,1
-female,white,35,some college,MI,0.501176682,1,0
-female,white,94,hs,MD,0.359837503,3,1
-female,white,63,post-grad,NE,0.635476741,1,0
-female,white,41,some college,NY,0.382275815,2,0
-male,white,27,4-year college,NC,0.519037458,3,0
-female,other,47,hs,TX,0.547132256,3,1
-female,white,30,4-year college,FL,0.506188355,3,0
-male,white,35,4-year college,NC,0.519037458,3,1
-male,black,30,4-year college,TN,0.63624343,3,1
-female,white,56,hs,WI,0.50407989,1,1
-female,white,35,post-grad,TX,0.547132256,3,0
-female,white,64,hs,FL,0.506188355,3,1
-male,white,77,hs,MD,0.359837503,3,1
-female,white,58,hs,IL,0.409799486,1,0
-female,white,66,hs,IL,0.409799486,1,0
-female,black,32,some college,NY,0.382275815,2,0
-female,other,20,4-year college,FL,0.506188355,3,0
-female,white,51,some college,IN,0.601173095,1,0
-female,white,45,some college,OR,0.438441611,4,1
-male,black,40,hs,IL,0.409799486,1,1
-female,white,19,some college,OH,0.542676846,1,0
-male,other,47,some college,TX,0.547132256,3,1
-female,white,27,some college,CA,0.338717892,4,1
-female,white,65,hs,IL,0.409799486,1,1
-male,white,79,4-year college,MS,0.590898473,3,1
-male,white,65,some college,IA,0.550635478,1,0
-female,white,60,hs,AZ,0.518900234,4,0
-male,white,80,4-year college,PA,0.503755358,2,1
-female,white,66,post-grad,MD,0.359837503,3,1
-male,white,37,post-grad,TN,0.63624343,3,0
-female,white,54,hs,OH,0.542676846,1,0
-female,other,24,some college,TN,0.63624343,3,0
-female,white,19,some college,MO,0.59818561,1,1
-male,white,53,some college,VA,0.471736237,3,1
-female,white,71,hs,KY,0.65670629,3,1
-female,white,52,some college,WI,0.50407989,1,0
-female,other,24,some college,NJ,0.427158099,2,0
-female,other,65,4-year college,TX,0.547132256,3,0
-male,white,88,4-year college,MA,0.353487213,2,1
-female,white,51,hs,MA,0.353487213,2,0
-female,white,34,4-year college,OR,0.438441611,4,0
-male,white,47,some college,TX,0.547132256,3,1
-female,white,27,4-year college,OH,0.542676846,1,0
-female,other,29,hs,GA,0.526611726,3,0
-female,white,25,4-year college,TX,0.547132256,3,1
-male,white,55,4-year college,MS,0.590898473,3,1
-male,white,36,some college,KY,0.65670629,3,0
-female,white,48,4-year college,OR,0.438441611,4,0
-female,other,68,4-year college,FL,0.506188355,3,1
-female,black,24,some college,FL,0.506188355,3,0
-male,white,83,4-year college,SC,0.574602564,3,1
-male,white,61,some college,CA,0.338717892,4,0
-male,white,57,post-grad,KS,0.611114703,1,0
-female,white,63,some college,TN,0.63624343,3,0
-female,black,40,post-grad,NY,0.382275815,2,0
-female,white,55,hs,IL,0.409799486,1,0
-female,white,32,4-year college,IL,0.409799486,1,0
-female,white,28,some college,NJ,0.427158099,2,1
-female,other,20,hs,NJ,0.427158099,2,1
-female,other,44,some college,CA,0.338717892,4,0
-male,white,68,some college,OH,0.542676846,1,1
-female,white,46,some college,NM,0.453492051,4,1
-male,white,25,4-year college,CA,0.338717892,4,1
-male,white,36,hs,NM,0.453492051,4,0
-female,white,88,some college,LA,0.601716772,3,1
-male,black,46,some college,NY,0.382275815,2,0
-female,white,45,some college,SC,0.574602564,3,0
-female,white,42,4-year college,WI,0.50407989,1,0
-male,white,53,some college,FL,0.506188355,3,1
-female,white,58,hs,NH,0.498029716,2,0
-female,white,99,hs,IL,0.409799486,1,1
-male,white,40,some college,NY,0.382275815,2,0
-male,white,85,hs,MD,0.359837503,3,0
-female,white,81,hs,TN,0.63624343,3,0
-female,white,63,some college,FL,0.506188355,3,1
-female,other,26,some college,CA,0.338717892,4,0
-female,white,24,some college,MI,0.501176682,1,0
-female,white,41,4-year college,NY,0.382275815,2,0
-female,white,67,hs,RI,0.416892959,2,0
-male,white,65,some college,KS,0.611114703,1,0
-female,white,25,4-year college,PA,0.503755358,2,0
-female,white,63,post-grad,OH,0.542676846,1,1
-male,white,97,4-year college,NH,0.498029716,2,0
-male,white,56,4-year college,SD,0.659718581,1,1
-female,white,48,hs,TX,0.547132256,3,1
-female,white,84,post-grad,WA,0.412130688,4,0
-male,white,52,no hs,CA,0.338717892,4,0
-female,white,69,4-year college,CA,0.338717892,4,0
-female,white,64,hs,NC,0.519037458,3,1
-male,white,55,post-grad,CA,0.338717892,4,0
-female,white,42,post-grad,OH,0.542676846,1,1
-female,white,68,4-year college,AZ,0.518900234,4,0
-female,white,58,hs,CA,0.338717892,4,1
-female,white,26,4-year college,KY,0.65670629,3,0
-female,other,22,4-year college,FL,0.506188355,3,1
-male,white,25,hs,IL,0.409799486,1,1
-female,other,29,hs,CA,0.338717892,4,0
-female,white,23,hs,GA,0.526611726,3,0
-male,white,47,no hs,GA,0.526611726,3,0
-male,white,78,some college,SC,0.574602564,3,1
-male,black,18,hs,CA,0.338717892,4,0
-female,black,61,no hs,TN,0.63624343,3,0
-female,white,47,4-year college,PA,0.503755358,2,1
-female,white,59,some college,NY,0.382275815,2,0
-male,white,30,4-year college,NY,0.382275815,2,0
-female,white,38,some college,PA,0.503755358,2,0
-female,white,23,some college,NC,0.519037458,3,1
-female,white,29,no hs,CA,0.338717892,4,0
-female,other,45,post-grad,NC,0.519037458,3,1
-male,white,37,some college,OH,0.542676846,1,0
-male,white,32,4-year college,IL,0.409799486,1,0
-male,white,71,4-year college,FL,0.506188355,3,1
-male,black,60,hs,IL,0.409799486,1,0
-male,white,56,hs,AL,0.643741436,3,1
-female,white,26,hs,TX,0.547132256,3,1
-male,white,18,hs,TX,0.547132256,3,0
-female,white,65,4-year college,OH,0.542676846,1,0
-female,white,51,hs,MO,0.59818561,1,1
-male,white,47,post-grad,PA,0.503755358,2,0
-male,white,67,4-year college,FL,0.506188355,3,1
-male,white,62,some college,IL,0.409799486,1,0
-male,white,27,hs,OH,0.542676846,1,0
-female,other,22,post-grad,CA,0.338717892,4,0
-female,black,41,some college,OH,0.542676846,1,1
-male,other,55,some college,CA,0.338717892,4,0
-male,black,42,hs,CT,0.428584525,2,1
-female,white,29,4-year college,MI,0.501176682,1,1
-female,white,18,4-year college,CA,0.338717892,4,0
-female,black,57,some college,WI,0.50407989,1,0
-female,white,41,some college,MD,0.359837503,3,0
-female,white,59,post-grad,MO,0.59818561,1,0
-female,white,26,hs,TX,0.547132256,3,0
-male,white,33,hs,NC,0.519037458,3,1
-female,white,39,post-grad,IN,0.601173095,1,0
-female,white,61,some college,AL,0.643741436,3,1
-female,other,34,some college,TX,0.547132256,3,0
-female,white,37,hs,PA,0.503755358,2,1
-male,white,29,4-year college,ND,0.698092429,1,0
-male,white,34,post-grad,PA,0.503755358,2,1
-male,white,89,post-grad,GA,0.526611726,3,0
-male,white,53,post-grad,WV,0.721610523,3,1
-female,white,66,some college,NY,0.382275815,2,0
-female,white,63,some college,IA,0.550635478,1,0
-female,white,69,some college,CO,0.473166666,4,0
-male,white,89,some college,IA,0.550635478,1,1
-female,other,43,some college,NV,0.487062906,4,0
-female,white,47,some college,PA,0.503755358,2,0
-female,white,18,4-year college,WI,0.50407989,1,0
-female,white,33,some college,GA,0.526611726,3,1
-female,white,63,4-year college,MI,0.501176682,1,1
-male,white,48,post-grad,WI,0.50407989,1,0
-female,other,25,some college,CA,0.338717892,4,1
-male,white,25,4-year college,FL,0.506188355,3,1
-female,white,30,hs,NJ,0.427158099,2,1
-male,white,43,some college,CA,0.338717892,4,1
-female,white,56,some college,HI,0.325586625,4,1
-female,white,57,some college,WA,0.412130688,4,0
-female,black,22,hs,NC,0.519037458,3,1
-female,other,20,some college,CA,0.338717892,4,1
-female,other,28,some college,TX,0.547132256,3,0
-male,white,59,4-year college,VA,0.471736237,3,1
-female,white,23,hs,CA,0.338717892,4,1
-female,other,35,post-grad,PA,0.503755358,2,0
-female,black,45,hs,IL,0.409799486,1,1
-male,white,46,hs,NY,0.382275815,2,0
-male,white,67,some college,PA,0.503755358,2,0
-male,white,40,post-grad,GA,0.526611726,3,1
-male,white,69,some college,TN,0.63624343,3,0
-male,white,32,post-grad,FL,0.506188355,3,1
-female,black,30,some college,GA,0.526611726,3,0
-male,white,53,4-year college,WI,0.50407989,1,0
-female,white,22,hs,PA,0.503755358,2,0
-male,white,91,post-grad,FL,0.506188355,3,0
-female,white,29,4-year college,NY,0.382275815,2,0
-male,white,26,4-year college,IL,0.409799486,1,1
-male,white,31,4-year college,MD,0.359837503,3,0
-female,black,53,some college,TX,0.547132256,3,0
-female,white,27,4-year college,ME,0.484032089,2,0
-male,white,55,some college,KY,0.65670629,3,0
-female,white,28,some college,CA,0.338717892,4,0
-female,white,34,no hs,AL,0.643741436,3,1
-female,white,65,some college,PA,0.503755358,2,1
-female,black,21,hs,NY,0.382275815,2,0
-female,white,61,hs,CT,0.428584525,2,0
-female,other,28,post-grad,AZ,0.518900234,4,0
-female,white,43,some college,MN,0.491681431,1,1
-female,white,59,hs,MO,0.59818561,1,0
-male,white,36,some college,OH,0.542676846,1,0
-female,other,84,some college,AZ,0.518900234,4,1
-male,white,66,hs,MO,0.59818561,1,0
-female,white,49,4-year college,MI,0.501176682,1,0
-female,white,26,hs,FL,0.506188355,3,1
-female,white,45,hs,OH,0.542676846,1,0
-female,black,23,hs,NM,0.453492051,4,0
-female,other,55,4-year college,NY,0.382275815,2,0
-female,other,20,some college,FL,0.506188355,3,1
-male,other,43,post-grad,CA,0.338717892,4,0
-female,white,20,some college,FL,0.506188355,3,0
-male,white,82,4-year college,CA,0.338717892,4,0
-male,white,63,4-year college,CA,0.338717892,4,1
-female,other,39,some college,HI,0.325586625,4,1
-female,white,98,hs,MA,0.353487213,2,1
-female,white,43,4-year college,TX,0.547132256,3,0
-male,other,35,4-year college,CT,0.428584525,2,0
-female,other,47,some college,AL,0.643741436,3,1
-male,white,62,4-year college,PA,0.503755358,2,0
-male,white,55,some college,PA,0.503755358,2,1
-male,white,69,hs,PA,0.503755358,2,1
-female,black,38,some college,IN,0.601173095,1,0
-female,other,19,some college,MA,0.353487213,2,0
-female,white,54,post-grad,TX,0.547132256,3,0
-male,white,54,hs,CA,0.338717892,4,1
-female,other,59,4-year college,TX,0.547132256,3,0
-male,white,60,no hs,IL,0.409799486,1,0
-female,white,27,some college,IN,0.601173095,1,0
-male,white,30,some college,VA,0.471736237,3,0
-male,white,38,some college,MS,0.590898473,3,0
-female,white,37,post-grad,TX,0.547132256,3,0
-female,white,70,some college,MD,0.359837503,3,0
-female,white,62,hs,LA,0.601716772,3,1
-male,white,93,some college,AZ,0.518900234,4,1
-female,white,63,some college,MA,0.353487213,2,0
-male,white,67,hs,MD,0.359837503,3,0
-female,white,61,4-year college,MO,0.59818561,1,1
-male,other,62,post-grad,NY,0.382275815,2,0
-female,white,54,hs,WI,0.50407989,1,1
-male,other,18,some college,GA,0.526611726,3,0
-female,white,78,some college,CA,0.338717892,4,1
-female,white,28,hs,UT,0.623836582,4,1
-male,black,29,some college,PA,0.503755358,2,1
-female,white,33,4-year college,CA,0.338717892,4,0
-female,white,54,hs,MS,0.590898473,3,0
-female,white,65,hs,SC,0.574602564,3,1
-female,black,59,some college,PA,0.503755358,2,0
-male,white,52,4-year college,UT,0.623836582,4,0
-male,other,54,4-year college,PA,0.503755358,2,1
-male,white,98,4-year college,FL,0.506188355,3,1
-female,white,47,no hs,WY,0.757053196,4,1
-female,other,23,some college,OH,0.542676846,1,0
-male,white,73,post-grad,MO,0.59818561,1,0
-male,white,65,post-grad,GA,0.526611726,3,0
-female,black,97,post-grad,WI,0.50407989,1,0
-female,white,51,some college,AZ,0.518900234,4,1
-female,white,92,some college,WA,0.412130688,4,1
-female,white,83,some college,AZ,0.518900234,4,1
-female,white,36,some college,GA,0.526611726,3,0
-female,white,99,some college,FL,0.506188355,3,0
-female,white,60,some college,TX,0.547132256,3,1
-female,black,21,4-year college,MN,0.491681431,1,0
-female,white,74,hs,AZ,0.518900234,4,0
-male,white,22,no hs,OH,0.542676846,1,1
-male,white,35,4-year college,PA,0.503755358,2,1
-female,white,75,hs,SC,0.574602564,3,0
-male,other,42,hs,NY,0.382275815,2,0
-female,white,28,hs,OH,0.542676846,1,1
-male,white,61,hs,CA,0.338717892,4,1
-female,white,69,hs,TN,0.63624343,3,0
-female,white,77,some college,CA,0.338717892,4,1
-male,other,51,some college,FL,0.506188355,3,0
-female,black,51,hs,MO,0.59818561,1,1
-female,other,37,no hs,AZ,0.518900234,4,1
-male,other,29,some college,CA,0.338717892,4,0
-female,other,25,no hs,AZ,0.518900234,4,0
-male,white,28,some college,MO,0.59818561,1,0
-male,white,44,4-year college,VA,0.471736237,3,1
-male,white,35,some college,OH,0.542676846,1,1
-female,white,54,4-year college,IL,0.409799486,1,0
-female,white,29,hs,IL,0.409799486,1,1
-female,white,33,post-grad,TX,0.547132256,3,1
-male,other,41,4-year college,NY,0.382275815,2,0
-female,white,43,some college,VA,0.471736237,3,0
-male,white,83,some college,PA,0.503755358,2,1
-male,white,77,post-grad,NY,0.382275815,2,0
-female,white,67,post-grad,MS,0.590898473,3,0
-male,other,48,post-grad,TX,0.547132256,3,0
-male,white,57,4-year college,NM,0.453492051,4,0
-male,other,29,4-year college,TX,0.547132256,3,0
-female,white,50,some college,FL,0.506188355,3,0
-female,white,70,4-year college,CA,0.338717892,4,0
-male,white,76,some college,FL,0.506188355,3,1
-female,white,69,some college,WV,0.721610523,3,1
-female,white,32,4-year college,CA,0.338717892,4,0
-female,other,31,hs,TX,0.547132256,3,0
-male,white,55,some college,UT,0.623836582,4,1
-male,white,56,4-year college,NC,0.519037458,3,1
-female,other,57,post-grad,VA,0.471736237,3,1
-female,white,72,hs,PA,0.503755358,2,1
-female,white,68,some college,FL,0.506188355,3,1
-female,white,74,4-year college,TN,0.63624343,3,1
-male,white,50,some college,OR,0.438441611,4,0
-male,white,27,no hs,LA,0.601716772,3,0
-female,white,18,some college,MI,0.501176682,1,0
-female,white,40,hs,SC,0.574602564,3,0
-male,other,21,some college,CA,0.338717892,4,1
-female,white,82,hs,FL,0.506188355,3,1
-female,white,30,hs,NH,0.498029716,2,0
-female,white,55,post-grad,OR,0.438441611,4,1
-female,white,38,post-grad,PA,0.503755358,2,0
-female,white,66,some college,CO,0.473166666,4,0
-male,white,64,post-grad,MD,0.359837503,3,1
-male,other,43,post-grad,NY,0.382275815,2,0
-male,white,54,some college,NY,0.382275815,2,0
-female,white,62,hs,NY,0.382275815,2,1
-male,white,64,some college,FL,0.506188355,3,0
-male,white,47,some college,KS,0.611114703,1,0
-female,white,47,hs,PA,0.503755358,2,1
-male,white,74,post-grad,IL,0.409799486,1,1
-female,black,63,4-year college,GA,0.526611726,3,0
-female,white,56,hs,TN,0.63624343,3,1
-male,white,82,some college,MN,0.491681431,1,0
-female,white,81,hs,FL,0.506188355,3,1
-female,white,30,4-year college,AZ,0.518900234,4,0
-male,other,39,some college,MN,0.491681431,1,1
-female,white,54,hs,OR,0.438441611,4,1
-male,other,26,some college,NJ,0.427158099,2,0
-female,white,45,hs,NY,0.382275815,2,0
-female,white,49,no hs,MI,0.501176682,1,0
-female,white,49,some college,IL,0.409799486,1,1
-female,white,62,some college,AL,0.643741436,3,0
-female,white,52,hs,NY,0.382275815,2,1
-male,white,32,4-year college,IN,0.601173095,1,0
-male,white,63,hs,ID,0.683101767,4,0
-female,white,32,4-year college,IL,0.409799486,1,0
-female,white,21,4-year college,TX,0.547132256,3,0
-female,other,32,post-grad,ND,0.698092429,1,0
-male,white,59,hs,NJ,0.427158099,2,0
-female,white,20,hs,NY,0.382275815,2,0
-female,white,86,post-grad,IN,0.601173095,1,1
-female,white,67,some college,OH,0.542676846,1,0
-male,white,23,some college,OH,0.542676846,1,0
-female,white,29,4-year college,LA,0.601716772,3,1
-male,white,38,post-grad,IL,0.409799486,1,0
-female,black,23,some college,CA,0.338717892,4,0
-male,white,58,4-year college,VA,0.471736237,3,0
-male,white,59,post-grad,FL,0.506188355,3,1
-male,white,19,4-year college,NY,0.382275815,2,0
-female,white,50,some college,WA,0.412130688,4,1
-female,white,24,4-year college,IA,0.550635478,1,0
-female,other,24,some college,UT,0.623836582,4,0
-female,white,18,4-year college,PA,0.503755358,2,1
-female,white,49,4-year college,WI,0.50407989,1,0
-female,black,47,some college,NC,0.519037458,3,1
-female,white,44,some college,IA,0.550635478,1,1
-female,white,61,hs,OR,0.438441611,4,0
-female,white,42,post-grad,IA,0.550635478,1,1
-female,white,21,4-year college,WI,0.50407989,1,0
-female,white,23,some college,IN,0.601173095,1,1
-female,black,27,hs,PA,0.503755358,2,1
-male,white,59,hs,CA,0.338717892,4,1
-male,white,83,post-grad,NV,0.487062906,4,1
-male,other,53,post-grad,CA,0.338717892,4,0
-female,white,96,some college,CA,0.338717892,4,0
-female,black,61,hs,OH,0.542676846,1,1
-female,white,60,some college,KY,0.65670629,3,1
-female,white,100,post-grad,MD,0.359837503,3,0
-female,white,36,some college,KY,0.65670629,3,1
-female,white,66,some college,AR,0.642851377,3,1
-female,white,21,hs,ME,0.484032089,2,0
-female,white,25,some college,TX,0.547132256,3,0
-female,other,27,hs,OK,0.693047372,3,0
-male,white,27,hs,MI,0.501176682,1,0
-female,white,19,hs,FL,0.506188355,3,1
-female,white,23,4-year college,FL,0.506188355,3,0
-female,black,40,some college,IN,0.601173095,1,1
-female,white,68,hs,IL,0.409799486,1,0
-male,white,65,hs,PA,0.503755358,2,0
-male,white,20,some college,FL,0.506188355,3,0
-male,white,68,4-year college,IL,0.409799486,1,1
-female,white,28,hs,ME,0.484032089,2,0
-male,white,51,hs,FL,0.506188355,3,1
-male,white,18,some college,NY,0.382275815,2,0
-male,other,26,4-year college,TX,0.547132256,3,0
-female,black,30,4-year college,NY,0.382275815,2,1
-male,white,92,4-year college,UT,0.623836582,4,0
-female,other,65,hs,OR,0.438441611,4,0
-female,white,92,some college,VA,0.471736237,3,0
-female,white,60,hs,CA,0.338717892,4,0
-male,white,56,hs,OR,0.438441611,4,0
-male,white,56,some college,NY,0.382275815,2,0
-female,black,58,post-grad,VA,0.471736237,3,1
-female,black,56,4-year college,TX,0.547132256,3,0
-female,other,32,4-year college,NY,0.382275815,2,1
-male,white,64,4-year college,MI,0.501176682,1,1
-female,other,43,4-year college,NJ,0.427158099,2,0
-female,black,46,4-year college,MD,0.359837503,3,0
-female,white,28,4-year college,MI,0.501176682,1,1
-male,white,39,some college,IL,0.409799486,1,0
-male,black,21,some college,DE,0.440013786,3,1
-female,black,46,4-year college,LA,0.601716772,3,0
-male,white,31,hs,NY,0.382275815,2,1
-female,white,48,4-year college,MA,0.353487213,2,0
-female,black,69,some college,VA,0.471736237,3,0
-female,white,33,some college,OH,0.542676846,1,0
-female,white,51,4-year college,GA,0.526611726,3,0
-male,other,44,post-grad,TN,0.63624343,3,0
-male,white,95,4-year college,AL,0.643741436,3,1
-male,black,26,no hs,TX,0.547132256,3,0
-male,white,28,hs,LA,0.601716772,3,0
-female,white,44,4-year college,AR,0.642851377,3,1
-male,white,60,4-year college,AR,0.642851377,3,0
-female,other,32,hs,MN,0.491681431,1,0
-female,white,22,hs,IN,0.601173095,1,1
-female,other,51,post-grad,WA,0.412130688,4,1
-male,white,62,post-grad,GA,0.526611726,3,1
-male,white,66,hs,IL,0.409799486,1,0
-female,white,23,4-year college,WI,0.50407989,1,0
-male,white,38,post-grad,MI,0.501176682,1,0
-male,white,66,hs,IN,0.601173095,1,1
-female,white,49,4-year college,VA,0.471736237,3,0
-female,other,25,some college,TX,0.547132256,3,0
-male,white,54,hs,NC,0.519037458,3,0
-male,white,66,hs,MI,0.501176682,1,0
-male,white,32,some college,NJ,0.427158099,2,1
-male,white,25,4-year college,CA,0.338717892,4,0
-female,white,66,some college,WI,0.50407989,1,0
-female,white,92,some college,IL,0.409799486,1,0
-female,white,65,post-grad,GA,0.526611726,3,1
-male,white,34,hs,WA,0.412130688,4,0
-female,other,60,hs,NY,0.382275815,2,0
-male,black,60,some college,MI,0.501176682,1,1
-male,black,30,hs,CO,0.473166666,4,1
-male,white,29,some college,MO,0.59818561,1,0
-female,white,23,4-year college,NY,0.382275815,2,0
-male,white,43,4-year college,CO,0.473166666,4,0
-female,white,66,hs,FL,0.506188355,3,0
-male,white,63,some college,FL,0.506188355,3,1
-female,other,52,hs,OH,0.542676846,1,1
-male,white,86,4-year college,IL,0.409799486,1,1
-female,white,43,hs,NY,0.382275815,2,0
-male,white,47,hs,IL,0.409799486,1,0
-female,white,44,some college,VA,0.471736237,3,0
-female,other,43,no hs,AR,0.642851377,3,1
-female,white,35,4-year college,MT,0.611096643,4,0
-male,white,63,some college,IN,0.601173095,1,1
-female,white,20,some college,CT,0.428584525,2,0
-female,white,24,4-year college,WI,0.50407989,1,0
-female,white,55,some college,FL,0.506188355,3,0
-male,white,50,hs,NC,0.519037458,3,1
-female,white,63,no hs,AR,0.642851377,3,0
-male,white,25,some college,CA,0.338717892,4,1
-male,white,32,post-grad,AK,0.583856547,4,0
-male,white,66,some college,NY,0.382275815,2,0
-male,white,57,hs,KY,0.65670629,3,0
-female,white,57,some college,AL,0.643741436,3,0
-male,other,37,hs,CA,0.338717892,4,0
-female,white,40,post-grad,IL,0.409799486,1,0
-male,other,26,post-grad,MI,0.501176682,1,0
-female,white,58,hs,TN,0.63624343,3,1
-male,white,41,some college,UT,0.623836582,4,1
-female,white,81,some college,TX,0.547132256,3,1
-female,black,49,4-year college,VA,0.471736237,3,0
-male,white,45,post-grad,OH,0.542676846,1,1
-female,white,32,4-year college,IL,0.409799486,1,0
-male,white,55,post-grad,MA,0.353487213,2,0
-male,white,37,some college,IN,0.601173095,1,1
-female,white,26,some college,PA,0.503755358,2,1
-male,white,61,some college,NJ,0.427158099,2,0
-male,white,38,hs,NY,0.382275815,2,0
-male,white,75,hs,IN,0.601173095,1,1
-male,white,44,post-grad,WA,0.412130688,4,0
-female,white,64,hs,WI,0.50407989,1,0
-female,other,45,post-grad,MA,0.353487213,2,0
-female,white,28,4-year college,AL,0.643741436,3,0
-male,white,42,post-grad,IN,0.601173095,1,1
-male,white,57,some college,OH,0.542676846,1,0
-female,black,37,4-year college,CA,0.338717892,4,0
-male,white,93,hs,WI,0.50407989,1,1
-male,white,52,some college,TX,0.547132256,3,1
-male,white,62,post-grad,VA,0.471736237,3,1
-male,black,35,4-year college,NC,0.519037458,3,1
-female,white,30,hs,NV,0.487062906,4,0
-female,other,29,hs,FL,0.506188355,3,0
-female,white,68,4-year college,IN,0.601173095,1,1
-female,white,86,some college,WA,0.412130688,4,1
-male,white,85,post-grad,OR,0.438441611,4,1
-female,white,52,hs,NY,0.382275815,2,1
-male,white,35,hs,IL,0.409799486,1,1
-female,white,64,some college,NH,0.498029716,2,0
-male,white,81,some college,WA,0.412130688,4,1
-female,white,70,post-grad,MI,0.501176682,1,0
-male,other,21,some college,CA,0.338717892,4,0
-female,white,95,4-year college,MA,0.353487213,2,0
-female,white,34,4-year college,WA,0.412130688,4,0
-female,other,19,hs,IN,0.601173095,1,0
-female,other,23,no hs,TX,0.547132256,3,1
-male,white,92,some college,IN,0.601173095,1,0
-male,white,21,some college,LA,0.601716772,3,1
-female,black,34,some college,TX,0.547132256,3,0
-female,white,27,some college,PA,0.503755358,2,0
-male,white,64,hs,CA,0.338717892,4,1
-female,white,65,some college,MO,0.59818561,1,1
-female,black,42,4-year college,MD,0.359837503,3,0
-male,other,36,some college,CA,0.338717892,4,0
-male,white,69,no hs,PA,0.503755358,2,1
-female,white,62,hs,FL,0.506188355,3,1
-female,white,56,some college,WI,0.50407989,1,0
-female,black,45,4-year college,MD,0.359837503,3,0
-female,white,57,some college,MA,0.353487213,2,0
-male,white,58,hs,AL,0.643741436,3,1
-male,other,38,post-grad,IL,0.409799486,1,0
-female,white,82,4-year college,ND,0.698092429,1,1
-female,other,23,hs,CA,0.338717892,4,1
-male,black,19,4-year college,GA,0.526611726,3,1
-male,other,31,4-year college,PA,0.503755358,2,1
-female,black,21,hs,GA,0.526611726,3,0
-male,other,29,hs,NC,0.519037458,3,0
-male,white,52,some college,NY,0.382275815,2,0
-female,white,57,post-grad,NY,0.382275815,2,1
-male,white,67,4-year college,CA,0.338717892,4,1
-female,white,19,4-year college,NY,0.382275815,2,0
-female,white,41,hs,IL,0.409799486,1,0
-female,white,33,some college,CA,0.338717892,4,1
-male,white,72,some college,NV,0.487062906,4,1
-female,other,52,some college,TX,0.547132256,3,0
-female,black,33,post-grad,MD,0.359837503,3,0
-female,white,36,no hs,NC,0.519037458,3,0
-female,white,69,some college,NE,0.635476741,1,0
-female,white,22,4-year college,WA,0.412130688,4,0
-female,white,48,some college,PA,0.503755358,2,0
-male,white,80,post-grad,IN,0.601173095,1,1
-male,white,43,hs,UT,0.623836582,4,0
-female,black,47,hs,OH,0.542676846,1,0
-female,other,59,some college,TX,0.547132256,3,1
-male,white,89,hs,OH,0.542676846,1,0
-female,other,37,hs,CA,0.338717892,4,0
-female,white,35,some college,OH,0.542676846,1,0
-female,white,69,some college,TX,0.547132256,3,1
-female,white,69,hs,FL,0.506188355,3,1
-female,other,30,4-year college,GA,0.526611726,3,0
-female,white,94,hs,PA,0.503755358,2,1
-female,white,36,some college,PA,0.503755358,2,0
-female,other,49,some college,CA,0.338717892,4,0
-female,white,35,some college,WI,0.50407989,1,0
-male,white,93,post-grad,WI,0.50407989,1,0
-female,other,23,post-grad,FL,0.506188355,3,0
-female,white,93,some college,NY,0.382275815,2,0
-male,white,31,post-grad,NC,0.519037458,3,1
-female,black,38,no hs,MD,0.359837503,3,0
-male,white,52,hs,SC,0.574602564,3,0
-female,white,62,post-grad,PA,0.503755358,2,1
-male,other,29,some college,IL,0.409799486,1,1
-female,white,18,4-year college,MA,0.353487213,2,0
-male,white,19,some college,OH,0.542676846,1,0
-male,white,82,post-grad,CT,0.428584525,2,1
-male,white,83,some college,MS,0.590898473,3,1
-female,white,74,no hs,UT,0.623836582,4,1
-male,white,61,hs,KY,0.65670629,3,1
-male,white,34,some college,IN,0.601173095,1,1
-male,white,37,4-year college,WI,0.50407989,1,1
-male,white,47,hs,MA,0.353487213,2,0
-female,white,49,hs,DE,0.440013786,3,1
-male,white,53,hs,MA,0.353487213,2,1
-female,white,68,post-grad,SC,0.574602564,3,1
-female,white,65,some college,NV,0.487062906,4,0
-female,white,33,hs,CA,0.338717892,4,0
-male,white,53,hs,WA,0.412130688,4,0
-female,white,51,4-year college,MN,0.491681431,1,0
-female,black,59,hs,IL,0.409799486,1,0
-male,white,43,hs,NY,0.382275815,2,0
-male,white,65,post-grad,HI,0.325586625,4,0
-male,white,66,hs,CT,0.428584525,2,0
-female,other,23,4-year college,NC,0.519037458,3,0
-female,white,68,hs,OH,0.542676846,1,0
-male,white,89,hs,OR,0.438441611,4,0
-male,white,35,hs,TX,0.547132256,3,1
-female,other,39,hs,OK,0.693047372,3,0
-female,black,26,some college,CO,0.473166666,4,0
-male,white,69,some college,KY,0.65670629,3,0
-female,other,38,post-grad,CA,0.338717892,4,0
-female,white,38,post-grad,FL,0.506188355,3,0
-female,black,34,no hs,PA,0.503755358,2,0
-male,white,53,some college,RI,0.416892959,2,0
-female,white,29,some college,NC,0.519037458,3,0
-male,white,98,hs,FL,0.506188355,3,1
-female,white,47,some college,CA,0.338717892,4,0
-male,white,62,hs,SC,0.574602564,3,0
-female,white,37,hs,NY,0.382275815,2,0
-male,white,40,hs,NY,0.382275815,2,0
-female,white,77,post-grad,AL,0.643741436,3,0
-female,white,20,some college,PA,0.503755358,2,1
-male,white,54,hs,NY,0.382275815,2,0
-female,white,54,4-year college,NY,0.382275815,2,0
-female,white,19,no hs,WV,0.721610523,3,1
-female,white,54,post-grad,CA,0.338717892,4,0
-female,white,27,some college,RI,0.416892959,2,0
-female,white,23,some college,WV,0.721610523,3,1
-female,other,48,some college,IL,0.409799486,1,0
-female,white,47,hs,OR,0.438441611,4,1
-male,other,28,some college,CA,0.338717892,4,1
-male,white,23,4-year college,NY,0.382275815,2,0
-male,other,58,4-year college,FL,0.506188355,3,1
-male,other,62,4-year college,NH,0.498029716,2,1
-male,white,36,4-year college,NH,0.498029716,2,1
-female,other,27,post-grad,MA,0.353487213,2,1
-female,white,66,4-year college,MA,0.353487213,2,0
-female,black,51,hs,IL,0.409799486,1,0
-female,white,22,some college,TX,0.547132256,3,0
-male,white,65,hs,IN,0.601173095,1,1
-female,white,40,hs,WI,0.50407989,1,0
-male,other,33,some college,FL,0.506188355,3,0
-female,other,32,hs,IL,0.409799486,1,0
-male,other,51,hs,NY,0.382275815,2,0
-male,white,65,hs,IL,0.409799486,1,0
-female,other,33,hs,MN,0.491681431,1,1
-female,white,18,4-year college,TX,0.547132256,3,0
-female,white,64,some college,GA,0.526611726,3,1
-male,other,26,some college,CA,0.338717892,4,0
-female,other,25,4-year college,AL,0.643741436,3,0
-female,white,66,post-grad,GA,0.526611726,3,1
-female,black,62,4-year college,LA,0.601716772,3,0
-female,white,55,hs,MA,0.353487213,2,0
-female,white,71,4-year college,CA,0.338717892,4,0
-female,white,37,no hs,GA,0.526611726,3,0
-female,white,47,hs,LA,0.601716772,3,0
-female,white,37,some college,CT,0.428584525,2,1
-female,white,97,hs,NC,0.519037458,3,1
-male,white,69,post-grad,AZ,0.518900234,4,0
-female,other,39,hs,TX,0.547132256,3,1
-female,white,68,post-grad,MN,0.491681431,1,0
-male,white,66,post-grad,UT,0.623836582,4,1
-female,white,63,hs,KY,0.65670629,3,0
-female,white,37,some college,NV,0.487062906,4,1
-female,white,40,hs,CO,0.473166666,4,0
-female,white,30,post-grad,GA,0.526611726,3,0
-female,black,49,some college,NC,0.519037458,3,1
-male,white,67,hs,NJ,0.427158099,2,1
-female,other,27,some college,CA,0.338717892,4,1
-female,white,44,post-grad,TN,0.63624343,3,0
-male,white,75,post-grad,CA,0.338717892,4,1
-female,white,24,some college,TX,0.547132256,3,1
-female,white,49,post-grad,VA,0.471736237,3,1
-female,white,47,4-year college,NJ,0.427158099,2,0
-male,white,39,some college,OK,0.693047372,3,1
-male,other,65,hs,MO,0.59818561,1,0
-male,white,59,4-year college,TX,0.547132256,3,1
-female,white,48,4-year college,WI,0.50407989,1,1
-female,white,36,post-grad,PA,0.503755358,2,0
-female,black,52,some college,MD,0.359837503,3,0
-male,other,21,hs,CA,0.338717892,4,0
-female,white,34,4-year college,IN,0.601173095,1,1
-male,white,22,post-grad,MD,0.359837503,3,0
-male,white,83,4-year college,FL,0.506188355,3,1
-male,white,77,hs,NY,0.382275815,2,1
-female,white,46,some college,NY,0.382275815,2,1
-male,white,50,post-grad,UT,0.623836582,4,1
-female,white,96,some college,PA,0.503755358,2,0
-female,white,24,hs,PA,0.503755358,2,1
-female,white,47,post-grad,MI,0.501176682,1,0
-female,white,29,4-year college,FL,0.506188355,3,0
-female,white,57,hs,NV,0.487062906,4,1
-female,white,65,4-year college,TX,0.547132256,3,0
-female,white,67,hs,GA,0.526611726,3,1
-female,white,63,hs,PA,0.503755358,2,0
-female,white,30,4-year college,OK,0.693047372,3,1
-female,white,33,4-year college,CT,0.428584525,2,0
-female,white,58,hs,NJ,0.427158099,2,0
-female,white,81,4-year college,CA,0.338717892,4,1
-male,other,26,some college,AZ,0.518900234,4,0
-female,white,51,some college,NY,0.382275815,2,0
-female,other,22,post-grad,TX,0.547132256,3,0
-male,white,61,some college,IL,0.409799486,1,1
-male,white,62,4-year college,OK,0.693047372,3,1
-female,white,33,hs,NY,0.382275815,2,0
-male,white,25,some college,ND,0.698092429,1,0
-female,other,56,4-year college,NJ,0.427158099,2,0
-female,black,53,hs,VA,0.471736237,3,1
-female,black,61,hs,SC,0.574602564,3,0
-male,white,25,some college,VA,0.471736237,3,0
-female,other,82,some college,TX,0.547132256,3,1
-male,white,29,no hs,OR,0.438441611,4,1
-male,white,36,4-year college,NJ,0.427158099,2,0
-female,white,54,4-year college,TX,0.547132256,3,0
-female,white,18,4-year college,IL,0.409799486,1,1
-male,white,27,hs,WI,0.50407989,1,1
-female,white,46,some college,FL,0.506188355,3,0
-female,other,22,no hs,NY,0.382275815,2,0
-female,white,57,some college,HI,0.325586625,4,1
-female,black,39,post-grad,TN,0.63624343,3,0
-male,white,33,hs,KS,0.611114703,1,0
-female,other,32,some college,NY,0.382275815,2,0
-female,white,69,some college,PA,0.503755358,2,0
-male,white,36,4-year college,MI,0.501176682,1,1
-male,white,51,post-grad,PA,0.503755358,2,0
-female,other,25,post-grad,IL,0.409799486,1,0
-female,white,62,hs,ID,0.683101767,4,1
-female,white,80,hs,MD,0.359837503,3,0
-female,other,28,some college,IN,0.601173095,1,1
-male,white,40,hs,IA,0.550635478,1,0
-male,black,43,4-year college,TX,0.547132256,3,0
-male,other,27,hs,FL,0.506188355,3,1
-male,black,58,some college,FL,0.506188355,3,0
-male,white,84,some college,CA,0.338717892,4,0
-female,white,50,some college,WI,0.50407989,1,0
-female,other,30,hs,NY,0.382275815,2,0
-female,white,32,hs,NE,0.635476741,1,0
-female,white,64,hs,FL,0.506188355,3,1
-male,white,92,some college,ID,0.683101767,4,1
-male,other,46,hs,FL,0.506188355,3,0
-male,white,61,4-year college,CA,0.338717892,4,0
-male,white,39,4-year college,TX,0.547132256,3,0
-male,white,60,no hs,NC,0.519037458,3,1
-male,white,88,hs,TX,0.547132256,3,1
-female,white,28,hs,PA,0.503755358,2,0
-female,white,68,some college,KY,0.65670629,3,1
-female,black,48,some college,TX,0.547132256,3,1
-female,other,26,post-grad,CA,0.338717892,4,0
-male,white,48,hs,AL,0.643741436,3,1
-female,white,50,some college,TX,0.547132256,3,1
-female,black,58,4-year college,MI,0.501176682,1,0
-female,white,28,hs,MA,0.353487213,2,0
-male,white,81,hs,GA,0.526611726,3,1
-female,other,28,some college,CA,0.338717892,4,0
-male,white,95,post-grad,HI,0.325586625,4,0
-female,white,21,4-year college,NY,0.382275815,2,0
-female,white,48,hs,NY,0.382275815,2,1
-female,other,30,4-year college,CO,0.473166666,4,0
-female,white,32,hs,TX,0.547132256,3,1
-female,white,66,some college,GA,0.526611726,3,1
-male,white,38,some college,TX,0.547132256,3,0
-female,white,32,some college,PA,0.503755358,2,0
-male,black,45,4-year college,OH,0.542676846,1,0
-female,white,93,hs,NY,0.382275815,2,0
-female,white,26,4-year college,OR,0.438441611,4,0
-female,black,54,some college,MS,0.590898473,3,1
-female,white,66,hs,PA,0.503755358,2,0
-female,white,62,post-grad,GA,0.526611726,3,1
-female,other,57,hs,NY,0.382275815,2,1
-male,other,47,4-year college,NY,0.382275815,2,1
-female,white,42,some college,CO,0.473166666,4,1
-female,other,43,some college,CA,0.338717892,4,0
-male,white,97,hs,FL,0.506188355,3,0
-male,white,18,4-year college,TX,0.547132256,3,0
-male,white,54,some college,NC,0.519037458,3,1
-female,white,49,post-grad,CT,0.428584525,2,0
-male,white,97,post-grad,WA,0.412130688,4,1
-male,white,28,some college,CA,0.338717892,4,1
-female,white,74,hs,NY,0.382275815,2,0
-female,white,44,4-year college,FL,0.506188355,3,1
-male,white,39,some college,CA,0.338717892,4,1
-female,white,66,hs,WI,0.50407989,1,0
-female,white,37,some college,MA,0.353487213,2,1
-male,white,59,4-year college,OH,0.542676846,1,0
-male,white,21,4-year college,FL,0.506188355,3,0
-female,white,68,4-year college,MI,0.501176682,1,0
-female,white,29,4-year college,CA,0.338717892,4,0
-female,white,47,hs,MA,0.353487213,2,0
-female,white,62,post-grad,ND,0.698092429,1,0
-male,white,40,no hs,GA,0.526611726,3,1
-male,white,46,4-year college,TN,0.63624343,3,1
-female,white,60,some college,MI,0.501176682,1,0
-female,white,50,4-year college,MO,0.59818561,1,1
-male,white,65,hs,PA,0.503755358,2,1
-female,white,49,no hs,TX,0.547132256,3,1
-male,white,62,hs,TN,0.63624343,3,1
-female,white,64,hs,RI,0.416892959,2,0
-male,white,47,4-year college,TN,0.63624343,3,1
-female,white,28,4-year college,PA,0.503755358,2,0
-female,white,42,hs,GA,0.526611726,3,0
-female,white,19,some college,IN,0.601173095,1,1
-female,white,23,hs,AZ,0.518900234,4,1
-female,other,28,4-year college,WI,0.50407989,1,0
-female,white,66,hs,NJ,0.427158099,2,1
-male,white,37,some college,CT,0.428584525,2,1
-female,black,56,hs,TN,0.63624343,3,1
-female,white,51,hs,FL,0.506188355,3,1
-male,other,55,4-year college,CA,0.338717892,4,1
-female,other,30,4-year college,NY,0.382275815,2,0
-male,other,53,post-grad,TX,0.547132256,3,1
-male,white,62,some college,MD,0.359837503,3,1
-female,white,38,4-year college,WA,0.412130688,4,1
-male,white,60,some college,AZ,0.518900234,4,1
-female,other,46,some college,FL,0.506188355,3,0
-female,other,29,some college,CA,0.338717892,4,0
-male,white,85,post-grad,MO,0.59818561,1,0
-male,black,22,some college,CA,0.338717892,4,0
-male,other,51,4-year college,MA,0.353487213,2,0
-female,black,20,some college,TN,0.63624343,3,0
-male,white,73,post-grad,TX,0.547132256,3,0
-male,white,34,post-grad,NV,0.487062906,4,1
-male,white,36,some college,FL,0.506188355,3,0
-male,white,59,some college,TX,0.547132256,3,1
-male,other,95,4-year college,TX,0.547132256,3,1
-female,white,54,some college,NH,0.498029716,2,0
-female,white,26,no hs,GA,0.526611726,3,0
-male,black,55,4-year college,NC,0.519037458,3,0
-male,white,38,4-year college,CO,0.473166666,4,0
-female,white,70,some college,IL,0.409799486,1,1
-male,white,50,hs,OR,0.438441611,4,1
-male,white,46,4-year college,MN,0.491681431,1,1
-female,white,90,hs,FL,0.506188355,3,0
-female,other,25,hs,SC,0.574602564,3,1
-female,white,30,hs,TX,0.547132256,3,1
-female,black,44,4-year college,TX,0.547132256,3,1
-female,white,31,hs,NH,0.498029716,2,1
-female,white,66,hs,MA,0.353487213,2,0
-female,white,96,post-grad,AZ,0.518900234,4,0
-female,white,89,hs,PA,0.503755358,2,1
-female,white,55,hs,AL,0.643741436,3,1
-male,white,61,4-year college,TX,0.547132256,3,1
-male,white,42,some college,ME,0.484032089,2,0
-male,white,66,some college,FL,0.506188355,3,0
-female,white,67,some college,TX,0.547132256,3,1
-female,white,56,hs,OK,0.693047372,3,1
-male,white,63,some college,CA,0.338717892,4,0
-female,white,100,post-grad,MD,0.359837503,3,1
-male,other,45,some college,FL,0.506188355,3,1
-female,white,85,post-grad,MA,0.353487213,2,0
-female,white,95,no hs,NY,0.382275815,2,1
-female,white,57,hs,UT,0.623836582,4,1
-male,white,55,hs,CO,0.473166666,4,1
-male,white,48,hs,TX,0.547132256,3,0
-male,white,36,some college,AZ,0.518900234,4,0
-female,white,20,some college,NJ,0.427158099,2,0
-male,black,57,some college,TX,0.547132256,3,0
-female,white,51,no hs,NY,0.382275815,2,0
-male,white,58,some college,CA,0.338717892,4,0
-female,white,55,some college,TX,0.547132256,3,0
-female,black,35,some college,TX,0.547132256,3,1
-female,other,39,4-year college,WA,0.412130688,4,1
-female,other,41,hs,CA,0.338717892,4,0
-female,white,51,post-grad,IL,0.409799486,1,0
-male,white,60,hs,KY,0.65670629,3,0
-female,white,66,hs,OH,0.542676846,1,1
-female,white,53,4-year college,MI,0.501176682,1,1
-female,white,20,no hs,OH,0.542676846,1,0
-female,white,69,some college,TX,0.547132256,3,1
-female,white,44,hs,TN,0.63624343,3,0
-male,white,52,some college,CA,0.338717892,4,0
-male,white,33,hs,CA,0.338717892,4,1
-female,white,24,hs,NC,0.519037458,3,1
-female,white,26,some college,WV,0.721610523,3,0
-male,white,53,some college,NV,0.487062906,4,0
-female,white,78,4-year college,TX,0.547132256,3,1
-male,black,25,hs,NV,0.487062906,4,0
-male,other,37,some college,CA,0.338717892,4,1
-female,other,77,some college,CA,0.338717892,4,1
-male,white,39,hs,KY,0.65670629,3,0
-female,white,49,some college,IN,0.601173095,1,1
-female,white,56,some college,MO,0.59818561,1,1
-female,other,34,some college,MA,0.353487213,2,0
-male,white,44,post-grad,WA,0.412130688,4,0
-female,white,64,post-grad,TX,0.547132256,3,1
-female,white,39,4-year college,ND,0.698092429,1,0
-female,white,26,4-year college,SC,0.574602564,3,0
-female,white,76,some college,TX,0.547132256,3,1
-male,white,94,post-grad,AZ,0.518900234,4,0
-male,white,57,some college,MI,0.501176682,1,1
-female,white,21,some college,MD,0.359837503,3,0
-male,other,63,some college,CA,0.338717892,4,0
-female,white,55,post-grad,FL,0.506188355,3,0
-female,white,21,4-year college,NY,0.382275815,2,1
-female,other,53,some college,CO,0.473166666,4,1
-male,other,65,4-year college,TN,0.63624343,3,1
-female,white,76,hs,TX,0.547132256,3,1
-male,white,20,some college,FL,0.506188355,3,1
-female,other,27,hs,OH,0.542676846,1,0
-male,other,39,some college,NC,0.519037458,3,0
-female,white,61,hs,CA,0.338717892,4,0
-female,white,20,hs,MO,0.59818561,1,0
-female,other,59,hs,TX,0.547132256,3,0
-male,other,45,4-year college,IL,0.409799486,1,1
-male,white,74,post-grad,CA,0.338717892,4,0
-male,white,53,4-year college,IN,0.601173095,1,0
-female,other,19,hs,PA,0.503755358,2,1
-male,white,91,post-grad,ID,0.683101767,4,0
-female,black,38,some college,FL,0.506188355,3,0
-female,white,51,hs,FL,0.506188355,3,0
-female,white,41,hs,MA,0.353487213,2,0
-female,white,96,hs,NC,0.519037458,3,1
-male,other,53,4-year college,TX,0.547132256,3,1
-male,other,61,some college,IN,0.601173095,1,0
-female,white,40,some college,MN,0.491681431,1,1
-male,white,55,hs,IL,0.409799486,1,1
-male,white,65,hs,FL,0.506188355,3,1
-female,white,30,post-grad,MO,0.59818561,1,0
-female,white,57,4-year college,NJ,0.427158099,2,1
-male,white,82,some college,IN,0.601173095,1,0
-female,white,38,some college,AL,0.643741436,3,1
-male,white,62,some college,IL,0.409799486,1,0
-male,white,50,some college,TX,0.547132256,3,1
-female,white,49,some college,WV,0.721610523,3,0
-female,white,37,some college,MD,0.359837503,3,0
-male,white,65,hs,MI,0.501176682,1,0
-female,white,35,4-year college,CO,0.473166666,4,1
-female,other,59,4-year college,NY,0.382275815,2,1
-male,white,63,post-grad,CA,0.338717892,4,0
-male,white,37,4-year college,NH,0.498029716,2,0
-male,other,25,some college,CA,0.338717892,4,1
-male,black,44,4-year college,OK,0.693047372,3,0
-female,white,65,hs,TX,0.547132256,3,1
-male,white,51,hs,CA,0.338717892,4,1
-male,white,71,hs,KY,0.65670629,3,1
-female,black,30,4-year college,AL,0.643741436,3,0
-female,white,61,some college,PA,0.503755358,2,1
-male,white,77,post-grad,NC,0.519037458,3,0
-female,other,59,some college,AZ,0.518900234,4,0
-male,white,45,4-year college,SD,0.659718581,1,0
-male,white,36,post-grad,CA,0.338717892,4,1
-female,other,55,some college,CA,0.338717892,4,0
-female,white,33,some college,AZ,0.518900234,4,0
-female,white,68,some college,ME,0.484032089,2,1
-female,black,34,hs,VA,0.471736237,3,1
-female,white,68,post-grad,NY,0.382275815,2,0
-male,white,24,4-year college,OH,0.542676846,1,0
-male,white,38,4-year college,ND,0.698092429,1,1
-female,white,100,hs,PA,0.503755358,2,1
-female,white,71,post-grad,AR,0.642851377,3,0
-male,white,29,hs,MS,0.590898473,3,1
-female,white,44,some college,PA,0.503755358,2,1
-female,white,23,no hs,NY,0.382275815,2,0
-male,other,29,hs,MI,0.501176682,1,1
-female,white,38,hs,OR,0.438441611,4,1
-female,white,54,some college,TX,0.547132256,3,0
-male,other,53,4-year college,CT,0.428584525,2,1
-male,white,67,hs,AR,0.642851377,3,1
-male,white,42,hs,SC,0.574602564,3,1
-female,white,41,hs,NY,0.382275815,2,1
-male,white,34,some college,OH,0.542676846,1,0
-male,white,27,some college,OH,0.542676846,1,0
-male,white,69,4-year college,NY,0.382275815,2,1
-female,white,39,some college,AR,0.642851377,3,1
-male,white,50,post-grad,WI,0.50407989,1,0
-male,black,23,4-year college,MD,0.359837503,3,0
-female,other,22,no hs,FL,0.506188355,3,0
-female,white,39,hs,TX,0.547132256,3,0
-female,white,41,hs,NC,0.519037458,3,1
-male,other,37,4-year college,CO,0.473166666,4,1
-female,black,35,hs,VA,0.471736237,3,0
-female,white,52,post-grad,VA,0.471736237,3,0
-male,white,89,post-grad,LA,0.601716772,3,0
-male,white,78,hs,FL,0.506188355,3,1
-female,white,57,some college,AZ,0.518900234,4,1
-female,white,69,4-year college,MT,0.611096643,4,1
-male,white,58,post-grad,VT,0.348135737,2,0
-male,white,60,hs,NH,0.498029716,2,0
-female,white,51,some college,LA,0.601716772,3,0
-female,white,70,4-year college,FL,0.506188355,3,0
-male,white,69,hs,FL,0.506188355,3,1
-male,black,66,4-year college,OH,0.542676846,1,1
-female,white,60,post-grad,NY,0.382275815,2,0
-male,white,65,some college,PA,0.503755358,2,0
-female,other,34,some college,TX,0.547132256,3,1
-male,white,74,some college,OR,0.438441611,4,0
-female,other,55,post-grad,FL,0.506188355,3,0
-male,white,86,hs,MI,0.501176682,1,1
-female,white,94,hs,MS,0.590898473,3,1
-male,white,87,post-grad,AZ,0.518900234,4,0
-male,other,24,post-grad,OH,0.542676846,1,0
-female,white,22,4-year college,FL,0.506188355,3,0
-male,white,42,no hs,NY,0.382275815,2,0
-female,white,95,hs,TN,0.63624343,3,1
-female,white,59,some college,NC,0.519037458,3,1
-male,white,23,post-grad,VA,0.471736237,3,0
-male,white,18,some college,FL,0.506188355,3,1
-male,white,68,some college,NV,0.487062906,4,1
-female,white,18,some college,CA,0.338717892,4,0
-male,black,58,4-year college,LA,0.601716772,3,0
-male,white,49,4-year college,DE,0.440013786,3,1
-male,white,68,4-year college,NY,0.382275815,2,1
-male,white,59,post-grad,PA,0.503755358,2,1
-female,white,37,hs,MI,0.501176682,1,0
-female,other,33,4-year college,CO,0.473166666,4,0
-female,white,22,4-year college,MD,0.359837503,3,0
-female,white,45,post-grad,SC,0.574602564,3,0
-female,white,38,no hs,UT,0.623836582,4,0
-female,white,37,4-year college,MA,0.353487213,2,0
-female,white,57,some college,NY,0.382275815,2,0
-female,other,28,no hs,NY,0.382275815,2,1
-female,white,53,hs,NJ,0.427158099,2,1
-male,white,58,4-year college,OH,0.542676846,1,1
-male,white,33,hs,NY,0.382275815,2,0
-female,white,55,some college,IL,0.409799486,1,1
-female,white,67,4-year college,GA,0.526611726,3,0
-male,white,85,post-grad,FL,0.506188355,3,0
-female,white,49,4-year college,MS,0.590898473,3,0
-female,white,20,hs,WV,0.721610523,3,0
-male,white,44,some college,CO,0.473166666,4,0
-female,black,30,some college,FL,0.506188355,3,0
-female,white,21,some college,MN,0.491681431,1,0
-male,white,45,post-grad,TN,0.63624343,3,0
-male,white,31,some college,FL,0.506188355,3,0
-female,white,23,hs,IA,0.550635478,1,1
-female,white,50,some college,OH,0.542676846,1,0
-male,white,43,some college,IL,0.409799486,1,1
-female,white,41,some college,TN,0.63624343,3,0
-female,white,62,post-grad,FL,0.506188355,3,0
-male,white,100,hs,IN,0.601173095,1,0
-female,white,100,post-grad,FL,0.506188355,3,0
-male,white,51,post-grad,FL,0.506188355,3,1
-female,white,62,some college,AZ,0.518900234,4,1
-male,white,55,some college,HI,0.325586625,4,0
-male,white,69,4-year college,TX,0.547132256,3,1
-male,other,24,some college,CA,0.338717892,4,0
-female,white,31,some college,FL,0.506188355,3,0
-female,white,42,no hs,MI,0.501176682,1,0
-female,other,31,4-year college,KY,0.65670629,3,0
-male,white,41,hs,MA,0.353487213,2,0
-female,black,36,some college,IL,0.409799486,1,1
-female,white,63,4-year college,MD,0.359837503,3,0
-male,white,22,some college,GA,0.526611726,3,0
-female,white,23,4-year college,CO,0.473166666,4,0
-male,white,56,hs,TN,0.63624343,3,0
-female,white,41,hs,CA,0.338717892,4,0
-female,white,74,hs,ND,0.698092429,1,0
-female,black,57,some college,NE,0.635476741,1,0
-male,white,24,4-year college,WI,0.50407989,1,0
-female,white,51,some college,FL,0.506188355,3,1
-female,white,49,some college,MT,0.611096643,4,1
-male,other,25,4-year college,OH,0.542676846,1,0
-female,white,33,hs,TX,0.547132256,3,0
-female,white,29,some college,OH,0.542676846,1,0
-male,white,96,post-grad,VA,0.471736237,3,0
-male,white,51,hs,VA,0.471736237,3,1
-female,black,55,no hs,MD,0.359837503,3,1
-female,white,55,4-year college,FL,0.506188355,3,0
-female,other,33,4-year college,MO,0.59818561,1,1
-female,white,89,hs,UT,0.623836582,4,0
-female,white,22,post-grad,WV,0.721610523,3,0
-female,white,53,some college,OH,0.542676846,1,1
-female,white,71,hs,MN,0.491681431,1,0
-male,other,18,no hs,OK,0.693047372,3,0
-male,white,37,hs,VA,0.471736237,3,0
-male,white,67,hs,IN,0.601173095,1,0
-male,white,59,some college,OR,0.438441611,4,0
-male,other,25,post-grad,CA,0.338717892,4,0
-male,white,59,hs,NH,0.498029716,2,1
-male,white,62,some college,IL,0.409799486,1,0
-male,white,65,some college,PA,0.503755358,2,1
-female,white,54,hs,RI,0.416892959,2,0
-male,white,31,4-year college,TX,0.547132256,3,1
-male,white,32,no hs,OH,0.542676846,1,1
-female,black,39,hs,OK,0.693047372,3,0
-female,white,79,hs,MI,0.501176682,1,1
-female,white,66,4-year college,NM,0.453492051,4,1
-female,white,57,some college,PA,0.503755358,2,1
-female,white,21,hs,NC,0.519037458,3,0
-female,white,32,post-grad,LA,0.601716772,3,0
-female,white,69,some college,CA,0.338717892,4,1
-female,white,68,hs,VA,0.471736237,3,0
-female,other,45,4-year college,CA,0.338717892,4,0
-female,white,43,some college,TN,0.63624343,3,1
-female,other,41,post-grad,NY,0.382275815,2,0
-female,white,23,hs,KY,0.65670629,3,1
-female,white,41,some college,WY,0.757053196,4,0
-male,black,23,hs,LA,0.601716772,3,1
-female,other,18,post-grad,FL,0.506188355,3,0
-female,other,42,hs,FL,0.506188355,3,1
-male,white,25,4-year college,NY,0.382275815,2,0
-female,white,69,some college,NV,0.487062906,4,1
-male,other,24,4-year college,AZ,0.518900234,4,0
-female,white,45,hs,TN,0.63624343,3,1
-female,white,66,4-year college,TX,0.547132256,3,1
-male,white,29,4-year college,MO,0.59818561,1,1
-female,other,51,some college,FL,0.506188355,3,1
-female,other,28,4-year college,VA,0.471736237,3,0
-male,white,63,post-grad,CA,0.338717892,4,0
-female,black,23,some college,GA,0.526611726,3,0
-female,white,69,some college,OH,0.542676846,1,0
-female,white,59,hs,FL,0.506188355,3,0
-female,white,40,post-grad,AL,0.643741436,3,0
-female,white,52,some college,AZ,0.518900234,4,0
-female,black,55,post-grad,NC,0.519037458,3,0
-male,white,77,post-grad,IA,0.550635478,1,0
-female,black,30,4-year college,MD,0.359837503,3,0
-female,white,22,4-year college,ME,0.484032089,2,0
-female,other,37,some college,TX,0.547132256,3,1
-female,black,52,hs,NY,0.382275815,2,0
-female,white,57,hs,MA,0.353487213,2,1
-female,white,84,hs,CO,0.473166666,4,0
-female,black,45,4-year college,CA,0.338717892,4,0
-female,other,34,hs,AR,0.642851377,3,0
-female,white,42,some college,OH,0.542676846,1,0
-male,white,22,some college,NH,0.498029716,2,1
-female,other,39,some college,FL,0.506188355,3,0
-male,white,62,some college,VA,0.471736237,3,0
-female,white,58,post-grad,AZ,0.518900234,4,1
-male,white,79,hs,AZ,0.518900234,4,1
-male,white,42,hs,NC,0.519037458,3,0
-female,white,21,hs,WA,0.412130688,4,0
-female,white,18,some college,MI,0.501176682,1,0
-female,white,64,hs,NY,0.382275815,2,0
-male,white,98,4-year college,TX,0.547132256,3,0
-male,white,79,some college,NC,0.519037458,3,1
-female,white,45,4-year college,NY,0.382275815,2,0
-male,white,59,4-year college,CA,0.338717892,4,0
-male,black,45,4-year college,GA,0.526611726,3,1
-male,other,57,4-year college,AZ,0.518900234,4,0
-male,white,56,4-year college,NC,0.519037458,3,0
-female,black,37,4-year college,OH,0.542676846,1,1
-female,white,33,some college,CA,0.338717892,4,0
-female,other,37,some college,TN,0.63624343,3,1
-female,white,63,some college,NC,0.519037458,3,0
-female,white,24,4-year college,MI,0.501176682,1,0
-male,other,41,4-year college,FL,0.506188355,3,0
-male,white,49,4-year college,OR,0.438441611,4,1
-male,white,24,hs,WA,0.412130688,4,0
-male,white,63,hs,MO,0.59818561,1,0
-female,white,59,hs,OH,0.542676846,1,1
-female,other,34,some college,TX,0.547132256,3,0
-female,white,32,post-grad,MI,0.501176682,1,0
-male,white,59,4-year college,FL,0.506188355,3,1
-female,other,36,some college,TX,0.547132256,3,0
-male,black,57,4-year college,NY,0.382275815,2,0
-male,black,29,hs,CA,0.338717892,4,0
-male,white,21,hs,MD,0.359837503,3,1
-female,black,41,some college,IL,0.409799486,1,0
-male,white,36,some college,PA,0.503755358,2,0
-male,white,42,some college,WI,0.50407989,1,0
-female,other,43,4-year college,KY,0.65670629,3,1
-male,white,53,4-year college,PA,0.503755358,2,0
-female,black,55,post-grad,IL,0.409799486,1,0
-male,other,25,hs,NY,0.382275815,2,0
-male,other,51,some college,CA,0.338717892,4,0
-female,white,22,some college,VA,0.471736237,3,0
-female,white,55,4-year college,AZ,0.518900234,4,0
-female,white,55,4-year college,TX,0.547132256,3,1
-female,white,24,some college,TX,0.547132256,3,0
-female,white,53,hs,PA,0.503755358,2,0
-male,white,58,some college,IL,0.409799486,1,1
-female,white,21,some college,NC,0.519037458,3,1
-male,other,23,some college,CA,0.338717892,4,0
-female,other,25,4-year college,VT,0.348135737,2,0
-female,white,52,some college,MN,0.491681431,1,0
-male,white,48,no hs,NC,0.519037458,3,1
-male,other,35,some college,CA,0.338717892,4,0
-female,white,51,some college,CA,0.338717892,4,1
-male,white,46,post-grad,NE,0.635476741,1,0
-male,white,35,4-year college,NE,0.635476741,1,0
-male,white,24,4-year college,TX,0.547132256,3,0
-female,other,21,post-grad,IL,0.409799486,1,1
-male,white,66,some college,IL,0.409799486,1,1
-female,white,91,post-grad,NY,0.382275815,2,0
-male,white,61,4-year college,CA,0.338717892,4,0
-female,white,68,some college,PA,0.503755358,2,1
-male,white,58,some college,CA,0.338717892,4,0
-male,other,25,4-year college,FL,0.506188355,3,0
-female,white,73,hs,NY,0.382275815,2,0
-female,white,34,post-grad,CO,0.473166666,4,0
-male,white,90,4-year college,WA,0.412130688,4,0
-male,white,62,some college,IA,0.550635478,1,0
-male,white,19,hs,NC,0.519037458,3,1
-female,white,28,some college,IL,0.409799486,1,1
-female,white,21,some college,PA,0.503755358,2,0
-female,other,20,4-year college,FL,0.506188355,3,1
-female,white,23,hs,VA,0.471736237,3,1
-female,black,19,4-year college,GA,0.526611726,3,1
-male,white,30,hs,WV,0.721610523,3,0
-female,other,36,post-grad,AZ,0.518900234,4,1
-female,black,61,hs,NY,0.382275815,2,0
-female,black,90,no hs,IL,0.409799486,1,0
-female,other,26,no hs,CA,0.338717892,4,1
-male,white,63,hs,MA,0.353487213,2,0
-male,white,29,no hs,IN,0.601173095,1,1
-female,white,39,post-grad,CO,0.473166666,4,0
-female,white,56,hs,TN,0.63624343,3,1
-male,white,39,4-year college,GA,0.526611726,3,1
-male,white,24,4-year college,CA,0.338717892,4,0
-female,other,30,hs,OH,0.542676846,1,0
-female,white,37,4-year college,TX,0.547132256,3,1
-female,black,31,some college,NJ,0.427158099,2,1
-male,white,85,post-grad,CA,0.338717892,4,1
-female,white,26,4-year college,VA,0.471736237,3,0
-female,white,18,4-year college,CT,0.428584525,2,0
-female,white,62,hs,IN,0.601173095,1,0
-male,other,35,hs,NY,0.382275815,2,0
-male,white,59,hs,TX,0.547132256,3,1
-female,white,67,post-grad,IN,0.601173095,1,1
-male,white,37,some college,LA,0.601716772,3,0
-female,other,26,4-year college,OH,0.542676846,1,0
-female,black,69,some college,GA,0.526611726,3,1
-male,white,77,post-grad,FL,0.506188355,3,1
-female,other,22,some college,CA,0.338717892,4,0
-female,white,62,4-year college,NJ,0.427158099,2,0
-female,other,67,hs,TX,0.547132256,3,1
-male,white,24,some college,OH,0.542676846,1,1
-female,white,37,some college,TN,0.63624343,3,0
-male,white,53,some college,AZ,0.518900234,4,0
-female,white,37,hs,PA,0.503755358,2,0
-female,white,59,hs,CA,0.338717892,4,0
-female,white,40,some college,FL,0.506188355,3,0
-female,white,56,some college,CA,0.338717892,4,1
-female,white,20,hs,FL,0.506188355,3,0
-female,other,28,post-grad,CA,0.338717892,4,1
-female,white,54,hs,PA,0.503755358,2,0
-male,white,90,post-grad,HI,0.325586625,4,1
-female,white,53,hs,FL,0.506188355,3,1
-female,black,89,hs,FL,0.506188355,3,0
-female,white,39,4-year college,CA,0.338717892,4,0
-female,other,22,hs,NM,0.453492051,4,1
-male,white,85,post-grad,IL,0.409799486,1,1
-female,white,30,hs,TX,0.547132256,3,1
-male,black,18,hs,NC,0.519037458,3,1
-male,white,63,hs,IA,0.550635478,1,0
-female,white,48,hs,NY,0.382275815,2,0
-male,white,90,hs,NC,0.519037458,3,1
-male,other,29,some college,CO,0.473166666,4,0
-male,white,64,some college,MI,0.501176682,1,0
-male,white,25,post-grad,AR,0.642851377,3,1
-male,other,45,post-grad,FL,0.506188355,3,1
-female,white,63,hs,NY,0.382275815,2,1
-male,white,51,some college,NY,0.382275815,2,0
-female,white,23,post-grad,CA,0.338717892,4,0
-female,white,41,4-year college,OH,0.542676846,1,0
-female,white,19,some college,MS,0.590898473,3,1
-male,other,43,4-year college,FL,0.506188355,3,0
-male,white,78,no hs,PA,0.503755358,2,0
-female,white,70,post-grad,AR,0.642851377,3,0
-female,white,63,post-grad,MT,0.611096643,4,0
-female,white,28,some college,GA,0.526611726,3,0
-female,other,36,some college,KY,0.65670629,3,1
-female,black,52,4-year college,NY,0.382275815,2,0
-female,white,23,hs,OK,0.693047372,3,0
-female,white,70,post-grad,PA,0.503755358,2,1
-male,white,58,4-year college,TX,0.547132256,3,0
-male,black,53,some college,NC,0.519037458,3,0
-male,white,57,post-grad,KY,0.65670629,3,0
-female,other,25,4-year college,WA,0.412130688,4,0
-female,white,57,some college,CA,0.338717892,4,0
-male,white,89,4-year college,DE,0.440013786,3,1
-male,white,54,4-year college,AZ,0.518900234,4,1
-male,white,67,no hs,MS,0.590898473,3,1
-male,white,65,hs,FL,0.506188355,3,1
-female,white,34,4-year college,MI,0.501176682,1,1
-male,other,50,post-grad,CA,0.338717892,4,0
-male,white,19,hs,MI,0.501176682,1,0
-female,white,36,some college,MI,0.501176682,1,1
-female,white,37,post-grad,FL,0.506188355,3,0
-female,white,54,post-grad,MO,0.59818561,1,0
-female,white,37,4-year college,CO,0.473166666,4,0
-female,white,66,hs,OR,0.438441611,4,0
-male,black,24,hs,FL,0.506188355,3,0
-male,white,77,some college,TX,0.547132256,3,1
-male,white,83,some college,CA,0.338717892,4,1
-female,white,36,post-grad,MN,0.491681431,1,1
-female,white,22,post-grad,AR,0.642851377,3,0
-female,white,20,some college,UT,0.623836582,4,1
-female,white,46,4-year college,NM,0.453492051,4,0
-female,other,30,hs,TX,0.547132256,3,0
-female,white,92,hs,OH,0.542676846,1,0
-male,black,56,4-year college,MO,0.59818561,1,0
-female,white,22,hs,TX,0.547132256,3,0
-female,white,24,some college,MI,0.501176682,1,0
-female,white,18,some college,MN,0.491681431,1,0
-male,white,76,hs,DE,0.440013786,3,0
-female,white,35,some college,NY,0.382275815,2,0
-female,white,59,no hs,TX,0.547132256,3,1
-female,black,45,4-year college,OH,0.542676846,1,0
-male,white,58,hs,MD,0.359837503,3,1
-male,white,89,post-grad,TN,0.63624343,3,0
-female,white,88,some college,CA,0.338717892,4,1
-male,other,34,4-year college,NC,0.519037458,3,0
-male,other,52,post-grad,TX,0.547132256,3,0
-female,white,24,hs,AL,0.643741436,3,1
-female,white,62,hs,TX,0.547132256,3,1
-male,white,41,hs,CT,0.428584525,2,1
-male,white,37,some college,TX,0.547132256,3,0
-female,other,50,some college,MT,0.611096643,4,0
-female,white,36,some college,MI,0.501176682,1,0
-female,white,86,hs,FL,0.506188355,3,0
-male,white,65,hs,IL,0.409799486,1,0
-female,white,57,some college,CT,0.428584525,2,1
-male,white,50,post-grad,GA,0.526611726,3,1
-female,white,61,some college,TN,0.63624343,3,1
-female,white,29,4-year college,OK,0.693047372,3,0
-female,white,47,hs,AZ,0.518900234,4,1
-female,white,18,some college,NE,0.635476741,1,1
-male,white,86,hs,NC,0.519037458,3,0
-male,white,98,post-grad,MA,0.353487213,2,0
-male,white,21,some college,IL,0.409799486,1,1
-female,white,62,some college,NC,0.519037458,3,1
-female,white,52,some college,AZ,0.518900234,4,1
-female,white,55,hs,PA,0.503755358,2,0
-male,other,22,post-grad,NY,0.382275815,2,1
-female,other,46,hs,TX,0.547132256,3,0
-female,white,40,hs,MI,0.501176682,1,0
-female,white,62,some college,TX,0.547132256,3,1
-female,white,38,some college,TN,0.63624343,3,1
-female,white,36,4-year college,WA,0.412130688,4,0
-female,white,51,hs,TX,0.547132256,3,1
-male,white,85,hs,RI,0.416892959,2,0
-female,black,28,post-grad,IL,0.409799486,1,0
-female,white,75,hs,NJ,0.427158099,2,0
-male,white,24,some college,PA,0.503755358,2,0
-male,white,87,post-grad,AZ,0.518900234,4,0
-female,white,68,some college,OH,0.542676846,1,1
-female,white,22,some college,CA,0.338717892,4,1
-female,white,27,some college,NJ,0.427158099,2,0
-male,white,48,4-year college,TN,0.63624343,3,1
-female,white,38,some college,CA,0.338717892,4,0
-male,other,25,some college,UT,0.623836582,4,0
-male,white,74,some college,CA,0.338717892,4,1
-male,other,40,hs,NY,0.382275815,2,1
-male,black,40,hs,GA,0.526611726,3,1
-female,white,67,hs,WI,0.50407989,1,1
-female,white,53,hs,NJ,0.427158099,2,0
-male,white,64,post-grad,CA,0.338717892,4,0
-male,white,36,some college,VA,0.471736237,3,1
-female,white,19,some college,VA,0.471736237,3,1
-female,white,36,hs,TX,0.547132256,3,1
-female,black,76,4-year college,NC,0.519037458,3,1
-female,white,47,hs,WA,0.412130688,4,0
-female,white,27,4-year college,CA,0.338717892,4,0
-female,black,25,some college,GA,0.526611726,3,1
-female,white,88,some college,NY,0.382275815,2,0
-female,white,58,no hs,KY,0.65670629,3,1
-female,white,42,hs,AL,0.643741436,3,0
-male,black,23,some college,TX,0.547132256,3,0
-male,white,39,some college,TN,0.63624343,3,1
-female,white,68,some college,NY,0.382275815,2,1
-female,white,69,post-grad,FL,0.506188355,3,0
-female,white,47,4-year college,CA,0.338717892,4,1
-female,white,30,4-year college,IL,0.409799486,1,0
-male,white,44,some college,NC,0.519037458,3,0
-male,white,81,post-grad,MO,0.59818561,1,1
-female,white,34,some college,MS,0.590898473,3,1
-male,white,31,post-grad,MI,0.501176682,1,0
-female,white,83,some college,TX,0.547132256,3,1
-female,white,49,some college,NY,0.382275815,2,0
-female,white,72,hs,UT,0.623836582,4,1
-male,white,53,post-grad,CA,0.338717892,4,0
-male,white,80,hs,WI,0.50407989,1,0
-male,black,43,hs,VA,0.471736237,3,1
-female,white,82,hs,NJ,0.427158099,2,0
-male,white,59,post-grad,TX,0.547132256,3,0
-female,white,68,4-year college,NJ,0.427158099,2,1
-male,white,36,post-grad,MN,0.491681431,1,1
-male,other,46,some college,WV,0.721610523,3,1
-male,white,61,4-year college,CA,0.338717892,4,0
-male,white,27,some college,IL,0.409799486,1,0
-male,white,65,post-grad,CA,0.338717892,4,1
-female,white,59,hs,FL,0.506188355,3,1
-female,white,28,some college,SD,0.659718581,1,0
-female,white,21,4-year college,CO,0.473166666,4,1
-male,white,77,some college,WA,0.412130688,4,0
-male,white,86,post-grad,NE,0.635476741,1,0
-male,white,62,post-grad,CT,0.428584525,2,1
-female,other,32,4-year college,AZ,0.518900234,4,0
-female,white,21,some college,MS,0.590898473,3,1
-male,black,59,some college,TX,0.547132256,3,0
-male,other,66,post-grad,WA,0.412130688,4,0
-female,white,52,hs,PA,0.503755358,2,0
-male,white,36,post-grad,MT,0.611096643,4,1
-female,white,50,no hs,TN,0.63624343,3,0
-female,white,21,4-year college,CA,0.338717892,4,1
-male,white,48,some college,NJ,0.427158099,2,0
-female,white,24,some college,PA,0.503755358,2,0
-male,white,69,4-year college,MO,0.59818561,1,1
-female,white,49,4-year college,IL,0.409799486,1,1
-male,white,36,hs,MT,0.611096643,4,0
-female,white,40,some college,FL,0.506188355,3,0
-female,white,35,4-year college,OH,0.542676846,1,0
-male,white,55,post-grad,CT,0.428584525,2,0
-female,white,34,post-grad,OR,0.438441611,4,0
-male,other,26,hs,WI,0.50407989,1,1
-female,white,65,some college,ND,0.698092429,1,0
-female,white,40,post-grad,IL,0.409799486,1,0
-female,black,36,4-year college,CA,0.338717892,4,1
-male,white,48,some college,NE,0.635476741,1,0
-male,white,62,post-grad,NY,0.382275815,2,0
-male,white,52,4-year college,OH,0.542676846,1,0
-female,white,66,hs,WI,0.50407989,1,1
-female,other,29,some college,TX,0.547132256,3,1
-male,white,46,some college,OH,0.542676846,1,1
-male,white,67,hs,TX,0.547132256,3,0
-male,other,35,no hs,GA,0.526611726,3,1
-female,white,18,some college,TX,0.547132256,3,1
-female,white,72,4-year college,FL,0.506188355,3,1
-female,white,57,hs,WV,0.721610523,3,1
-female,white,62,some college,GA,0.526611726,3,1
-female,other,27,some college,TX,0.547132256,3,1
-female,other,57,some college,OH,0.542676846,1,1
-female,white,96,post-grad,VA,0.471736237,3,1
-male,white,64,post-grad,WI,0.50407989,1,1
-female,white,98,4-year college,PA,0.503755358,2,0
-female,white,54,hs,IL,0.409799486,1,1
-male,white,74,4-year college,NY,0.382275815,2,0
-male,black,33,some college,MD,0.359837503,3,0
-male,white,27,some college,NJ,0.427158099,2,1
-male,white,38,post-grad,TN,0.63624343,3,0
-male,white,45,4-year college,TN,0.63624343,3,0
-female,black,29,some college,MI,0.501176682,1,0
-male,white,96,some college,FL,0.506188355,3,0
-female,other,50,4-year college,AZ,0.518900234,4,1
-female,other,57,no hs,TX,0.547132256,3,1
-male,white,43,some college,WI,0.50407989,1,1
-male,other,53,some college,OH,0.542676846,1,1
-male,white,62,some college,VA,0.471736237,3,0
-male,white,55,post-grad,TX,0.547132256,3,1
-male,white,21,hs,KY,0.65670629,3,0
-female,white,67,post-grad,NC,0.519037458,3,0
-female,white,62,hs,FL,0.506188355,3,0
-female,white,67,4-year college,CA,0.338717892,4,1
-female,white,50,hs,PA,0.503755358,2,1
-male,white,66,post-grad,CO,0.473166666,4,1
-male,other,26,no hs,LA,0.601716772,3,1
-female,white,53,hs,VA,0.471736237,3,1
-female,white,62,hs,WA,0.412130688,4,0
-male,white,90,some college,WV,0.721610523,3,1
-male,other,31,some college,HI,0.325586625,4,0
-female,other,18,some college,TX,0.547132256,3,0
-male,white,37,hs,NJ,0.427158099,2,0
-male,white,56,some college,IL,0.409799486,1,1
-female,white,25,hs,MI,0.501176682,1,0
-female,white,27,4-year college,AL,0.643741436,3,0
-female,white,28,4-year college,MN,0.491681431,1,0
-female,white,69,no hs,SC,0.574602564,3,0
-female,white,26,post-grad,CT,0.428584525,2,0
-female,white,49,some college,CT,0.428584525,2,0
-female,white,50,some college,NH,0.498029716,2,1
-female,white,89,hs,WI,0.50407989,1,1
-male,white,45,post-grad,CA,0.338717892,4,1
-male,white,59,4-year college,TX,0.547132256,3,0
-female,white,66,hs,FL,0.506188355,3,1
-male,other,87,4-year college,OK,0.693047372,3,1
-female,white,30,4-year college,NJ,0.427158099,2,0
-male,white,56,some college,MN,0.491681431,1,1
-female,black,18,hs,AL,0.643741436,3,0
-male,white,60,some college,NY,0.382275815,2,0
-male,white,35,post-grad,MA,0.353487213,2,0
-female,white,95,some college,AL,0.643741436,3,0
-male,white,78,4-year college,CA,0.338717892,4,0
-male,white,51,some college,AL,0.643741436,3,1
-male,white,50,4-year college,MN,0.491681431,1,0
-female,other,77,4-year college,AZ,0.518900234,4,0
-female,other,57,4-year college,FL,0.506188355,3,0
-female,other,46,hs,TX,0.547132256,3,1
-female,other,24,4-year college,CA,0.338717892,4,0
-male,other,99,some college,CA,0.338717892,4,1
-male,other,20,some college,CA,0.338717892,4,1
-female,other,60,hs,CA,0.338717892,4,1
-female,white,53,some college,TX,0.547132256,3,1
-female,white,52,hs,TN,0.63624343,3,1
-female,white,20,4-year college,OR,0.438441611,4,0
-male,white,73,hs,NC,0.519037458,3,0
-female,white,38,some college,WA,0.412130688,4,1
-male,white,46,post-grad,IN,0.601173095,1,0
-male,white,61,post-grad,FL,0.506188355,3,0
-male,white,63,no hs,OR,0.438441611,4,0
-male,white,45,no hs,GA,0.526611726,3,1
-male,white,69,some college,TX,0.547132256,3,1
-male,white,41,some college,AL,0.643741436,3,1
-female,white,34,hs,TX,0.547132256,3,1
-female,white,21,some college,OH,0.542676846,1,0
-female,other,20,4-year college,NY,0.382275815,2,1
-female,white,38,4-year college,SC,0.574602564,3,1
-male,white,64,4-year college,MI,0.501176682,1,1
-female,white,49,some college,AR,0.642851377,3,1
-female,white,54,hs,ME,0.484032089,2,0
-male,white,52,post-grad,TX,0.547132256,3,0
-female,other,28,some college,CA,0.338717892,4,0
-female,white,44,some college,TX,0.547132256,3,1
-female,black,50,some college,CA,0.338717892,4,0
-female,white,34,post-grad,MI,0.501176682,1,0
-female,other,28,hs,CA,0.338717892,4,1
-female,white,55,post-grad,FL,0.506188355,3,0
-male,white,47,some college,CA,0.338717892,4,1
-female,other,51,hs,OK,0.693047372,3,0
-male,white,75,post-grad,NM,0.453492051,4,1
-male,white,31,some college,PA,0.503755358,2,0
-female,white,72,some college,IA,0.550635478,1,0
-male,white,74,post-grad,FL,0.506188355,3,1
-female,white,22,some college,VA,0.471736237,3,0
-male,other,63,4-year college,WV,0.721610523,3,1
-male,white,40,post-grad,GA,0.526611726,3,1
-male,other,40,post-grad,AZ,0.518900234,4,0
-male,white,51,hs,ID,0.683101767,4,0
-male,white,31,some college,TN,0.63624343,3,0
-female,black,42,some college,NJ,0.427158099,2,0
-female,white,49,hs,AR,0.642851377,3,1
-male,white,39,4-year college,MI,0.501176682,1,0
-male,white,59,hs,NC,0.519037458,3,0
-female,white,67,hs,MO,0.59818561,1,1
-female,white,66,hs,LA,0.601716772,3,1
-female,white,35,some college,MN,0.491681431,1,0
-male,white,79,4-year college,OH,0.542676846,1,0
-male,white,53,hs,MD,0.359837503,3,0
-male,white,81,no hs,NC,0.519037458,3,1
-male,white,77,4-year college,TX,0.547132256,3,1
-male,other,57,post-grad,NY,0.382275815,2,0
-female,white,22,post-grad,LA,0.601716772,3,1
-male,white,28,some college,GA,0.526611726,3,1
-male,black,45,post-grad,TN,0.63624343,3,0
-female,white,66,hs,MI,0.501176682,1,1
-female,white,90,hs,NC,0.519037458,3,0
-female,white,61,hs,MA,0.353487213,2,0
-female,white,27,some college,CA,0.338717892,4,0
-male,other,29,some college,NY,0.382275815,2,0
-male,white,41,some college,AL,0.643741436,3,0
-female,white,64,no hs,CT,0.428584525,2,1
-female,white,31,hs,NY,0.382275815,2,0
-female,other,21,some college,CA,0.338717892,4,0
-female,white,79,hs,NY,0.382275815,2,0
-female,white,52,some college,SC,0.574602564,3,0
-female,black,61,4-year college,GA,0.526611726,3,1
-female,white,55,some college,FL,0.506188355,3,1
-female,black,58,some college,IL,0.409799486,1,0
-female,white,52,hs,MN,0.491681431,1,0
-male,white,38,4-year college,OK,0.693047372,3,0
-male,other,22,post-grad,TX,0.547132256,3,0
-male,black,37,4-year college,TX,0.547132256,3,0
-male,white,22,4-year college,WV,0.721610523,3,1
-female,white,94,some college,ND,0.698092429,1,0
-female,white,52,post-grad,NE,0.635476741,1,0
-female,white,44,4-year college,GA,0.526611726,3,1
-female,white,50,post-grad,OH,0.542676846,1,1
-male,white,67,some college,OH,0.542676846,1,0
-female,white,25,some college,CA,0.338717892,4,0
-female,white,69,some college,OR,0.438441611,4,1
-female,white,57,hs,NY,0.382275815,2,0
-male,white,42,post-grad,OR,0.438441611,4,0
-male,white,30,some college,MN,0.491681431,1,0
-male,other,79,some college,OH,0.542676846,1,1
-female,white,59,post-grad,MD,0.359837503,3,0
-female,white,19,no hs,WA,0.412130688,4,0
-female,other,29,post-grad,FL,0.506188355,3,0
-male,white,38,post-grad,MD,0.359837503,3,0
-female,white,53,post-grad,OK,0.693047372,3,0
-male,white,57,hs,OH,0.542676846,1,1
-female,other,22,some college,IL,0.409799486,1,1
-female,black,21,4-year college,GA,0.526611726,3,1
-female,black,25,some college,MA,0.353487213,2,0
-female,white,54,post-grad,OH,0.542676846,1,0
-female,black,24,post-grad,GA,0.526611726,3,1
-female,white,53,some college,OH,0.542676846,1,0
-female,white,83,post-grad,NY,0.382275815,2,0
-male,white,51,4-year college,WA,0.412130688,4,0
-female,other,29,some college,CA,0.338717892,4,0
-female,white,61,post-grad,CO,0.473166666,4,1
-female,white,74,hs,DE,0.440013786,3,0
-male,other,26,some college,CA,0.338717892,4,1
-male,white,84,hs,NJ,0.427158099,2,1
-male,white,20,hs,FL,0.506188355,3,1
-female,white,52,4-year college,CA,0.338717892,4,0
-female,other,28,some college,TX,0.547132256,3,0
-female,white,47,4-year college,KY,0.65670629,3,0
-male,white,43,hs,CA,0.338717892,4,0
-male,other,38,4-year college,TN,0.63624343,3,1
-male,white,35,hs,CA,0.338717892,4,1
-female,white,100,some college,LA,0.601716772,3,1
-female,white,37,hs,VA,0.471736237,3,0
-female,white,42,hs,PA,0.503755358,2,1
-male,white,49,post-grad,OH,0.542676846,1,1
-female,white,54,some college,CO,0.473166666,4,0
-female,white,22,hs,OK,0.693047372,3,0
-male,black,43,some college,GA,0.526611726,3,0
-male,white,52,some college,OH,0.542676846,1,0
-female,white,43,post-grad,CA,0.338717892,4,0
-male,white,64,hs,GA,0.526611726,3,0
-male,black,29,some college,NC,0.519037458,3,0
-female,black,19,hs,PA,0.503755358,2,0
-male,white,26,4-year college,AR,0.642851377,3,0
-male,white,85,some college,PA,0.503755358,2,1
-female,white,66,some college,CA,0.338717892,4,0
-male,white,94,4-year college,CA,0.338717892,4,1
-female,white,96,4-year college,HI,0.325586625,4,1
-female,white,20,some college,CA,0.338717892,4,0
-female,black,51,hs,NY,0.382275815,2,0
-female,black,27,some college,NY,0.382275815,2,1
-male,white,20,hs,NC,0.519037458,3,1
-male,white,89,hs,MI,0.501176682,1,1
-male,white,61,post-grad,FL,0.506188355,3,1
-male,white,39,4-year college,WI,0.50407989,1,0
-female,other,33,post-grad,NY,0.382275815,2,1
-female,white,65,post-grad,PA,0.503755358,2,0
-male,white,31,post-grad,MD,0.359837503,3,0
-male,white,39,post-grad,UT,0.623836582,4,1
-female,black,53,post-grad,PA,0.503755358,2,0
-male,other,27,4-year college,TX,0.547132256,3,0
-female,white,59,some college,AR,0.642851377,3,1
-female,other,34,hs,CA,0.338717892,4,0
-female,white,62,post-grad,CA,0.338717892,4,0
-female,other,58,no hs,IA,0.550635478,1,1
-male,white,55,4-year college,NJ,0.427158099,2,0
-female,white,83,some college,IL,0.409799486,1,0
-female,white,35,some college,CA,0.338717892,4,0
-male,white,70,4-year college,IA,0.550635478,1,1
-male,white,54,some college,WA,0.412130688,4,0
-male,white,69,4-year college,TX,0.547132256,3,1
-female,white,22,4-year college,WA,0.412130688,4,0
-male,white,68,some college,SD,0.659718581,1,1
-female,other,19,hs,CA,0.338717892,4,0
-male,other,78,post-grad,VA,0.471736237,3,1
-male,white,21,4-year college,VA,0.471736237,3,0
-female,white,65,4-year college,GA,0.526611726,3,1
-female,white,30,hs,DE,0.440013786,3,0
-male,white,76,some college,NJ,0.427158099,2,1
-female,other,30,hs,TX,0.547132256,3,0
-male,white,60,hs,FL,0.506188355,3,0
-male,white,46,some college,NC,0.519037458,3,1
-female,white,67,4-year college,VA,0.471736237,3,0
-male,white,56,hs,TX,0.547132256,3,1
-male,white,65,some college,NC,0.519037458,3,0
-female,white,50,hs,AL,0.643741436,3,0
-female,white,33,4-year college,LA,0.601716772,3,0
-female,other,27,4-year college,OK,0.693047372,3,0
-female,other,35,post-grad,CA,0.338717892,4,0
-male,white,57,some college,FL,0.506188355,3,0
-male,white,38,post-grad,NH,0.498029716,2,1
-female,other,31,some college,TX,0.547132256,3,1
-female,white,68,some college,AR,0.642851377,3,1
-female,white,19,hs,OH,0.542676846,1,0
-female,white,27,some college,TX,0.547132256,3,0
-female,white,59,some college,VT,0.348135737,2,1
-female,white,52,hs,NC,0.519037458,3,1
-male,black,33,some college,TX,0.547132256,3,0
-female,white,41,some college,WY,0.757053196,4,1
-male,white,60,some college,OH,0.542676846,1,0
-female,white,71,4-year college,FL,0.506188355,3,1
-male,white,76,some college,IN,0.601173095,1,1
-male,white,85,hs,NC,0.519037458,3,1
-male,white,64,4-year college,CA,0.338717892,4,1
-male,white,41,4-year college,OH,0.542676846,1,1
-female,white,53,hs,PA,0.503755358,2,1
-female,black,21,no hs,FL,0.506188355,3,0
-male,other,48,post-grad,CA,0.338717892,4,1
-female,other,19,some college,AZ,0.518900234,4,0
-female,other,34,hs,GA,0.526611726,3,1
-female,white,60,post-grad,NE,0.635476741,1,1
-male,white,95,4-year college,MA,0.353487213,2,0
-female,other,47,4-year college,NJ,0.427158099,2,1
-male,white,40,4-year college,NC,0.519037458,3,1
-female,white,32,some college,FL,0.506188355,3,0
-female,white,98,some college,VA,0.471736237,3,0
-male,white,57,some college,NV,0.487062906,4,0
-female,white,60,some college,TX,0.547132256,3,1
-female,black,54,4-year college,TX,0.547132256,3,0
-male,black,23,some college,GA,0.526611726,3,0
-female,other,38,4-year college,NJ,0.427158099,2,0
-male,white,78,4-year college,NY,0.382275815,2,1
-female,white,64,post-grad,OH,0.542676846,1,1
-male,white,19,hs,VT,0.348135737,2,1
-male,white,25,4-year college,MN,0.491681431,1,0
-male,white,82,some college,GA,0.526611726,3,0
-female,white,56,post-grad,AL,0.643741436,3,1
-male,other,28,some college,NM,0.453492051,4,1
-female,white,42,hs,VA,0.471736237,3,0
-male,black,42,some college,SC,0.574602564,3,0
-female,white,29,4-year college,OH,0.542676846,1,0
-male,white,81,some college,KY,0.65670629,3,1
-female,other,27,4-year college,TX,0.547132256,3,1
-male,white,34,hs,PA,0.503755358,2,1
-female,white,83,hs,TX,0.547132256,3,1
-female,white,32,hs,MA,0.353487213,2,0
-male,other,62,some college,NM,0.453492051,4,0
-female,white,57,some college,LA,0.601716772,3,1
-female,black,43,post-grad,GA,0.526611726,3,0
-female,other,64,4-year college,NV,0.487062906,4,1
-female,white,22,some college,MS,0.590898473,3,1
-female,white,29,4-year college,OK,0.693047372,3,1
-female,white,53,post-grad,CA,0.338717892,4,0
-male,other,55,4-year college,MT,0.611096643,4,1
-female,white,52,hs,MD,0.359837503,3,0
-female,other,40,hs,CA,0.338717892,4,0
-female,white,57,hs,FL,0.506188355,3,0
-female,white,33,hs,VA,0.471736237,3,1
-female,white,18,hs,WV,0.721610523,3,0
-male,white,26,4-year college,MD,0.359837503,3,0
-female,black,20,hs,FL,0.506188355,3,1
-female,white,55,hs,PA,0.503755358,2,0
-male,other,21,some college,MO,0.59818561,1,0
-female,white,77,hs,OH,0.542676846,1,0
-male,white,67,some college,AZ,0.518900234,4,1
-female,other,63,some college,CA,0.338717892,4,0
-female,other,59,post-grad,MN,0.491681431,1,0
-female,white,66,some college,GA,0.526611726,3,1
-female,white,49,some college,CT,0.428584525,2,1
-male,white,60,some college,CO,0.473166666,4,0
-female,white,99,hs,NE,0.635476741,1,0
-male,white,55,some college,MO,0.59818561,1,0
-female,white,38,post-grad,CA,0.338717892,4,0
-male,white,70,4-year college,AL,0.643741436,3,1
-female,white,21,hs,FL,0.506188355,3,1
-male,white,73,some college,NM,0.453492051,4,1
-male,black,84,some college,TX,0.547132256,3,1
-male,white,56,4-year college,FL,0.506188355,3,0
-female,white,71,hs,MO,0.59818561,1,1
-male,white,44,some college,TX,0.547132256,3,1
-female,white,35,post-grad,NY,0.382275815,2,0
-male,black,22,some college,MS,0.590898473,3,1
-female,white,23,no hs,MA,0.353487213,2,1
-male,other,20,hs,IN,0.601173095,1,0
-female,white,47,hs,NJ,0.427158099,2,1
-male,white,35,4-year college,NY,0.382275815,2,0
-male,white,87,post-grad,AZ,0.518900234,4,0
-male,white,64,some college,CA,0.338717892,4,0
-female,white,39,4-year college,IN,0.601173095,1,1
-female,black,53,hs,NC,0.519037458,3,0
-male,white,50,4-year college,CO,0.473166666,4,1
-male,other,41,some college,NV,0.487062906,4,0
-male,white,83,some college,GA,0.526611726,3,1
-female,black,35,hs,VA,0.471736237,3,0
-male,white,51,hs,PA,0.503755358,2,1
-female,white,44,post-grad,OH,0.542676846,1,0
-female,other,20,some college,OH,0.542676846,1,0
-male,other,57,some college,CT,0.428584525,2,0
-female,white,32,some college,UT,0.623836582,4,0
-male,white,26,hs,IN,0.601173095,1,0
-male,white,40,post-grad,MA,0.353487213,2,0
-female,white,72,some college,KS,0.611114703,1,1
-male,white,39,4-year college,IN,0.601173095,1,0
-female,white,55,hs,PA,0.503755358,2,0
-female,white,50,hs,GA,0.526611726,3,1
-female,white,68,some college,MN,0.491681431,1,0
-male,white,18,hs,CT,0.428584525,2,1
-male,white,62,some college,OH,0.542676846,1,0
-female,white,68,hs,IN,0.601173095,1,0
-female,black,67,hs,TX,0.547132256,3,0
-male,white,57,post-grad,CA,0.338717892,4,0
-female,other,28,some college,CA,0.338717892,4,0
-male,white,35,some college,TX,0.547132256,3,0
-male,white,58,post-grad,TX,0.547132256,3,1
-female,other,82,hs,IL,0.409799486,1,1
-male,white,62,post-grad,CA,0.338717892,4,0
-female,white,93,some college,AL,0.643741436,3,1
-female,white,37,hs,NY,0.382275815,2,1
-female,white,41,4-year college,SC,0.574602564,3,1
-male,black,34,no hs,CA,0.338717892,4,1
-male,white,48,hs,ID,0.683101767,4,1
-female,white,45,hs,SC,0.574602564,3,1
-male,white,42,hs,FL,0.506188355,3,1
-male,white,52,post-grad,MO,0.59818561,1,0
-female,white,63,4-year college,NY,0.382275815,2,0
-male,other,64,hs,FL,0.506188355,3,1
-male,white,49,some college,MA,0.353487213,2,0
-female,white,51,post-grad,WV,0.721610523,3,0
-female,white,39,hs,CT,0.428584525,2,1
-female,other,29,4-year college,TX,0.547132256,3,0
-female,white,92,hs,OR,0.438441611,4,0
-female,white,45,some college,CA,0.338717892,4,0
-female,black,25,hs,LA,0.601716772,3,0
-female,white,43,some college,AR,0.642851377,3,1
-male,other,30,4-year college,NY,0.382275815,2,1
-female,other,30,4-year college,TX,0.547132256,3,0
-male,white,56,4-year college,UT,0.623836582,4,1
-female,white,65,4-year college,MI,0.501176682,1,0
-male,white,59,post-grad,TX,0.547132256,3,0
-female,white,45,4-year college,GA,0.526611726,3,1
-female,white,25,hs,WI,0.50407989,1,1
-male,white,45,some college,WI,0.50407989,1,0
-female,white,64,some college,NC,0.519037458,3,1
-female,white,45,post-grad,ID,0.683101767,4,1
-female,white,54,4-year college,PA,0.503755358,2,1
-female,other,42,4-year college,GA,0.526611726,3,0
-female,white,63,hs,PA,0.503755358,2,0
-female,white,58,hs,MD,0.359837503,3,0
-female,white,67,some college,FL,0.506188355,3,1
-female,white,67,hs,GA,0.526611726,3,0
-male,black,52,some college,NY,0.382275815,2,0
-male,white,45,some college,AZ,0.518900234,4,0
-female,white,68,4-year college,CA,0.338717892,4,0
-male,white,49,4-year college,VA,0.471736237,3,0
-male,white,34,post-grad,WA,0.412130688,4,1
-female,white,27,hs,VA,0.471736237,3,0
-female,white,88,some college,UT,0.623836582,4,1
-male,white,29,4-year college,NC,0.519037458,3,1
-male,white,33,hs,WV,0.721610523,3,0
-female,white,60,4-year college,TX,0.547132256,3,0
-male,white,50,4-year college,IL,0.409799486,1,1
-female,white,60,hs,TX,0.547132256,3,1
-male,white,60,post-grad,MD,0.359837503,3,0
-male,other,28,some college,FL,0.506188355,3,0
-female,white,56,post-grad,MD,0.359837503,3,0
-female,other,30,post-grad,PA,0.503755358,2,0
-female,other,25,hs,SD,0.659718581,1,1
-female,white,34,4-year college,MD,0.359837503,3,0
-female,white,43,post-grad,IN,0.601173095,1,1
-female,white,29,4-year college,FL,0.506188355,3,1
-female,black,75,hs,NJ,0.427158099,2,0
-male,white,47,hs,OH,0.542676846,1,1
-male,black,68,4-year college,MI,0.501176682,1,0
-female,white,85,hs,PA,0.503755358,2,1
-female,white,65,hs,PA,0.503755358,2,1
-female,other,58,some college,PA,0.503755358,2,1
-male,white,54,post-grad,CA,0.338717892,4,0
-male,white,43,some college,IL,0.409799486,1,0
-male,other,58,some college,IN,0.601173095,1,1
-male,white,32,some college,WI,0.50407989,1,0
-male,white,21,hs,NY,0.382275815,2,1
-female,white,48,4-year college,FL,0.506188355,3,0
-female,black,98,post-grad,NC,0.519037458,3,1
-female,white,30,hs,AL,0.643741436,3,1
-female,black,59,4-year college,SC,0.574602564,3,1
-male,white,48,some college,AZ,0.518900234,4,1
-male,white,81,4-year college,CA,0.338717892,4,0
-female,white,52,post-grad,WA,0.412130688,4,0
-female,white,74,some college,OR,0.438441611,4,0
-female,white,76,hs,VA,0.471736237,3,1
-male,white,60,no hs,PA,0.503755358,2,0
-female,black,34,4-year college,OH,0.542676846,1,0
-female,other,75,some college,FL,0.506188355,3,0
-female,white,44,post-grad,TX,0.547132256,3,0
-female,white,51,some college,PA,0.503755358,2,1
-male,white,33,some college,NH,0.498029716,2,1
-male,white,84,post-grad,TX,0.547132256,3,0
-male,other,57,4-year college,AZ,0.518900234,4,0
-female,white,23,4-year college,CA,0.338717892,4,0
-female,white,54,hs,AZ,0.518900234,4,0
-male,other,19,some college,NV,0.487062906,4,1
-female,white,58,hs,AR,0.642851377,3,1
-male,white,73,hs,AR,0.642851377,3,1
-female,other,29,some college,LA,0.601716772,3,1
-female,white,64,hs,GA,0.526611726,3,1
-female,other,56,post-grad,NY,0.382275815,2,0
-female,white,61,post-grad,NV,0.487062906,4,1
-female,white,18,post-grad,NC,0.519037458,3,0
-female,white,53,some college,OH,0.542676846,1,0
-male,other,20,some college,CA,0.338717892,4,0
-female,white,60,hs,CA,0.338717892,4,0
-female,other,48,some college,AZ,0.518900234,4,0
-female,black,58,some college,MN,0.491681431,1,0
-female,other,37,some college,UT,0.623836582,4,1
-female,white,38,hs,WA,0.412130688,4,0
-female,white,20,some college,AR,0.642851377,3,0
-female,other,48,some college,CA,0.338717892,4,0
-male,white,44,post-grad,SC,0.574602564,3,1
-male,white,96,hs,TN,0.63624343,3,1
-male,white,69,hs,OH,0.542676846,1,0
-female,white,29,some college,NY,0.382275815,2,1
-female,other,38,hs,TX,0.547132256,3,1
-female,white,53,no hs,CA,0.338717892,4,0
-male,white,37,4-year college,TX,0.547132256,3,1
-male,white,87,some college,NY,0.382275815,2,1
-male,white,60,post-grad,CT,0.428584525,2,0
-female,white,51,some college,WA,0.412130688,4,0
-female,white,50,4-year college,NJ,0.427158099,2,0
-female,black,51,hs,VA,0.471736237,3,1
-male,white,37,some college,RI,0.416892959,2,0
-male,white,19,4-year college,TX,0.547132256,3,0
-female,white,22,some college,TX,0.547132256,3,1
-female,other,29,hs,WA,0.412130688,4,0
-male,white,57,4-year college,OK,0.693047372,3,1
-female,white,47,post-grad,TX,0.547132256,3,1
-female,black,58,some college,MD,0.359837503,3,0
-female,white,53,post-grad,PA,0.503755358,2,1
-female,black,23,some college,CT,0.428584525,2,0
-female,black,39,no hs,NY,0.382275815,2,1
-female,white,54,hs,IL,0.409799486,1,0
-female,white,29,4-year college,UT,0.623836582,4,0
-male,white,37,no hs,PA,0.503755358,2,0
-female,white,51,no hs,IN,0.601173095,1,0
-female,white,33,hs,IL,0.409799486,1,0
-male,white,47,hs,NY,0.382275815,2,0
-male,white,66,4-year college,MI,0.501176682,1,1
-female,white,50,post-grad,MD,0.359837503,3,1
-female,other,38,4-year college,MA,0.353487213,2,1
-female,white,55,hs,ID,0.683101767,4,0
-female,white,55,hs,NC,0.519037458,3,1
-female,black,44,4-year college,MO,0.59818561,1,0
-female,white,31,hs,NY,0.382275815,2,0
-male,white,62,some college,AZ,0.518900234,4,1
-female,white,27,hs,WI,0.50407989,1,1
-male,white,22,hs,LA,0.601716772,3,1
-male,other,19,4-year college,NJ,0.427158099,2,0
-male,white,62,4-year college,AZ,0.518900234,4,0
-male,white,53,4-year college,UT,0.623836582,4,1
-female,white,69,hs,IA,0.550635478,1,0
-female,white,36,some college,OR,0.438441611,4,0
-male,white,100,4-year college,MO,0.59818561,1,1
-female,white,60,4-year college,MO,0.59818561,1,0
-female,other,33,hs,IN,0.601173095,1,1
-female,white,27,hs,KY,0.65670629,3,0
-female,other,24,hs,CA,0.338717892,4,0
-female,white,22,4-year college,GA,0.526611726,3,0
-female,white,21,4-year college,PA,0.503755358,2,0
-male,white,20,some college,KY,0.65670629,3,0
-female,white,24,no hs,WA,0.412130688,4,0
-male,white,62,4-year college,CT,0.428584525,2,0
-female,white,26,some college,TN,0.63624343,3,0
-female,white,19,4-year college,OH,0.542676846,1,0
-male,other,42,4-year college,HI,0.325586625,4,0
-male,white,90,some college,ID,0.683101767,4,1
-male,white,35,some college,UT,0.623836582,4,0
-female,other,25,hs,MI,0.501176682,1,0
-male,white,51,4-year college,CT,0.428584525,2,0
-male,white,45,hs,CT,0.428584525,2,0
-male,white,55,4-year college,MD,0.359837503,3,0
-male,black,49,4-year college,IN,0.601173095,1,1
-male,white,94,some college,KS,0.611114703,1,1
-female,white,55,some college,PA,0.503755358,2,0
-male,white,44,some college,AZ,0.518900234,4,0
-male,white,18,some college,TN,0.63624343,3,0
-male,white,46,4-year college,OH,0.542676846,1,1
-male,white,51,some college,AR,0.642851377,3,0
-female,white,23,some college,PA,0.503755358,2,0
-female,white,51,no hs,AR,0.642851377,3,1
-female,white,56,post-grad,OK,0.693047372,3,0
-female,other,33,some college,FL,0.506188355,3,0
-female,white,46,4-year college,OR,0.438441611,4,0
-female,white,45,4-year college,FL,0.506188355,3,0
-female,white,68,post-grad,MO,0.59818561,1,1
-female,other,28,hs,CA,0.338717892,4,1
-male,white,87,post-grad,WV,0.721610523,3,1
-male,white,75,post-grad,CA,0.338717892,4,1
-male,white,67,post-grad,PA,0.503755358,2,0
-female,white,35,hs,FL,0.506188355,3,1
-male,white,89,post-grad,TN,0.63624343,3,1
-male,other,33,post-grad,CT,0.428584525,2,0
-female,white,44,some college,CO,0.473166666,4,0
-female,white,46,hs,IA,0.550635478,1,0
-female,other,61,some college,FL,0.506188355,3,1
-female,white,24,some college,GA,0.526611726,3,0
-female,white,63,some college,FL,0.506188355,3,1
-male,other,56,hs,CA,0.338717892,4,1
-male,white,51,some college,FL,0.506188355,3,0
-female,other,54,some college,TX,0.547132256,3,1
-male,black,19,hs,CA,0.338717892,4,0
-male,white,55,hs,GA,0.526611726,3,0
-female,white,34,hs,GA,0.526611726,3,1
-female,white,67,hs,OH,0.542676846,1,1
-female,other,37,4-year college,WA,0.412130688,4,0
-male,white,78,4-year college,CA,0.338717892,4,0
-male,white,19,post-grad,CA,0.338717892,4,1
-female,white,20,some college,VT,0.348135737,2,0
-male,white,28,no hs,FL,0.506188355,3,0
-female,black,67,some college,PA,0.503755358,2,1
-male,white,30,4-year college,PA,0.503755358,2,1
-female,white,75,post-grad,ME,0.484032089,2,0
-male,white,42,4-year college,MD,0.359837503,3,1
-male,other,40,no hs,MA,0.353487213,2,0
-male,white,39,4-year college,VA,0.471736237,3,0
-male,white,48,post-grad,WY,0.757053196,4,1
-female,other,59,4-year college,NY,0.382275815,2,0
-male,white,48,hs,TX,0.547132256,3,0
-female,white,60,hs,MO,0.59818561,1,1
-male,black,39,hs,GA,0.526611726,3,1
-male,white,79,some college,VT,0.348135737,2,1
-male,white,65,some college,NM,0.453492051,4,0
-female,white,72,no hs,FL,0.506188355,3,0
-male,white,35,post-grad,IN,0.601173095,1,0
-female,other,47,post-grad,DE,0.440013786,3,0
-female,white,53,hs,OH,0.542676846,1,1
-female,white,94,hs,PA,0.503755358,2,0
-female,white,64,some college,AR,0.642851377,3,1
-male,black,39,4-year college,MD,0.359837503,3,1
-male,other,37,some college,VA,0.471736237,3,0
-female,white,60,hs,OH,0.542676846,1,0
-male,white,46,some college,TX,0.547132256,3,1
-female,other,25,hs,CA,0.338717892,4,0
-female,black,52,some college,VA,0.471736237,3,0
-male,white,21,hs,WA,0.412130688,4,0
-male,white,34,hs,OR,0.438441611,4,1
-male,white,30,some college,MD,0.359837503,3,0
-male,black,51,some college,NY,0.382275815,2,0
-female,white,65,hs,TX,0.547132256,3,1
-male,other,27,hs,MO,0.59818561,1,0
-female,white,54,post-grad,WA,0.412130688,4,0
-female,black,51,4-year college,NY,0.382275815,2,0
-female,other,22,post-grad,WA,0.412130688,4,0
-male,white,50,post-grad,TX,0.547132256,3,0
-female,black,52,4-year college,MD,0.359837503,3,1
-female,other,18,4-year college,FL,0.506188355,3,0
-male,white,65,post-grad,MS,0.590898473,3,1
-female,white,40,some college,NY,0.382275815,2,0
-female,white,24,some college,MO,0.59818561,1,1
-female,white,36,hs,AZ,0.518900234,4,0
-male,other,39,hs,NC,0.519037458,3,1
-female,white,54,hs,OH,0.542676846,1,1
-female,white,22,some college,MI,0.501176682,1,0
-male,white,78,post-grad,VA,0.471736237,3,1
-male,white,57,4-year college,CA,0.338717892,4,0
-female,other,51,some college,TX,0.547132256,3,1
-male,white,33,post-grad,MO,0.59818561,1,0
-male,white,77,hs,WA,0.412130688,4,0
-female,white,68,some college,PA,0.503755358,2,0
-male,white,62,4-year college,WA,0.412130688,4,1
-male,other,20,some college,AR,0.642851377,3,0
-female,other,22,4-year college,NJ,0.427158099,2,0
-female,other,35,hs,CA,0.338717892,4,1
-female,white,32,hs,WI,0.50407989,1,1
-male,white,46,hs,WA,0.412130688,4,1
-male,white,66,hs,FL,0.506188355,3,0
-male,white,98,post-grad,FL,0.506188355,3,0
-female,white,34,post-grad,KY,0.65670629,3,0
-female,other,27,hs,OK,0.693047372,3,0
-female,white,42,some college,NY,0.382275815,2,1
-female,white,24,4-year college,CA,0.338717892,4,0
-female,white,28,some college,RI,0.416892959,2,0
-female,white,85,hs,MI,0.501176682,1,1
-female,white,75,hs,WI,0.50407989,1,1
-female,white,57,hs,PA,0.503755358,2,1
-male,white,26,some college,VA,0.471736237,3,1
-male,white,50,some college,TN,0.63624343,3,1
-female,white,54,4-year college,CA,0.338717892,4,0
-male,other,51,post-grad,LA,0.601716772,3,1
-female,white,59,hs,NC,0.519037458,3,1
-male,white,39,4-year college,SC,0.574602564,3,1
-female,other,38,hs,TX,0.547132256,3,0
-female,other,37,post-grad,TX,0.547132256,3,0
-female,other,19,4-year college,TX,0.547132256,3,1
-female,white,32,4-year college,FL,0.506188355,3,0
-male,white,60,hs,FL,0.506188355,3,0
-male,white,61,4-year college,VA,0.471736237,3,1
-male,other,48,hs,NJ,0.427158099,2,0
-male,black,38,some college,TX,0.547132256,3,0
-female,white,100,hs,CA,0.338717892,4,0
-female,white,66,4-year college,MO,0.59818561,1,0
-female,white,33,hs,PA,0.503755358,2,0
-female,white,28,4-year college,NY,0.382275815,2,0
-male,white,85,some college,TX,0.547132256,3,1
-female,white,37,some college,IL,0.409799486,1,0
-male,white,22,some college,IN,0.601173095,1,1
-female,white,35,some college,IL,0.409799486,1,0
-male,other,66,4-year college,FL,0.506188355,3,0
-female,white,63,some college,WI,0.50407989,1,0
-female,white,55,4-year college,NH,0.498029716,2,0
-male,white,68,hs,KY,0.65670629,3,1
-female,white,62,4-year college,PA,0.503755358,2,1
-female,white,67,some college,MO,0.59818561,1,0
-female,other,53,some college,MI,0.501176682,1,1
-female,white,30,hs,NY,0.382275815,2,0
-male,other,65,hs,VA,0.471736237,3,1
-female,white,60,4-year college,CO,0.473166666,4,1
-female,white,49,4-year college,CA,0.338717892,4,0
-male,white,36,hs,AL,0.643741436,3,1
-male,white,52,4-year college,OK,0.693047372,3,1
-female,white,55,hs,CA,0.338717892,4,0
-male,white,53,4-year college,KS,0.611114703,1,1
-female,white,20,no hs,GA,0.526611726,3,0
-male,white,63,4-year college,MS,0.590898473,3,1
-male,white,89,post-grad,CA,0.338717892,4,1
-male,other,50,4-year college,PA,0.503755358,2,0
-male,white,36,4-year college,KY,0.65670629,3,0
-female,white,19,4-year college,MO,0.59818561,1,1
-male,white,66,some college,WA,0.412130688,4,1
-female,black,48,4-year college,TX,0.547132256,3,0
-male,white,65,4-year college,GA,0.526611726,3,1
-female,black,59,post-grad,PA,0.503755358,2,0
-female,black,53,post-grad,IL,0.409799486,1,0
-female,white,34,hs,IL,0.409799486,1,1
-female,white,58,hs,MO,0.59818561,1,0
-female,white,62,no hs,MD,0.359837503,3,1
-female,white,21,post-grad,FL,0.506188355,3,0
-male,white,63,4-year college,WI,0.50407989,1,1
-female,other,32,post-grad,TX,0.547132256,3,1
-male,white,38,some college,SC,0.574602564,3,0
-male,other,34,post-grad,TX,0.547132256,3,1
-female,white,32,some college,IL,0.409799486,1,1
-male,white,43,some college,AL,0.643741436,3,0
-male,white,75,post-grad,CO,0.473166666,4,0
-male,other,79,4-year college,TX,0.547132256,3,1
-male,white,31,4-year college,KS,0.611114703,1,0
-female,other,23,hs,FL,0.506188355,3,0
-male,white,32,4-year college,AZ,0.518900234,4,1
-male,white,45,no hs,WA,0.412130688,4,1
-male,white,92,4-year college,VA,0.471736237,3,1
-female,white,53,some college,NV,0.487062906,4,0
-female,white,69,post-grad,CA,0.338717892,4,1
-female,white,20,no hs,OH,0.542676846,1,1
-female,white,38,hs,WI,0.50407989,1,0
-male,white,36,4-year college,UT,0.623836582,4,0
-male,white,95,4-year college,FL,0.506188355,3,0
-male,other,41,some college,NJ,0.427158099,2,0
-male,other,45,4-year college,MN,0.491681431,1,1
-female,black,41,4-year college,FL,0.506188355,3,1
-female,white,52,hs,OR,0.438441611,4,1
-female,white,78,some college,PA,0.503755358,2,0
-female,white,65,4-year college,TN,0.63624343,3,1
-male,black,40,no hs,NY,0.382275815,2,0
-male,white,70,hs,NY,0.382275815,2,0
-female,other,43,hs,CA,0.338717892,4,1
-female,white,79,4-year college,ID,0.683101767,4,0
-female,white,31,post-grad,WA,0.412130688,4,0
-female,white,100,some college,CA,0.338717892,4,0
-male,white,90,some college,CA,0.338717892,4,1
-male,white,60,post-grad,MA,0.353487213,2,1
-female,white,65,hs,WV,0.721610523,3,1
-female,other,29,4-year college,CA,0.338717892,4,0
-male,other,62,post-grad,OR,0.438441611,4,1
-female,white,80,some college,WI,0.50407989,1,0
-female,white,83,some college,OK,0.693047372,3,1
-female,white,26,hs,TN,0.63624343,3,1
-female,white,37,some college,CA,0.338717892,4,1
-male,other,48,no hs,ND,0.698092429,1,1
-female,white,24,hs,GA,0.526611726,3,1
-male,white,68,4-year college,VA,0.471736237,3,1
-female,other,23,4-year college,CA,0.338717892,4,1
-male,white,66,4-year college,TX,0.547132256,3,1
-female,white,64,4-year college,MI,0.501176682,1,0
-female,white,55,no hs,PA,0.503755358,2,1
-male,white,55,4-year college,MO,0.59818561,1,0
-male,black,24,hs,NJ,0.427158099,2,0
-male,black,29,some college,TN,0.63624343,3,0
-female,white,60,post-grad,TX,0.547132256,3,0
-female,white,37,post-grad,MO,0.59818561,1,0
-female,white,68,hs,NY,0.382275815,2,1
-female,black,33,4-year college,MO,0.59818561,1,0
-male,white,52,hs,WA,0.412130688,4,0
-male,other,51,4-year college,NJ,0.427158099,2,0
-female,white,95,hs,NY,0.382275815,2,1
-male,white,33,hs,FL,0.506188355,3,0
-female,black,56,post-grad,IL,0.409799486,1,0
-male,white,62,hs,IL,0.409799486,1,1
-male,white,25,4-year college,GA,0.526611726,3,0
-female,white,27,hs,OH,0.542676846,1,0
-female,white,34,4-year college,OR,0.438441611,4,0
-male,black,20,hs,TX,0.547132256,3,0
-female,white,63,hs,AZ,0.518900234,4,0
-female,white,63,some college,TX,0.547132256,3,0
-male,other,25,hs,NV,0.487062906,4,1
-male,white,54,no hs,FL,0.506188355,3,0
-female,white,86,hs,CA,0.338717892,4,1
-female,white,55,some college,WY,0.757053196,4,0
-male,white,56,some college,PA,0.503755358,2,0
-male,white,68,post-grad,NE,0.635476741,1,1
-male,white,38,some college,KY,0.65670629,3,1
-female,black,18,some college,OH,0.542676846,1,0
-female,black,32,some college,LA,0.601716772,3,1
-male,white,43,hs,UT,0.623836582,4,0
-male,white,63,hs,PA,0.503755358,2,1
-female,white,45,4-year college,FL,0.506188355,3,1
-male,white,55,hs,CA,0.338717892,4,0
-female,other,38,post-grad,MA,0.353487213,2,0
-female,white,39,hs,PA,0.503755358,2,1
-female,black,52,hs,NJ,0.427158099,2,1
-female,other,98,4-year college,FL,0.506188355,3,1
-male,white,37,post-grad,OH,0.542676846,1,0
-female,white,41,no hs,VA,0.471736237,3,1
-female,white,27,some college,GA,0.526611726,3,0
-female,white,66,hs,TX,0.547132256,3,1
-male,white,23,some college,OH,0.542676846,1,0
-female,white,57,4-year college,VA,0.471736237,3,0
-female,white,34,hs,CT,0.428584525,2,0
-male,white,95,hs,DE,0.440013786,3,0
-male,other,79,post-grad,TX,0.547132256,3,0
-female,white,33,some college,RI,0.416892959,2,1
-female,white,84,hs,GA,0.526611726,3,1
-female,white,39,hs,IN,0.601173095,1,0
-male,white,60,4-year college,DE,0.440013786,3,1
-male,white,29,post-grad,AZ,0.518900234,4,0
-female,white,43,post-grad,SC,0.574602564,3,0
-female,white,56,hs,NH,0.498029716,2,0
-female,white,27,some college,FL,0.506188355,3,0
-female,white,85,hs,ID,0.683101767,4,1
-female,white,31,post-grad,MO,0.59818561,1,1
-female,white,18,post-grad,VA,0.471736237,3,1
-male,black,21,some college,AZ,0.518900234,4,0
-female,white,100,hs,FL,0.506188355,3,0
-female,white,75,hs,WA,0.412130688,4,1
-female,other,26,some college,CA,0.338717892,4,1
-male,white,25,some college,VA,0.471736237,3,1
-female,other,70,4-year college,TX,0.547132256,3,1
-female,white,50,hs,PA,0.503755358,2,0
-male,white,37,some college,IN,0.601173095,1,1
-female,white,64,hs,OH,0.542676846,1,0
-female,white,19,some college,OH,0.542676846,1,1
-female,white,28,some college,OH,0.542676846,1,0
-male,white,43,post-grad,TX,0.547132256,3,1
-female,white,27,4-year college,NJ,0.427158099,2,1
-male,white,62,hs,CA,0.338717892,4,1
-female,white,42,4-year college,KY,0.65670629,3,0
-female,white,61,hs,AZ,0.518900234,4,1
-female,white,60,4-year college,NJ,0.427158099,2,0
-male,black,57,some college,TX,0.547132256,3,0
-female,white,69,hs,TN,0.63624343,3,1
-female,white,31,4-year college,OH,0.542676846,1,1
-female,white,32,some college,NY,0.382275815,2,0
-male,white,64,hs,CO,0.473166666,4,1
-male,white,24,some college,WI,0.50407989,1,0
-female,white,77,4-year college,IA,0.550635478,1,1
-male,white,28,some college,KY,0.65670629,3,1
-male,other,19,4-year college,UT,0.623836582,4,0
-female,white,63,hs,MD,0.359837503,3,1
-female,white,49,post-grad,NC,0.519037458,3,0
-male,black,47,some college,GA,0.526611726,3,0
-male,white,50,some college,MI,0.501176682,1,0
-female,white,59,hs,OH,0.542676846,1,0
-male,white,96,some college,CA,0.338717892,4,1
-female,white,42,no hs,SC,0.574602564,3,0
-female,black,96,4-year college,GA,0.526611726,3,0
-male,other,29,hs,PA,0.503755358,2,1
-female,white,77,hs,VA,0.471736237,3,1
-male,white,55,4-year college,UT,0.623836582,4,1
-male,white,21,some college,KY,0.65670629,3,0
-male,white,73,post-grad,PA,0.503755358,2,1
-female,black,53,hs,IN,0.601173095,1,0
-male,white,48,4-year college,AZ,0.518900234,4,0
-female,black,41,hs,TX,0.547132256,3,0
-female,white,52,4-year college,NY,0.382275815,2,0
-male,white,60,post-grad,CA,0.338717892,4,0
-male,white,51,4-year college,AZ,0.518900234,4,1
-male,white,41,hs,PA,0.503755358,2,0
-female,white,26,4-year college,PA,0.503755358,2,0
-female,white,41,hs,TN,0.63624343,3,1
-male,white,52,hs,IN,0.601173095,1,1
-female,white,28,4-year college,AL,0.643741436,3,0
-female,black,26,4-year college,VA,0.471736237,3,0
-female,white,36,post-grad,TX,0.547132256,3,0
-female,white,59,some college,NJ,0.427158099,2,0
-male,other,20,some college,CA,0.338717892,4,1
-male,white,74,some college,PA,0.503755358,2,0
-male,other,44,some college,FL,0.506188355,3,0
-female,white,72,some college,WI,0.50407989,1,0
-female,white,37,post-grad,MD,0.359837503,3,0
-female,other,29,some college,CA,0.338717892,4,0
-female,white,19,some college,WI,0.50407989,1,0
-male,white,91,hs,MI,0.501176682,1,0
-male,other,42,post-grad,VA,0.471736237,3,1
-female,white,41,post-grad,AZ,0.518900234,4,0
-male,white,43,hs,MN,0.491681431,1,1
-female,white,71,4-year college,AZ,0.518900234,4,0
-male,white,47,some college,NC,0.519037458,3,1
-female,white,98,hs,CA,0.338717892,4,1
-female,white,61,post-grad,MO,0.59818561,1,1
-female,white,66,hs,CA,0.338717892,4,0
-male,other,51,some college,CA,0.338717892,4,0
-female,white,48,post-grad,WA,0.412130688,4,0
-male,white,64,hs,OH,0.542676846,1,1
-male,white,46,post-grad,CA,0.338717892,4,0
-male,white,98,no hs,FL,0.506188355,3,1
-female,white,73,hs,MI,0.501176682,1,1
-female,white,55,hs,CA,0.338717892,4,1
-female,black,43,4-year college,MI,0.501176682,1,0
-female,white,51,no hs,CA,0.338717892,4,1
-female,white,76,hs,FL,0.506188355,3,1
-female,white,48,some college,GA,0.526611726,3,1
-male,white,62,4-year college,WA,0.412130688,4,1
-male,white,65,some college,LA,0.601716772,3,1
-female,white,43,some college,MA,0.353487213,2,1
-male,black,28,no hs,MI,0.501176682,1,0
-female,white,77,4-year college,AL,0.643741436,3,1
-male,other,22,some college,CA,0.338717892,4,1
-male,white,67,some college,TN,0.63624343,3,1
-male,white,65,4-year college,TX,0.547132256,3,1
-male,white,68,some college,TX,0.547132256,3,1
-female,white,41,post-grad,FL,0.506188355,3,0
-female,white,55,hs,AK,0.583856547,4,0
-female,other,35,some college,WA,0.412130688,4,0
-male,other,97,post-grad,LA,0.601716772,3,1
-female,white,77,hs,ID,0.683101767,4,0
-male,black,31,4-year college,GA,0.526611726,3,0
-male,other,34,hs,ID,0.683101767,4,1
-male,white,56,some college,WA,0.412130688,4,0
-male,white,23,4-year college,PA,0.503755358,2,0
-female,black,27,no hs,IL,0.409799486,1,0
-female,white,65,some college,NY,0.382275815,2,0
-female,white,86,hs,NC,0.519037458,3,1
-female,other,21,hs,TX,0.547132256,3,0
-female,white,31,post-grad,OH,0.542676846,1,0
-male,white,80,some college,CA,0.338717892,4,1
-male,white,66,hs,PA,0.503755358,2,1
-female,white,46,hs,MT,0.611096643,4,0
-male,white,42,hs,VA,0.471736237,3,0
-female,other,29,4-year college,FL,0.506188355,3,0
-female,other,46,some college,FL,0.506188355,3,0
-male,white,44,hs,NM,0.453492051,4,1
-male,white,50,4-year college,MI,0.501176682,1,0
-male,white,58,some college,CO,0.473166666,4,1
-female,white,57,hs,IN,0.601173095,1,0
-male,other,52,some college,AZ,0.518900234,4,1
-male,white,83,4-year college,RI,0.416892959,2,1
-male,white,34,some college,CA,0.338717892,4,1
-male,white,20,no hs,CA,0.338717892,4,0
-male,white,38,4-year college,VA,0.471736237,3,0
-female,white,84,hs,NY,0.382275815,2,1
-female,white,61,no hs,IL,0.409799486,1,1
-male,white,96,some college,CA,0.338717892,4,1
-female,white,30,4-year college,MI,0.501176682,1,0
-female,other,36,hs,MI,0.501176682,1,1
-female,white,40,some college,VA,0.471736237,3,1
-female,white,57,some college,TX,0.547132256,3,1
-female,white,81,hs,NY,0.382275815,2,1
-male,white,90,post-grad,OR,0.438441611,4,0
-female,black,55,post-grad,TX,0.547132256,3,0
-female,white,46,some college,PA,0.503755358,2,0
-female,white,31,4-year college,WA,0.412130688,4,0
-male,other,45,post-grad,GA,0.526611726,3,1
-female,white,68,some college,FL,0.506188355,3,1
-female,white,46,no hs,SC,0.574602564,3,1
-female,white,19,post-grad,NJ,0.427158099,2,0
-male,white,55,some college,WI,0.50407989,1,0
-female,other,25,some college,CA,0.338717892,4,0
-female,white,25,no hs,TN,0.63624343,3,0
-female,white,74,some college,NY,0.382275815,2,0
-male,white,68,hs,WV,0.721610523,3,1
-male,white,51,some college,WA,0.412130688,4,0
-female,white,51,4-year college,NY,0.382275815,2,0
-female,white,25,post-grad,CA,0.338717892,4,0
-female,other,88,some college,FL,0.506188355,3,1
-male,white,55,hs,KS,0.611114703,1,0
-male,white,51,some college,MI,0.501176682,1,0
-male,white,73,hs,NY,0.382275815,2,0
-male,white,41,hs,MA,0.353487213,2,0
-female,white,50,some college,AZ,0.518900234,4,0
-male,white,71,post-grad,TX,0.547132256,3,1
-male,white,54,some college,MO,0.59818561,1,1
-female,white,23,some college,MO,0.59818561,1,0
-male,white,51,hs,OH,0.542676846,1,1
-male,other,33,hs,NY,0.382275815,2,1
-female,other,27,hs,TX,0.547132256,3,0
-male,white,57,hs,PA,0.503755358,2,1
-male,white,20,hs,CA,0.338717892,4,0
-male,white,65,some college,WV,0.721610523,3,1
-female,black,37,4-year college,PA,0.503755358,2,1
-male,white,85,hs,MO,0.59818561,1,1
-male,black,38,hs,GA,0.526611726,3,0
-male,white,86,post-grad,IL,0.409799486,1,0
-female,white,63,hs,OK,0.693047372,3,0
-male,black,28,some college,FL,0.506188355,3,0
-male,white,34,4-year college,NY,0.382275815,2,0
-female,white,29,post-grad,IN,0.601173095,1,1
-male,white,55,post-grad,SC,0.574602564,3,1
-male,white,63,post-grad,UT,0.623836582,4,1
-male,white,55,hs,ID,0.683101767,4,0
-male,white,35,4-year college,CT,0.428584525,2,0
-female,white,42,hs,NJ,0.427158099,2,1
-male,white,46,some college,NY,0.382275815,2,0
-female,other,35,4-year college,CA,0.338717892,4,0
-female,white,57,post-grad,VA,0.471736237,3,0
-female,white,23,some college,MO,0.59818561,1,1
-male,white,24,hs,TX,0.547132256,3,1
-female,white,54,some college,MO,0.59818561,1,0
-female,white,53,no hs,DE,0.440013786,3,1
-female,white,45,some college,CO,0.473166666,4,0
-female,white,44,4-year college,NV,0.487062906,4,0
-male,white,60,post-grad,MD,0.359837503,3,1
-female,white,24,some college,NJ,0.427158099,2,0
-female,white,22,hs,NC,0.519037458,3,1
-female,other,65,some college,CA,0.338717892,4,1
-male,white,82,post-grad,MI,0.501176682,1,0
-male,other,23,4-year college,TX,0.547132256,3,0
-female,white,67,hs,MA,0.353487213,2,0
-male,other,28,some college,VA,0.471736237,3,0
-female,other,21,4-year college,AZ,0.518900234,4,1
-female,black,30,some college,TX,0.547132256,3,0
-female,white,62,hs,PA,0.503755358,2,1
-female,white,36,hs,PA,0.503755358,2,1
-female,black,60,some college,MI,0.501176682,1,1
-female,white,39,4-year college,MD,0.359837503,3,1
-male,white,73,4-year college,NC,0.519037458,3,1
-male,white,49,4-year college,NJ,0.427158099,2,0
-female,white,78,hs,MO,0.59818561,1,1
-female,white,60,post-grad,KS,0.611114703,1,0
-male,white,46,hs,AL,0.643741436,3,1
-male,white,68,hs,TN,0.63624343,3,1
-male,white,66,hs,IL,0.409799486,1,0
-female,black,50,4-year college,NY,0.382275815,2,0
-female,white,67,some college,WA,0.412130688,4,0
-male,white,69,4-year college,UT,0.623836582,4,1
-female,white,91,some college,WA,0.412130688,4,1
-female,white,100,4-year college,VT,0.348135737,2,0
-female,white,29,some college,TX,0.547132256,3,1
-female,white,88,hs,IN,0.601173095,1,0
-male,white,32,4-year college,NY,0.382275815,2,0
-male,white,97,some college,TX,0.547132256,3,0
-male,other,18,some college,NJ,0.427158099,2,0
-female,other,87,some college,TX,0.547132256,3,0
-female,white,67,no hs,MI,0.501176682,1,0
-female,white,27,some college,NC,0.519037458,3,0
-male,white,46,hs,NY,0.382275815,2,0
-male,white,39,hs,GA,0.526611726,3,1
-male,white,88,some college,TX,0.547132256,3,1
-female,white,76,some college,WA,0.412130688,4,1
-female,black,47,4-year college,CO,0.473166666,4,0
-female,white,35,hs,IL,0.409799486,1,0
-female,other,18,4-year college,NJ,0.427158099,2,0
-male,white,92,some college,HI,0.325586625,4,1
-female,white,54,4-year college,GA,0.526611726,3,1
-male,white,47,4-year college,KY,0.65670629,3,1
-male,white,39,4-year college,WA,0.412130688,4,0
-female,white,62,some college,FL,0.506188355,3,0
-male,white,31,4-year college,MI,0.501176682,1,0
-female,white,20,hs,AL,0.643741436,3,0
-female,white,52,hs,OH,0.542676846,1,1
-female,white,56,some college,MS,0.590898473,3,1
-female,white,33,4-year college,TX,0.547132256,3,0
-female,white,92,some college,MA,0.353487213,2,0
-female,other,68,some college,CA,0.338717892,4,0
-female,black,28,4-year college,GA,0.526611726,3,1
-female,white,25,some college,MA,0.353487213,2,0
-female,other,26,hs,TX,0.547132256,3,1
-female,other,35,post-grad,NY,0.382275815,2,0
-female,other,33,post-grad,WI,0.50407989,1,0
-male,white,67,some college,FL,0.506188355,3,0
-female,white,45,some college,UT,0.623836582,4,1
-female,white,56,hs,WV,0.721610523,3,1
-male,white,23,some college,TX,0.547132256,3,0
-male,white,24,4-year college,MI,0.501176682,1,1
-female,black,62,some college,OH,0.542676846,1,0
-male,other,22,some college,TX,0.547132256,3,0
-male,white,69,4-year college,CA,0.338717892,4,0
-female,white,54,some college,KY,0.65670629,3,1
-male,black,29,some college,IL,0.409799486,1,1
-female,white,37,4-year college,IN,0.601173095,1,1
-female,other,31,4-year college,OR,0.438441611,4,0
-male,white,36,some college,NY,0.382275815,2,1
-female,white,60,hs,MO,0.59818561,1,1
-female,other,44,4-year college,FL,0.506188355,3,0
-female,white,57,some college,TX,0.547132256,3,0
-male,white,98,4-year college,MO,0.59818561,1,1
-female,white,46,4-year college,NC,0.519037458,3,1
-male,white,65,4-year college,OR,0.438441611,4,1
-male,white,73,4-year college,NY,0.382275815,2,0
-female,white,29,some college,OH,0.542676846,1,1
-female,white,81,hs,FL,0.506188355,3,1
-female,white,39,4-year college,OH,0.542676846,1,1
-male,white,54,4-year college,FL,0.506188355,3,0
-female,white,52,4-year college,MA,0.353487213,2,0
-female,white,75,4-year college,WA,0.412130688,4,0
-male,other,30,4-year college,TX,0.547132256,3,1
-female,black,42,some college,AL,0.643741436,3,0
-male,white,21,4-year college,MO,0.59818561,1,1
-male,white,60,hs,OH,0.542676846,1,1
-male,other,18,some college,CA,0.338717892,4,0
-male,white,58,hs,WV,0.721610523,3,1
-male,white,39,post-grad,TN,0.63624343,3,0
-female,black,28,4-year college,VA,0.471736237,3,0
-female,white,71,4-year college,PA,0.503755358,2,0
-female,white,36,hs,AL,0.643741436,3,1
-male,white,81,4-year college,CA,0.338717892,4,0
-male,white,35,4-year college,MN,0.491681431,1,0
-male,white,22,some college,PA,0.503755358,2,1
-female,white,43,4-year college,FL,0.506188355,3,0
-female,black,31,post-grad,IN,0.601173095,1,0
-female,white,67,hs,PA,0.503755358,2,1
-male,other,28,hs,NJ,0.427158099,2,0
-female,black,45,post-grad,MD,0.359837503,3,0
-male,white,71,some college,WA,0.412130688,4,0
-male,white,44,4-year college,ME,0.484032089,2,0
-female,other,30,some college,NC,0.519037458,3,1
-female,white,43,post-grad,IL,0.409799486,1,0
-male,white,42,post-grad,FL,0.506188355,3,1
-female,white,67,some college,KY,0.65670629,3,1
-female,white,37,some college,MA,0.353487213,2,0
-male,white,66,hs,AR,0.642851377,3,0
-female,white,21,post-grad,KY,0.65670629,3,0
-male,white,24,no hs,LA,0.601716772,3,1
-female,white,22,some college,AR,0.642851377,3,1
-female,white,18,post-grad,GA,0.526611726,3,1
-male,white,48,hs,NY,0.382275815,2,0
-male,white,45,hs,KY,0.65670629,3,0
-female,white,55,hs,CA,0.338717892,4,0
-female,white,37,hs,MO,0.59818561,1,0
-male,other,51,hs,CO,0.473166666,4,0
-female,black,44,4-year college,GA,0.526611726,3,0
-male,white,69,some college,PA,0.503755358,2,0
-male,white,57,some college,NM,0.453492051,4,0
-female,white,40,post-grad,FL,0.506188355,3,0
-male,black,22,some college,CA,0.338717892,4,1
-male,white,75,some college,CA,0.338717892,4,1
-female,white,37,4-year college,CA,0.338717892,4,0
-female,white,82,no hs,CA,0.338717892,4,1
-female,white,33,some college,AR,0.642851377,3,1
-female,white,53,4-year college,FL,0.506188355,3,1
-male,white,42,4-year college,MA,0.353487213,2,1
-male,white,56,4-year college,MD,0.359837503,3,0
-female,white,59,hs,CO,0.473166666,4,1
-female,white,37,some college,MO,0.59818561,1,0
-male,white,66,some college,AZ,0.518900234,4,1
-female,white,68,4-year college,KS,0.611114703,1,1
-male,black,69,some college,FL,0.506188355,3,0
-male,other,45,4-year college,MD,0.359837503,3,1
-female,white,38,post-grad,IL,0.409799486,1,0
-male,white,93,post-grad,TX,0.547132256,3,0
-female,white,44,some college,NV,0.487062906,4,0
-female,other,29,some college,OK,0.693047372,3,1
-male,white,60,4-year college,TX,0.547132256,3,1
-female,other,49,4-year college,NY,0.382275815,2,0
-female,white,37,4-year college,FL,0.506188355,3,1
-male,white,33,4-year college,MN,0.491681431,1,1
-male,white,82,4-year college,KS,0.611114703,1,0
-male,white,36,hs,NY,0.382275815,2,1
-female,white,68,some college,MO,0.59818561,1,1
-male,white,32,hs,SD,0.659718581,1,0
-female,white,21,hs,TX,0.547132256,3,0
-male,other,52,no hs,RI,0.416892959,2,1
-female,other,58,4-year college,TX,0.547132256,3,0
-female,other,20,some college,MI,0.501176682,1,0
-male,white,87,4-year college,GA,0.526611726,3,1
-male,white,73,some college,NJ,0.427158099,2,1
-female,other,60,hs,TX,0.547132256,3,1
-female,other,40,some college,NV,0.487062906,4,0
-female,white,50,hs,WI,0.50407989,1,0
-male,white,62,4-year college,NM,0.453492051,4,0
-male,white,45,some college,NC,0.519037458,3,1
-male,white,34,4-year college,WI,0.50407989,1,0
-male,white,60,some college,NC,0.519037458,3,1
-female,white,65,hs,AZ,0.518900234,4,1
-female,white,52,post-grad,FL,0.506188355,3,0
-female,other,35,post-grad,KS,0.611114703,1,0
-female,white,54,hs,OH,0.542676846,1,0
-female,white,45,some college,NC,0.519037458,3,1
-female,white,62,hs,VA,0.471736237,3,0
-male,white,69,hs,PA,0.503755358,2,1
-female,other,21,some college,CA,0.338717892,4,0
-female,white,26,4-year college,PA,0.503755358,2,1
-female,black,35,4-year college,GA,0.526611726,3,1
-female,white,67,4-year college,FL,0.506188355,3,0
-female,other,48,hs,HI,0.325586625,4,0
-male,white,66,4-year college,MO,0.59818561,1,0
-male,white,30,hs,PA,0.503755358,2,1
-female,white,52,post-grad,GA,0.526611726,3,1
-female,white,55,post-grad,MI,0.501176682,1,1
-female,white,38,some college,PA,0.503755358,2,0
-male,white,64,hs,OH,0.542676846,1,1
-male,white,54,some college,NY,0.382275815,2,1
-male,white,55,4-year college,MI,0.501176682,1,1
-female,white,31,hs,WA,0.412130688,4,1
-female,white,54,hs,MD,0.359837503,3,0
-female,white,42,no hs,FL,0.506188355,3,1
-male,other,32,4-year college,IL,0.409799486,1,0
-male,white,80,4-year college,MN,0.491681431,1,0
-female,white,45,hs,TX,0.547132256,3,1
-male,white,36,post-grad,CA,0.338717892,4,0
-male,white,48,hs,CA,0.338717892,4,0
-male,white,74,post-grad,MN,0.491681431,1,1
-male,white,66,4-year college,IN,0.601173095,1,1
-female,black,43,some college,CA,0.338717892,4,0
-male,white,28,some college,MI,0.501176682,1,0
-female,white,64,hs,NJ,0.427158099,2,0
-female,white,35,hs,AZ,0.518900234,4,1
-female,other,33,some college,TX,0.547132256,3,0
-female,white,37,post-grad,CA,0.338717892,4,0
-male,white,61,some college,PA,0.503755358,2,1
-male,white,57,some college,CA,0.338717892,4,0
-female,white,28,4-year college,CT,0.428584525,2,0
-female,white,61,post-grad,NC,0.519037458,3,0
-female,white,57,no hs,AZ,0.518900234,4,1
-female,white,29,no hs,ID,0.683101767,4,1
-male,white,44,4-year college,PA,0.503755358,2,1
-female,black,30,hs,LA,0.601716772,3,0
-female,white,25,hs,TX,0.547132256,3,1
-male,white,63,hs,NC,0.519037458,3,1
-male,black,35,4-year college,IL,0.409799486,1,0
-female,white,66,hs,GA,0.526611726,3,1
-female,black,22,4-year college,NY,0.382275815,2,0
-male,white,63,some college,CA,0.338717892,4,1
-male,white,85,some college,IN,0.601173095,1,1
-male,white,32,4-year college,FL,0.506188355,3,0
-female,white,62,post-grad,MO,0.59818561,1,0
-male,white,53,hs,WY,0.757053196,4,1
-male,white,32,hs,GA,0.526611726,3,1
-female,black,24,hs,TX,0.547132256,3,0
-female,white,58,hs,FL,0.506188355,3,0
-male,white,98,post-grad,TN,0.63624343,3,0
-male,white,23,some college,TX,0.547132256,3,0
-female,white,69,hs,NJ,0.427158099,2,1
-female,white,38,hs,FL,0.506188355,3,0
-female,white,62,no hs,FL,0.506188355,3,0
-female,white,60,4-year college,IL,0.409799486,1,1
-male,white,40,some college,KY,0.65670629,3,1
-female,white,49,post-grad,IL,0.409799486,1,1
-female,white,43,4-year college,OH,0.542676846,1,0
-female,white,32,post-grad,NY,0.382275815,2,0
-male,other,79,some college,OK,0.693047372,3,0
-male,white,28,hs,OH,0.542676846,1,0
-female,black,20,hs,NC,0.519037458,3,1
-male,white,66,hs,AZ,0.518900234,4,0
-male,white,19,hs,WA,0.412130688,4,0
-male,other,25,hs,FL,0.506188355,3,1
-male,white,75,some college,CA,0.338717892,4,1
-female,white,38,hs,TX,0.547132256,3,1
-female,white,54,some college,MI,0.501176682,1,1
-female,white,44,some college,VA,0.471736237,3,1
-female,white,42,4-year college,OK,0.693047372,3,0
-male,white,65,post-grad,MA,0.353487213,2,1
-female,other,43,4-year college,IL,0.409799486,1,0
-female,white,83,4-year college,VA,0.471736237,3,0
-female,white,78,hs,AL,0.643741436,3,1
-female,other,19,4-year college,CA,0.338717892,4,1
-male,white,100,no hs,MD,0.359837503,3,1
-female,white,70,some college,WV,0.721610523,3,0
-female,white,33,hs,NC,0.519037458,3,0
-female,white,72,some college,MO,0.59818561,1,1
-female,other,30,4-year college,CA,0.338717892,4,1
-male,black,53,some college,TX,0.547132256,3,0
-female,black,43,4-year college,NJ,0.427158099,2,0
-female,other,41,some college,TX,0.547132256,3,0
-female,white,81,some college,CA,0.338717892,4,1
-female,white,56,some college,WI,0.50407989,1,0
-male,white,63,4-year college,NJ,0.427158099,2,0
-female,white,37,post-grad,MD,0.359837503,3,0
-female,white,67,some college,MA,0.353487213,2,0
-male,black,52,hs,NY,0.382275815,2,0
-female,black,35,4-year college,UT,0.623836582,4,0
-female,white,32,post-grad,IL,0.409799486,1,0
-female,white,32,hs,CO,0.473166666,4,1
-male,white,63,post-grad,OR,0.438441611,4,0
-female,white,52,4-year college,WY,0.757053196,4,0
-male,other,82,hs,MT,0.611096643,4,1
-female,white,24,some college,CA,0.338717892,4,0
-female,white,49,hs,LA,0.601716772,3,0
-female,white,49,some college,NJ,0.427158099,2,0
-male,white,43,post-grad,OR,0.438441611,4,1
-male,other,22,4-year college,AZ,0.518900234,4,0
-female,other,47,4-year college,TX,0.547132256,3,1
-female,white,35,4-year college,IA,0.550635478,1,0
-female,white,53,some college,WI,0.50407989,1,0
-female,white,25,some college,FL,0.506188355,3,0
-male,white,68,post-grad,HI,0.325586625,4,1
-female,white,41,hs,LA,0.601716772,3,1
-female,white,54,hs,SC,0.574602564,3,1
-female,white,41,post-grad,OH,0.542676846,1,0
-female,white,52,post-grad,CT,0.428584525,2,0
-female,white,73,hs,IN,0.601173095,1,0
-female,white,77,post-grad,NJ,0.427158099,2,1
-female,white,49,4-year college,NY,0.382275815,2,0
-female,white,69,hs,MN,0.491681431,1,1
-female,white,45,some college,NC,0.519037458,3,0
-female,white,51,hs,MA,0.353487213,2,0
-female,white,70,post-grad,OH,0.542676846,1,1
-female,white,47,some college,KY,0.65670629,3,1
-female,white,65,post-grad,KS,0.611114703,1,1
-male,other,34,no hs,NY,0.382275815,2,0
-female,black,30,post-grad,MA,0.353487213,2,0
-male,white,84,4-year college,WI,0.50407989,1,0
-male,white,41,hs,OH,0.542676846,1,0
-female,white,50,some college,DE,0.440013786,3,1
-male,white,86,some college,PA,0.503755358,2,0
-male,other,68,some college,NY,0.382275815,2,1
-female,other,23,hs,CA,0.338717892,4,0
-male,white,35,4-year college,MD,0.359837503,3,1
-male,other,23,some college,CA,0.338717892,4,0
-male,white,53,hs,TX,0.547132256,3,1
-male,white,29,hs,NC,0.519037458,3,1
-female,white,46,some college,NC,0.519037458,3,0
-male,white,20,hs,NH,0.498029716,2,1
-male,white,31,some college,NC,0.519037458,3,0
-male,black,32,some college,CA,0.338717892,4,1
-female,other,37,4-year college,TX,0.547132256,3,0
-male,white,53,4-year college,IN,0.601173095,1,0
-female,white,23,4-year college,GA,0.526611726,3,1
-male,white,40,post-grad,PA,0.503755358,2,0
-female,white,50,hs,WI,0.50407989,1,0
-male,white,47,some college,NH,0.498029716,2,1
-male,black,91,post-grad,MD,0.359837503,3,0
-male,other,19,hs,MO,0.59818561,1,1
-female,white,58,post-grad,CA,0.338717892,4,0
-female,white,94,post-grad,MA,0.353487213,2,0
-female,white,19,some college,TX,0.547132256,3,1
-female,white,28,4-year college,NY,0.382275815,2,0
-male,white,56,post-grad,WA,0.412130688,4,1
-male,white,55,hs,ID,0.683101767,4,1
-male,white,60,4-year college,KS,0.611114703,1,1
-female,white,63,hs,OH,0.542676846,1,0
-female,white,54,hs,ID,0.683101767,4,0
-female,black,64,post-grad,GA,0.526611726,3,0
-male,white,31,some college,TX,0.547132256,3,0
-female,white,56,hs,IA,0.550635478,1,1
-male,white,58,hs,PA,0.503755358,2,0
-female,white,54,4-year college,UT,0.623836582,4,0
-female,white,18,some college,CA,0.338717892,4,0
-male,other,33,some college,IL,0.409799486,1,1
-male,white,54,post-grad,CA,0.338717892,4,1
-female,white,51,some college,WA,0.412130688,4,0
-female,other,25,post-grad,CA,0.338717892,4,1
-female,white,26,post-grad,OH,0.542676846,1,0
-male,white,76,4-year college,CA,0.338717892,4,0
-female,white,45,4-year college,NJ,0.427158099,2,1
-female,white,23,hs,CA,0.338717892,4,0
-female,black,40,4-year college,CA,0.338717892,4,1
-female,white,18,post-grad,MO,0.59818561,1,0
-female,white,64,some college,MO,0.59818561,1,1
-female,white,26,hs,FL,0.506188355,3,0
-male,other,32,some college,CA,0.338717892,4,0
-male,white,54,4-year college,KY,0.65670629,3,1
-female,white,37,4-year college,OH,0.542676846,1,0
-female,white,47,4-year college,NY,0.382275815,2,1
-male,other,19,some college,FL,0.506188355,3,0
-female,white,66,4-year college,MI,0.501176682,1,1
-female,white,25,some college,NC,0.519037458,3,0
-female,white,59,no hs,PA,0.503755358,2,0
-male,white,63,hs,MN,0.491681431,1,0
-male,black,28,some college,SC,0.574602564,3,0
-female,white,92,hs,NE,0.635476741,1,1
-male,white,20,some college,NM,0.453492051,4,0
-female,white,62,hs,FL,0.506188355,3,0
-female,white,33,some college,MO,0.59818561,1,1
-male,white,90,some college,OH,0.542676846,1,0
-male,white,96,4-year college,OH,0.542676846,1,1
-female,white,73,hs,NY,0.382275815,2,0
-female,white,49,4-year college,MD,0.359837503,3,0
-female,white,21,hs,PA,0.503755358,2,0
-female,black,62,4-year college,MI,0.501176682,1,1
-female,white,19,some college,NC,0.519037458,3,0
-female,white,41,hs,IA,0.550635478,1,0
-male,white,59,some college,OH,0.542676846,1,1
-female,white,37,post-grad,MO,0.59818561,1,0
-female,white,25,hs,MO,0.59818561,1,0
-female,white,51,hs,NY,0.382275815,2,1
-female,white,48,some college,WA,0.412130688,4,1
-female,white,57,hs,IA,0.550635478,1,0
-male,white,67,post-grad,CO,0.473166666,4,1
-female,white,24,post-grad,NE,0.635476741,1,0
-female,white,97,hs,NH,0.498029716,2,0
-female,white,57,hs,CT,0.428584525,2,0
-male,white,49,hs,TN,0.63624343,3,0
-female,white,48,4-year college,PA,0.503755358,2,1
-male,white,24,some college,CA,0.338717892,4,1
-male,white,30,some college,VA,0.471736237,3,0
-female,white,61,4-year college,NC,0.519037458,3,0
-female,white,67,4-year college,OH,0.542676846,1,0
-female,other,49,hs,OH,0.542676846,1,0
-female,white,55,hs,WI,0.50407989,1,1
-male,other,58,some college,OH,0.542676846,1,1
-male,white,72,4-year college,MD,0.359837503,3,1
-female,white,49,hs,IL,0.409799486,1,0
-male,white,24,4-year college,VA,0.471736237,3,1
-male,white,59,hs,MN,0.491681431,1,0
-female,white,92,some college,CT,0.428584525,2,1
-female,white,35,some college,IL,0.409799486,1,0
-female,white,36,hs,OH,0.542676846,1,0
-male,white,22,hs,NY,0.382275815,2,0
-male,other,65,some college,FL,0.506188355,3,1
-female,white,66,hs,IL,0.409799486,1,0
-male,white,32,some college,FL,0.506188355,3,1
-female,white,43,post-grad,IA,0.550635478,1,0
-male,white,66,some college,IL,0.409799486,1,0
-male,white,29,hs,MN,0.491681431,1,1
-male,black,27,no hs,NY,0.382275815,2,0
-female,black,43,some college,MI,0.501176682,1,1
-male,white,98,4-year college,MI,0.501176682,1,0
-female,white,58,hs,NC,0.519037458,3,0
-female,other,50,some college,CA,0.338717892,4,1
-female,white,33,hs,WY,0.757053196,4,1
-male,white,50,hs,PA,0.503755358,2,0
-female,other,32,hs,WA,0.412130688,4,0
-male,white,59,some college,SC,0.574602564,3,1
-female,white,40,some college,MO,0.59818561,1,0
-female,white,74,hs,WI,0.50407989,1,0
-male,white,21,hs,NY,0.382275815,2,0
-male,other,33,post-grad,VA,0.471736237,3,1
-female,white,95,some college,MI,0.501176682,1,1
-male,black,39,hs,IN,0.601173095,1,0
-female,black,33,some college,AL,0.643741436,3,0
-male,white,66,4-year college,OH,0.542676846,1,1
-female,white,68,some college,IL,0.409799486,1,0
-female,black,62,4-year college,ID,0.683101767,4,0
-female,white,63,hs,NE,0.635476741,1,0
-female,white,62,hs,TX,0.547132256,3,1
-male,white,40,some college,NY,0.382275815,2,1
-male,white,48,some college,MN,0.491681431,1,1
-female,white,53,some college,KY,0.65670629,3,0
-female,white,18,4-year college,DE,0.440013786,3,1
-female,black,67,4-year college,NY,0.382275815,2,0
-male,other,54,4-year college,VA,0.471736237,3,0
-female,white,62,some college,OK,0.693047372,3,0
-male,white,36,some college,NC,0.519037458,3,0
-female,white,51,some college,KY,0.65670629,3,1
-male,white,57,hs,NY,0.382275815,2,1
-female,white,38,4-year college,MI,0.501176682,1,0
-female,other,64,some college,FL,0.506188355,3,0
-female,black,38,some college,NY,0.382275815,2,1
-female,black,66,4-year college,MS,0.590898473,3,1
-female,white,95,post-grad,TX,0.547132256,3,1
-female,white,87,hs,WA,0.412130688,4,0
-male,white,31,hs,NC,0.519037458,3,0
-female,white,22,post-grad,TX,0.547132256,3,0
-male,white,99,4-year college,WA,0.412130688,4,0
-female,white,28,4-year college,TX,0.547132256,3,0
-female,white,23,post-grad,IA,0.550635478,1,0
-male,white,38,4-year college,IL,0.409799486,1,1
-male,white,89,hs,CA,0.338717892,4,0
-female,other,23,some college,CT,0.428584525,2,0
-female,white,52,some college,TX,0.547132256,3,0
-female,white,55,hs,TN,0.63624343,3,0
-female,white,63,some college,CA,0.338717892,4,0
-female,white,33,hs,WV,0.721610523,3,1
-female,other,36,some college,NY,0.382275815,2,0
-male,white,91,some college,MO,0.59818561,1,1
-male,white,51,4-year college,OK,0.693047372,3,1
-male,other,49,some college,OK,0.693047372,3,1
-female,black,26,4-year college,MS,0.590898473,3,1
-female,white,36,some college,AL,0.643741436,3,1
-male,other,18,4-year college,CA,0.338717892,4,0
-female,white,48,some college,MA,0.353487213,2,0
-female,white,70,post-grad,CA,0.338717892,4,0
-male,white,64,4-year college,NY,0.382275815,2,0
-female,white,69,some college,MI,0.501176682,1,0
-male,other,66,4-year college,FL,0.506188355,3,0
-male,white,61,hs,SC,0.574602564,3,0
-male,black,47,hs,AR,0.642851377,3,0
-male,white,59,some college,UT,0.623836582,4,0
-female,white,53,no hs,OH,0.542676846,1,1
-male,white,39,post-grad,FL,0.506188355,3,0
-female,white,26,some college,MN,0.491681431,1,0
-male,white,67,4-year college,IN,0.601173095,1,1
-male,white,66,some college,FL,0.506188355,3,0
-female,white,43,hs,IL,0.409799486,1,0
-male,other,18,post-grad,FL,0.506188355,3,0
-male,white,66,some college,TX,0.547132256,3,0
-female,white,27,4-year college,IA,0.550635478,1,1
-female,other,55,4-year college,NM,0.453492051,4,1
-male,other,29,some college,MI,0.501176682,1,0
-male,white,19,some college,NC,0.519037458,3,1
-female,white,67,hs,WV,0.721610523,3,0
-male,other,37,some college,CA,0.338717892,4,0
-female,white,40,hs,NJ,0.427158099,2,0
-female,white,35,post-grad,TX,0.547132256,3,0
-male,white,28,4-year college,OH,0.542676846,1,0
-female,other,41,some college,OK,0.693047372,3,0
-female,white,58,some college,NC,0.519037458,3,1
-female,white,64,some college,CA,0.338717892,4,0
-female,white,50,some college,AZ,0.518900234,4,1
-female,white,62,hs,MS,0.590898473,3,0
-female,white,19,4-year college,CO,0.473166666,4,0
-male,white,56,hs,WV,0.721610523,3,1
-female,white,52,hs,IL,0.409799486,1,0
-female,white,40,4-year college,CO,0.473166666,4,1
-female,white,21,some college,WI,0.50407989,1,1
-male,white,96,some college,ND,0.698092429,1,1
-male,white,43,4-year college,TN,0.63624343,3,0
-female,other,23,some college,VA,0.471736237,3,0
-male,black,22,4-year college,MA,0.353487213,2,1
-male,white,46,some college,PA,0.503755358,2,1
-male,other,54,4-year college,WA,0.412130688,4,0
-male,white,19,post-grad,AR,0.642851377,3,0
-female,white,44,4-year college,FL,0.506188355,3,1
-female,white,33,post-grad,PA,0.503755358,2,0
-female,white,32,4-year college,MS,0.590898473,3,1
-female,black,30,some college,KS,0.611114703,1,1
-female,white,86,4-year college,MD,0.359837503,3,0
-female,other,23,4-year college,CA,0.338717892,4,1
-male,white,46,some college,NH,0.498029716,2,0
-female,white,76,hs,OR,0.438441611,4,0
-male,other,23,4-year college,CA,0.338717892,4,0
-female,black,69,hs,MI,0.501176682,1,0
-male,black,63,some college,FL,0.506188355,3,0
-male,white,54,4-year college,FL,0.506188355,3,1
-female,white,69,hs,MA,0.353487213,2,0
-female,white,51,hs,FL,0.506188355,3,0
-male,white,99,hs,TX,0.547132256,3,0
-female,white,61,hs,MI,0.501176682,1,0
-female,white,35,hs,TX,0.547132256,3,1
-male,white,54,hs,KY,0.65670629,3,1
-male,white,67,some college,VA,0.471736237,3,1
-female,white,25,hs,NY,0.382275815,2,1
-female,white,36,some college,AL,0.643741436,3,1
-female,white,36,4-year college,PA,0.503755358,2,0
-male,white,32,some college,FL,0.506188355,3,0
-male,white,56,some college,FL,0.506188355,3,0
-male,other,56,4-year college,WA,0.412130688,4,1
-female,white,40,hs,WI,0.50407989,1,0
-female,white,50,hs,NY,0.382275815,2,0
-female,white,31,hs,PA,0.503755358,2,0
-female,white,42,hs,NC,0.519037458,3,0
-male,other,22,4-year college,CA,0.338717892,4,1
-female,white,62,4-year college,TX,0.547132256,3,0
-male,white,98,hs,NJ,0.427158099,2,1
-male,other,87,4-year college,CA,0.338717892,4,0
-male,black,38,some college,GA,0.526611726,3,1
-male,white,51,hs,ND,0.698092429,1,1
-female,other,18,some college,FL,0.506188355,3,0
-female,white,20,hs,MN,0.491681431,1,0
-male,white,51,hs,PA,0.503755358,2,0
-male,white,69,4-year college,CO,0.473166666,4,0
-male,white,41,some college,TN,0.63624343,3,0
-female,other,23,some college,FL,0.506188355,3,1
-female,white,50,some college,IN,0.601173095,1,0
-male,white,67,some college,VA,0.471736237,3,1
-female,white,98,hs,NC,0.519037458,3,1
-female,white,36,hs,VA,0.471736237,3,0
-male,white,62,some college,FL,0.506188355,3,0
-female,white,58,no hs,MI,0.501176682,1,1
-female,white,82,4-year college,ID,0.683101767,4,1
-female,other,28,post-grad,TX,0.547132256,3,0
-female,white,85,hs,NV,0.487062906,4,0
-female,white,20,some college,CA,0.338717892,4,0
-male,white,32,some college,MO,0.59818561,1,1
-female,white,40,4-year college,SC,0.574602564,3,1
-female,white,41,4-year college,WA,0.412130688,4,1
-female,white,65,hs,SC,0.574602564,3,1
-male,white,68,4-year college,NV,0.487062906,4,1
-female,white,91,4-year college,NJ,0.427158099,2,0
-male,other,52,some college,CA,0.338717892,4,1
-female,black,67,no hs,VA,0.471736237,3,1
-female,white,35,hs,WI,0.50407989,1,0
-male,white,57,hs,MO,0.59818561,1,1
-female,white,69,post-grad,VA,0.471736237,3,0
-female,other,49,some college,NY,0.382275815,2,1
-female,white,54,hs,AZ,0.518900234,4,1
-female,white,23,some college,NE,0.635476741,1,0
-female,other,30,hs,TX,0.547132256,3,0
-male,white,39,post-grad,AL,0.643741436,3,1
-female,white,70,hs,PA,0.503755358,2,0
-female,white,46,4-year college,CA,0.338717892,4,1
-female,other,32,some college,NV,0.487062906,4,1
-male,white,66,4-year college,NY,0.382275815,2,1
-female,white,36,some college,KY,0.65670629,3,1
-female,white,51,some college,OH,0.542676846,1,0
-female,black,18,post-grad,NY,0.382275815,2,0
-female,white,37,4-year college,VA,0.471736237,3,0
-male,white,50,hs,CA,0.338717892,4,0
-female,white,43,some college,OR,0.438441611,4,0
-female,white,64,some college,NV,0.487062906,4,1
-male,white,54,some college,NC,0.519037458,3,1
-female,white,45,some college,OR,0.438441611,4,0
-male,white,31,hs,AZ,0.518900234,4,1
-male,white,53,hs,CA,0.338717892,4,1
-female,black,40,hs,MD,0.359837503,3,1
-female,white,32,hs,VA,0.471736237,3,1
-female,white,69,some college,NE,0.635476741,1,1
-male,white,36,some college,TN,0.63624343,3,0
-female,white,68,some college,WI,0.50407989,1,0
-female,white,53,hs,LA,0.601716772,3,1
-male,white,75,some college,OH,0.542676846,1,1
-female,white,30,post-grad,WA,0.412130688,4,0
-female,white,25,4-year college,NJ,0.427158099,2,0
-male,white,55,hs,MI,0.501176682,1,0
-male,white,50,post-grad,IL,0.409799486,1,1
-female,white,79,some college,AR,0.642851377,3,1
-female,white,34,post-grad,MT,0.611096643,4,0
-female,white,68,hs,NY,0.382275815,2,0
-male,white,90,some college,UT,0.623836582,4,0
-male,white,18,some college,NH,0.498029716,2,1
-male,white,87,some college,AZ,0.518900234,4,1
-female,other,44,some college,CA,0.338717892,4,0
-male,white,63,4-year college,NC,0.519037458,3,0
-male,white,81,some college,ME,0.484032089,2,0
-female,white,52,4-year college,TX,0.547132256,3,1
-female,other,31,hs,CA,0.338717892,4,0
-female,black,45,some college,TN,0.63624343,3,0
-male,white,72,post-grad,NY,0.382275815,2,0
-male,other,69,hs,CA,0.338717892,4,0
-male,white,22,4-year college,TX,0.547132256,3,1
-male,white,71,hs,MO,0.59818561,1,0
-male,black,37,hs,LA,0.601716772,3,0
-male,black,33,some college,CA,0.338717892,4,0
-male,white,69,4-year college,PA,0.503755358,2,0
-female,other,28,some college,WA,0.412130688,4,1
-female,other,38,4-year college,GA,0.526611726,3,0
-male,white,77,post-grad,WA,0.412130688,4,1
-male,other,61,hs,CA,0.338717892,4,0
-male,other,18,some college,WA,0.412130688,4,0
-female,white,62,post-grad,AZ,0.518900234,4,0
-female,other,51,post-grad,WA,0.412130688,4,0
-male,other,35,post-grad,NC,0.519037458,3,0
-female,white,70,hs,MT,0.611096643,4,1
-female,white,56,4-year college,NY,0.382275815,2,0
-male,white,85,some college,KS,0.611114703,1,1
-female,white,52,no hs,PA,0.503755358,2,0
-male,white,99,some college,NM,0.453492051,4,1
-female,other,94,4-year college,CO,0.473166666,4,0
-female,white,36,post-grad,MA,0.353487213,2,1
-female,white,58,hs,NY,0.382275815,2,0
-female,other,22,4-year college,FL,0.506188355,3,0
-male,other,55,post-grad,IL,0.409799486,1,0
-male,other,46,post-grad,WA,0.412130688,4,0
-female,white,99,4-year college,FL,0.506188355,3,1
-female,white,75,hs,NY,0.382275815,2,0
-female,white,55,some college,KY,0.65670629,3,0
-female,white,22,hs,VA,0.471736237,3,0
-female,white,37,hs,MD,0.359837503,3,0
-male,white,50,hs,FL,0.506188355,3,1
-female,white,68,hs,AZ,0.518900234,4,1
-female,white,67,4-year college,NJ,0.427158099,2,1
-male,white,30,4-year college,CA,0.338717892,4,1
-female,other,37,hs,AL,0.643741436,3,0
-male,white,81,post-grad,CO,0.473166666,4,1
-male,white,68,some college,MT,0.611096643,4,0
-female,black,54,some college,GA,0.526611726,3,0
-female,white,60,hs,IL,0.409799486,1,0
-female,other,55,some college,TX,0.547132256,3,0
-male,white,69,some college,LA,0.601716772,3,0
-female,white,29,4-year college,PA,0.503755358,2,0
-male,white,50,post-grad,TX,0.547132256,3,0
-male,other,50,some college,NJ,0.427158099,2,1
-female,white,35,some college,UT,0.623836582,4,1
-male,white,45,post-grad,MO,0.59818561,1,0
-female,white,90,hs,FL,0.506188355,3,0
-female,other,23,4-year college,CA,0.338717892,4,1
-male,white,36,some college,MN,0.491681431,1,0
-male,white,61,4-year college,TX,0.547132256,3,0
-female,white,20,some college,MN,0.491681431,1,0
-male,other,32,some college,FL,0.506188355,3,0
-female,other,45,4-year college,FL,0.506188355,3,0
-male,white,52,4-year college,CA,0.338717892,4,1
-male,white,64,no hs,NJ,0.427158099,2,1
-male,other,36,4-year college,CA,0.338717892,4,0
-female,white,29,4-year college,NJ,0.427158099,2,0
-male,black,24,some college,LA,0.601716772,3,0
-female,white,34,post-grad,CO,0.473166666,4,1
-female,white,26,hs,NJ,0.427158099,2,0
-male,black,24,4-year college,VA,0.471736237,3,0
-female,white,56,some college,MI,0.501176682,1,0
-male,white,74,hs,OH,0.542676846,1,1
-male,white,70,4-year college,CA,0.338717892,4,1
-male,white,65,some college,WA,0.412130688,4,1
-female,white,54,some college,ID,0.683101767,4,1
-female,black,36,some college,FL,0.506188355,3,1
-female,white,45,some college,OK,0.693047372,3,1
-female,other,21,post-grad,WA,0.412130688,4,0
-male,white,54,some college,MT,0.611096643,4,1
-female,black,33,some college,IN,0.601173095,1,0
-female,white,52,no hs,AZ,0.518900234,4,0
-female,white,62,no hs,WA,0.412130688,4,0
-female,white,50,hs,TX,0.547132256,3,0
-female,white,61,hs,IN,0.601173095,1,1
-female,other,69,some college,CO,0.473166666,4,1
-female,white,18,some college,TN,0.63624343,3,0
-male,white,84,post-grad,GA,0.526611726,3,1
-male,black,43,hs,PA,0.503755358,2,1
-female,white,46,some college,NC,0.519037458,3,1
-female,other,22,some college,WI,0.50407989,1,0
-male,white,84,some college,CA,0.338717892,4,1
-male,white,80,no hs,UT,0.623836582,4,1
-female,other,48,some college,RI,0.416892959,2,0
-male,white,58,some college,MI,0.501176682,1,1
-female,white,37,hs,TX,0.547132256,3,1
-female,white,52,hs,MA,0.353487213,2,1
-male,white,50,hs,TN,0.63624343,3,0
-female,white,26,4-year college,NY,0.382275815,2,1
-male,white,50,hs,OH,0.542676846,1,0
-male,white,76,post-grad,PA,0.503755358,2,0
-female,white,21,some college,ID,0.683101767,4,0
-female,white,41,some college,CA,0.338717892,4,0
-female,white,30,post-grad,MA,0.353487213,2,0
-female,white,55,hs,IN,0.601173095,1,0
-female,white,21,post-grad,VA,0.471736237,3,0
-male,white,90,some college,NE,0.635476741,1,1
-female,white,61,post-grad,KS,0.611114703,1,0
-male,white,64,4-year college,AL,0.643741436,3,1
-female,other,49,post-grad,OH,0.542676846,1,0
-female,white,22,some college,SC,0.574602564,3,1
-female,black,59,some college,IL,0.409799486,1,0
-female,white,66,some college,TX,0.547132256,3,1
-female,white,20,some college,WI,0.50407989,1,0
-male,white,57,post-grad,FL,0.506188355,3,1
-female,white,40,4-year college,TX,0.547132256,3,0
-male,white,61,4-year college,CA,0.338717892,4,0
-female,black,39,4-year college,NJ,0.427158099,2,0
-male,white,34,4-year college,IL,0.409799486,1,0
-male,black,57,post-grad,CA,0.338717892,4,0
-female,white,19,4-year college,CA,0.338717892,4,1
-female,other,56,hs,CA,0.338717892,4,0
-male,white,60,hs,NC,0.519037458,3,1
-female,white,21,hs,MI,0.501176682,1,0
-male,white,25,some college,KS,0.611114703,1,1
-male,white,46,4-year college,MI,0.501176682,1,0
-female,white,88,hs,IN,0.601173095,1,0
-male,white,60,some college,IN,0.601173095,1,1
-female,white,61,hs,FL,0.506188355,3,0
-female,white,65,4-year college,MA,0.353487213,2,0
-female,white,24,some college,IN,0.601173095,1,0
-female,white,63,4-year college,AZ,0.518900234,4,1
-female,other,21,4-year college,IL,0.409799486,1,1
-female,white,31,hs,NY,0.382275815,2,1
-female,white,97,post-grad,FL,0.506188355,3,0
-male,white,84,post-grad,MN,0.491681431,1,0
-female,white,53,post-grad,VA,0.471736237,3,1
-female,other,22,hs,MI,0.501176682,1,0
-female,white,55,hs,OR,0.438441611,4,0
-female,black,18,post-grad,MD,0.359837503,3,0
-male,black,32,hs,GA,0.526611726,3,1
-female,other,27,hs,CA,0.338717892,4,0
-male,white,65,post-grad,NV,0.487062906,4,0
-male,white,47,post-grad,TN,0.63624343,3,1
-female,white,27,post-grad,PA,0.503755358,2,0
-male,white,38,some college,NJ,0.427158099,2,0
-male,white,56,some college,PA,0.503755358,2,0
-male,other,56,post-grad,FL,0.506188355,3,1
-female,white,27,some college,ID,0.683101767,4,1
-male,white,41,4-year college,WA,0.412130688,4,1
-male,white,43,no hs,OR,0.438441611,4,1
-female,other,33,some college,IL,0.409799486,1,0
-female,white,62,hs,NE,0.635476741,1,1
-female,white,65,some college,FL,0.506188355,3,0
-male,white,54,4-year college,MA,0.353487213,2,1
-male,white,37,some college,GA,0.526611726,3,1
-male,white,25,hs,IN,0.601173095,1,1
-male,white,22,hs,NY,0.382275815,2,0
-male,white,21,4-year college,AZ,0.518900234,4,0
-female,black,59,some college,MD,0.359837503,3,1
-male,white,45,some college,MO,0.59818561,1,0
-female,white,59,4-year college,WV,0.721610523,3,0
-male,other,26,some college,GA,0.526611726,3,0
-male,white,73,post-grad,WI,0.50407989,1,0
-female,white,34,4-year college,NV,0.487062906,4,0
-male,other,55,4-year college,RI,0.416892959,2,0
-male,white,60,some college,GA,0.526611726,3,1
-male,white,39,some college,MN,0.491681431,1,0
-female,white,78,hs,CA,0.338717892,4,0
-male,white,28,some college,GA,0.526611726,3,1
-male,white,58,some college,WI,0.50407989,1,1
-female,white,56,hs,NC,0.519037458,3,1
-male,other,29,post-grad,NY,0.382275815,2,0
-male,white,20,some college,VA,0.471736237,3,1
-female,white,20,4-year college,CA,0.338717892,4,0
-female,white,30,some college,OH,0.542676846,1,0
-male,white,97,some college,CT,0.428584525,2,0
-male,white,42,post-grad,NY,0.382275815,2,0
-female,white,48,some college,IA,0.550635478,1,1
-female,white,44,hs,IN,0.601173095,1,1
-female,black,38,some college,GA,0.526611726,3,1
-male,white,93,some college,WI,0.50407989,1,1
-female,other,64,4-year college,TN,0.63624343,3,0
-female,white,88,some college,AZ,0.518900234,4,0
-female,other,34,hs,TN,0.63624343,3,1
-male,white,57,some college,AZ,0.518900234,4,1
-male,white,55,hs,FL,0.506188355,3,1
-male,black,56,4-year college,CT,0.428584525,2,0
-female,white,33,some college,IN,0.601173095,1,1
-male,white,43,4-year college,AL,0.643741436,3,1
-male,white,68,some college,VA,0.471736237,3,0
-female,other,33,hs,AZ,0.518900234,4,0
-female,white,23,some college,FL,0.506188355,3,1
-female,white,47,4-year college,GA,0.526611726,3,1
-male,other,89,some college,WA,0.412130688,4,0
-female,white,19,4-year college,FL,0.506188355,3,0
-female,black,28,hs,CA,0.338717892,4,0
-female,black,62,some college,TX,0.547132256,3,0
-male,white,28,4-year college,FL,0.506188355,3,1
-male,white,38,some college,CO,0.473166666,4,0
-male,white,81,some college,VA,0.471736237,3,1
-female,white,60,post-grad,CA,0.338717892,4,0
-male,white,48,hs,TX,0.547132256,3,0
-female,white,52,hs,GA,0.526611726,3,1
-female,white,84,hs,NE,0.635476741,1,0
-female,white,95,4-year college,FL,0.506188355,3,1
-female,other,29,hs,TX,0.547132256,3,0
-female,white,62,post-grad,TX,0.547132256,3,0
-female,white,19,hs,OH,0.542676846,1,1
-female,other,67,hs,CT,0.428584525,2,0
-female,white,61,hs,OR,0.438441611,4,1
-female,black,38,4-year college,TX,0.547132256,3,0
-female,white,70,4-year college,TX,0.547132256,3,0
-male,other,50,hs,HI,0.325586625,4,0
-male,white,34,4-year college,PA,0.503755358,2,0
-male,white,65,no hs,PA,0.503755358,2,0
-male,white,45,some college,DE,0.440013786,3,1
-male,white,30,post-grad,PA,0.503755358,2,1
-female,white,47,hs,SC,0.574602564,3,1
-male,white,55,some college,NY,0.382275815,2,1
-female,white,61,hs,MA,0.353487213,2,0
-male,white,100,hs,WI,0.50407989,1,1
-male,black,49,hs,AR,0.642851377,3,0
-female,white,25,4-year college,MN,0.491681431,1,1
-female,other,43,some college,CA,0.338717892,4,0
-male,white,29,some college,FL,0.506188355,3,0
-male,white,55,4-year college,IL,0.409799486,1,0
-female,white,44,some college,PA,0.503755358,2,1
-female,other,24,some college,NY,0.382275815,2,0
-male,white,28,4-year college,NY,0.382275815,2,1
-female,white,82,post-grad,VA,0.471736237,3,1
-female,white,46,some college,NJ,0.427158099,2,1
-male,other,50,some college,CA,0.338717892,4,0
-female,white,67,some college,WI,0.50407989,1,1
-female,white,32,some college,VA,0.471736237,3,0
-male,white,58,4-year college,WA,0.412130688,4,0
-male,white,35,hs,IA,0.550635478,1,1
-female,white,36,4-year college,KY,0.65670629,3,1
-male,white,33,4-year college,MN,0.491681431,1,0
-male,white,61,hs,MI,0.501176682,1,0
-male,white,61,4-year college,PA,0.503755358,2,0
-female,other,47,4-year college,CO,0.473166666,4,1
-female,white,31,4-year college,MO,0.59818561,1,0
-female,black,42,some college,VA,0.471736237,3,0
-male,white,18,some college,NY,0.382275815,2,1
-female,white,34,4-year college,PA,0.503755358,2,0
-female,white,36,no hs,NC,0.519037458,3,0
-male,white,52,4-year college,NY,0.382275815,2,0
-male,white,45,4-year college,PA,0.503755358,2,0
-male,white,58,hs,NY,0.382275815,2,0
-male,white,50,4-year college,TX,0.547132256,3,0
-female,white,67,hs,KY,0.65670629,3,0
-male,white,64,some college,FL,0.506188355,3,0
-male,white,59,post-grad,CA,0.338717892,4,1
-female,white,21,some college,SC,0.574602564,3,0
-female,white,63,4-year college,FL,0.506188355,3,1
-male,white,46,hs,VA,0.471736237,3,0
-male,white,56,4-year college,MT,0.611096643,4,0
-female,white,95,4-year college,CA,0.338717892,4,0
-male,white,65,4-year college,AL,0.643741436,3,1
-female,white,28,hs,IN,0.601173095,1,0
-male,white,91,some college,CO,0.473166666,4,1
-male,white,43,some college,TN,0.63624343,3,0
-female,white,69,4-year college,MD,0.359837503,3,0
-female,black,20,some college,CO,0.473166666,4,0
-male,white,38,hs,IN,0.601173095,1,1
-female,white,37,4-year college,WI,0.50407989,1,0
-male,white,31,post-grad,MN,0.491681431,1,0
-male,white,30,post-grad,PA,0.503755358,2,0
-female,other,61,hs,CO,0.473166666,4,0
-female,other,40,4-year college,CA,0.338717892,4,1
-male,black,81,some college,FL,0.506188355,3,0
-female,black,45,4-year college,GA,0.526611726,3,0
-female,other,23,4-year college,CA,0.338717892,4,0
-male,white,42,hs,WA,0.412130688,4,1
-female,other,32,post-grad,MN,0.491681431,1,0
-female,white,64,hs,OH,0.542676846,1,0
-female,white,36,some college,NJ,0.427158099,2,1
-female,white,46,no hs,IN,0.601173095,1,0
-female,white,20,4-year college,MA,0.353487213,2,0
-female,white,35,some college,NM,0.453492051,4,0
-female,white,46,hs,LA,0.601716772,3,1
-female,white,20,post-grad,MI,0.501176682,1,0
-male,white,86,no hs,AZ,0.518900234,4,1
-male,white,64,hs,PA,0.503755358,2,0
-male,white,52,4-year college,IL,0.409799486,1,1
-male,white,61,hs,MI,0.501176682,1,1
-female,white,51,4-year college,MO,0.59818561,1,0
-female,white,68,hs,NC,0.519037458,3,1
-male,white,18,hs,MD,0.359837503,3,1
-female,white,59,hs,CA,0.338717892,4,0
-male,other,59,some college,FL,0.506188355,3,0
-male,other,83,hs,CA,0.338717892,4,0
-female,white,72,4-year college,TX,0.547132256,3,1
-male,white,65,hs,PA,0.503755358,2,1
-female,black,21,some college,TN,0.63624343,3,1
-male,other,45,4-year college,NE,0.635476741,1,0
-male,other,20,4-year college,VA,0.471736237,3,0
-female,white,19,hs,PA,0.503755358,2,1
-male,white,56,4-year college,CO,0.473166666,4,1
-male,white,43,hs,IN,0.601173095,1,1
-male,white,59,4-year college,TX,0.547132256,3,1
-male,white,37,hs,FL,0.506188355,3,0
-female,other,54,hs,CA,0.338717892,4,1
-male,other,26,hs,CA,0.338717892,4,0
-female,white,66,some college,PA,0.503755358,2,0
-female,white,49,hs,IN,0.601173095,1,1
-male,white,75,post-grad,OH,0.542676846,1,1
-female,white,39,post-grad,WI,0.50407989,1,0
-female,black,24,hs,NY,0.382275815,2,0
-female,white,43,some college,MO,0.59818561,1,1
-male,white,52,post-grad,GA,0.526611726,3,1
-male,white,32,post-grad,KY,0.65670629,3,1
-female,white,59,post-grad,TX,0.547132256,3,0
-male,white,59,no hs,OH,0.542676846,1,1
-male,other,31,some college,NJ,0.427158099,2,1
-female,white,27,hs,WV,0.721610523,3,1
-male,other,42,post-grad,NY,0.382275815,2,0
-female,black,43,hs,VA,0.471736237,3,0
-male,white,60,post-grad,FL,0.506188355,3,1
-female,white,28,post-grad,MO,0.59818561,1,1
-male,white,98,hs,NV,0.487062906,4,1
-female,white,60,hs,NY,0.382275815,2,1
-male,white,33,4-year college,MI,0.501176682,1,0
-female,white,60,some college,TX,0.547132256,3,0
-male,white,61,hs,WA,0.412130688,4,0
-male,white,46,4-year college,NY,0.382275815,2,0
-male,other,66,4-year college,TX,0.547132256,3,0
-female,white,58,hs,SC,0.574602564,3,0
-female,white,49,hs,KS,0.611114703,1,1
-female,white,43,post-grad,MN,0.491681431,1,0
-male,white,54,some college,OR,0.438441611,4,0
-female,white,27,hs,FL,0.506188355,3,0
-male,white,64,some college,OR,0.438441611,4,0
-female,other,55,hs,CA,0.338717892,4,1
-male,white,92,post-grad,NY,0.382275815,2,0
-male,black,30,some college,CA,0.338717892,4,0
-female,other,47,hs,TX,0.547132256,3,1
-female,white,39,hs,MI,0.501176682,1,0
-female,other,47,some college,CA,0.338717892,4,0
-female,white,98,hs,GA,0.526611726,3,1
-female,white,40,some college,TX,0.547132256,3,1
-male,white,61,hs,AZ,0.518900234,4,0
-male,white,23,4-year college,CT,0.428584525,2,0
-male,white,50,4-year college,KY,0.65670629,3,1
-female,white,43,hs,NY,0.382275815,2,0
-female,white,22,4-year college,IL,0.409799486,1,0
-female,other,77,post-grad,KY,0.65670629,3,1
-male,other,46,hs,TX,0.547132256,3,0
-female,white,35,4-year college,IN,0.601173095,1,1
-male,black,45,hs,SC,0.574602564,3,0
-female,other,43,post-grad,NY,0.382275815,2,0
-female,white,63,hs,FL,0.506188355,3,0
-female,white,76,hs,DE,0.440013786,3,1
-male,other,34,some college,PA,0.503755358,2,1
-female,white,65,some college,GA,0.526611726,3,0
-female,other,61,4-year college,CA,0.338717892,4,0
-male,white,73,4-year college,AL,0.643741436,3,1
-female,white,37,post-grad,CA,0.338717892,4,0
-female,other,55,hs,CA,0.338717892,4,1
-female,white,55,hs,CA,0.338717892,4,0
-female,white,90,some college,AL,0.643741436,3,1
-female,white,97,4-year college,WA,0.412130688,4,0
-male,white,72,hs,PA,0.503755358,2,1
-male,white,27,4-year college,NV,0.487062906,4,0
-female,other,56,some college,TX,0.547132256,3,0
-female,white,62,hs,MA,0.353487213,2,0
-female,other,21,some college,FL,0.506188355,3,0
-female,white,62,hs,KY,0.65670629,3,1
-male,white,68,some college,LA,0.601716772,3,1
-female,other,24,some college,SC,0.574602564,3,0
-female,white,24,some college,OH,0.542676846,1,1
-male,white,24,some college,CA,0.338717892,4,1
-male,white,45,hs,TN,0.63624343,3,1
-female,white,64,hs,VA,0.471736237,3,1
-male,black,41,4-year college,CA,0.338717892,4,1
-female,white,49,hs,MA,0.353487213,2,0
-female,other,45,4-year college,CA,0.338717892,4,1
-female,white,43,hs,FL,0.506188355,3,0
-female,white,40,4-year college,CA,0.338717892,4,0
-female,white,46,4-year college,PA,0.503755358,2,1
-female,white,25,4-year college,IL,0.409799486,1,1
-female,other,21,hs,CA,0.338717892,4,0
-female,white,72,some college,AL,0.643741436,3,0
-female,white,56,post-grad,CA,0.338717892,4,0
-female,white,83,4-year college,TX,0.547132256,3,1
-female,black,61,some college,AL,0.643741436,3,1
-female,white,56,hs,OH,0.542676846,1,0
-female,black,85,some college,TN,0.63624343,3,0
-male,white,66,post-grad,TX,0.547132256,3,0
-female,white,44,some college,NE,0.635476741,1,1
-female,white,38,4-year college,CA,0.338717892,4,0
-male,white,58,some college,OR,0.438441611,4,1
-male,other,69,hs,CA,0.338717892,4,0
-male,other,56,some college,MD,0.359837503,3,1
-female,white,51,hs,AL,0.643741436,3,0
-female,black,98,hs,NC,0.519037458,3,0
-female,white,66,some college,IL,0.409799486,1,0
-female,white,81,4-year college,CA,0.338717892,4,1
-female,white,23,4-year college,NY,0.382275815,2,0
-female,white,72,some college,KS,0.611114703,1,1
-female,white,48,some college,IN,0.601173095,1,0
-female,black,24,no hs,NY,0.382275815,2,0
-female,other,31,some college,LA,0.601716772,3,0
-male,other,24,some college,CA,0.338717892,4,0
-female,white,69,hs,OH,0.542676846,1,0
-female,white,29,some college,VA,0.471736237,3,0
-male,white,57,some college,MI,0.501176682,1,1
-female,white,67,hs,ME,0.484032089,2,0
-male,other,55,post-grad,TX,0.547132256,3,1
-male,white,46,hs,MA,0.353487213,2,0
-male,white,53,4-year college,IA,0.550635478,1,0
-female,white,49,some college,CA,0.338717892,4,0
-male,white,27,some college,GA,0.526611726,3,1
-male,white,79,post-grad,WA,0.412130688,4,1
-female,other,23,4-year college,CT,0.428584525,2,1
-male,white,58,post-grad,WI,0.50407989,1,1
-male,other,52,some college,WY,0.757053196,4,1
-male,white,42,hs,IL,0.409799486,1,1
-female,other,24,post-grad,CA,0.338717892,4,1
-male,white,47,hs,MO,0.59818561,1,1
-female,white,18,no hs,GA,0.526611726,3,0
-female,white,52,post-grad,FL,0.506188355,3,0
-female,white,91,hs,NJ,0.427158099,2,0
-female,black,60,hs,PA,0.503755358,2,0
-female,black,65,some college,FL,0.506188355,3,0
-male,white,64,post-grad,MI,0.501176682,1,0
-male,white,64,4-year college,NM,0.453492051,4,0
-female,white,54,some college,DE,0.440013786,3,1
-female,white,44,some college,AZ,0.518900234,4,0
-male,white,47,4-year college,TN,0.63624343,3,1
-female,white,61,hs,OH,0.542676846,1,1
-female,white,28,4-year college,NH,0.498029716,2,0
-male,other,18,hs,VA,0.471736237,3,0
-male,other,40,some college,MO,0.59818561,1,1
-female,white,60,hs,IA,0.550635478,1,1
-male,white,49,hs,MN,0.491681431,1,1
-male,white,44,hs,IN,0.601173095,1,0
-female,white,27,hs,KY,0.65670629,3,0
-female,white,46,no hs,ME,0.484032089,2,0
-female,white,22,some college,NY,0.382275815,2,0
-male,white,29,4-year college,MA,0.353487213,2,0
-female,white,82,4-year college,CA,0.338717892,4,0
-female,other,41,post-grad,NH,0.498029716,2,0
-male,other,22,some college,PA,0.503755358,2,0
-female,black,63,some college,KS,0.611114703,1,0
-male,white,24,4-year college,AL,0.643741436,3,0
-male,black,25,hs,FL,0.506188355,3,1
-female,other,48,4-year college,MA,0.353487213,2,0
-female,white,28,hs,RI,0.416892959,2,1
-male,white,24,hs,FL,0.506188355,3,0
-male,white,19,hs,FL,0.506188355,3,0
-male,white,58,4-year college,WI,0.50407989,1,1
-female,other,24,no hs,PA,0.503755358,2,1
-male,other,35,4-year college,NJ,0.427158099,2,1
-male,other,36,4-year college,CA,0.338717892,4,0
-female,white,58,4-year college,UT,0.623836582,4,0
-female,white,48,hs,TN,0.63624343,3,0
-female,other,28,4-year college,NY,0.382275815,2,0
-female,black,33,hs,MI,0.501176682,1,0
-female,white,64,hs,KS,0.611114703,1,0
-female,white,20,hs,NJ,0.427158099,2,0
-female,white,43,hs,RI,0.416892959,2,1
-male,white,47,4-year college,CT,0.428584525,2,0
-female,white,68,post-grad,IL,0.409799486,1,0
-female,white,26,4-year college,OH,0.542676846,1,1
-female,other,34,some college,MI,0.501176682,1,0
-male,white,71,some college,MO,0.59818561,1,0
-female,white,65,hs,OH,0.542676846,1,1
-female,other,28,hs,NY,0.382275815,2,1
-female,black,30,post-grad,CA,0.338717892,4,1
-female,white,23,some college,MA,0.353487213,2,0
-female,white,42,some college,MI,0.501176682,1,1
-male,white,54,some college,IN,0.601173095,1,0
-male,white,29,hs,MI,0.501176682,1,1
-female,black,29,some college,MI,0.501176682,1,0
-male,other,40,post-grad,WA,0.412130688,4,0
-male,black,49,some college,FL,0.506188355,3,1
-male,white,95,hs,MO,0.59818561,1,1
-female,white,34,4-year college,NY,0.382275815,2,1
-female,white,24,some college,AL,0.643741436,3,1
-male,white,50,some college,NC,0.519037458,3,1
-female,white,65,no hs,KY,0.65670629,3,0
-female,white,44,hs,NY,0.382275815,2,0
-female,other,56,hs,IA,0.550635478,1,1
-female,white,58,some college,AL,0.643741436,3,1
-male,white,53,post-grad,DE,0.440013786,3,0
-female,white,59,hs,FL,0.506188355,3,0
-male,white,30,some college,IN,0.601173095,1,0
-female,white,24,some college,MA,0.353487213,2,0
-male,white,50,hs,NV,0.487062906,4,0
-female,white,72,hs,NY,0.382275815,2,1
-female,white,33,hs,MO,0.59818561,1,1
-female,white,54,hs,FL,0.506188355,3,0
-female,other,45,hs,CT,0.428584525,2,1
-female,white,66,hs,NY,0.382275815,2,0
-female,other,30,some college,OH,0.542676846,1,1
-female,white,98,some college,NV,0.487062906,4,0
-male,white,78,hs,MD,0.359837503,3,0
-male,white,54,4-year college,MI,0.501176682,1,1
-male,white,45,4-year college,MI,0.501176682,1,1
-female,white,84,4-year college,MI,0.501176682,1,0
-female,white,50,hs,NJ,0.427158099,2,1
-female,white,24,hs,PA,0.503755358,2,0
-male,white,51,4-year college,TX,0.547132256,3,1
-male,white,36,4-year college,WI,0.50407989,1,1
-male,white,38,post-grad,MI,0.501176682,1,0
-female,other,54,hs,UT,0.623836582,4,0
-female,white,34,some college,MO,0.59818561,1,0
-male,other,46,hs,TX,0.547132256,3,1
-male,other,36,some college,NV,0.487062906,4,1
-male,white,36,4-year college,IN,0.601173095,1,1
-male,other,34,hs,TX,0.547132256,3,1
-female,white,62,some college,OK,0.693047372,3,1
-male,white,93,some college,GA,0.526611726,3,1
-female,white,85,hs,OH,0.542676846,1,1
-male,black,57,4-year college,CA,0.338717892,4,0
-female,other,55,some college,NC,0.519037458,3,0
-female,white,48,4-year college,PA,0.503755358,2,0
-female,other,48,some college,UT,0.623836582,4,0
-male,white,58,4-year college,MI,0.501176682,1,0
-female,white,77,post-grad,NY,0.382275815,2,1
-female,white,44,hs,OH,0.542676846,1,1
-female,other,18,4-year college,CA,0.338717892,4,0
-male,white,23,post-grad,MA,0.353487213,2,1
-female,white,31,post-grad,LA,0.601716772,3,1
-female,black,25,some college,IL,0.409799486,1,0
-female,white,21,some college,OH,0.542676846,1,0
-female,white,75,4-year college,OK,0.693047372,3,0
-female,white,48,hs,AL,0.643741436,3,1
-female,white,44,hs,CA,0.338717892,4,0
-male,other,24,some college,MN,0.491681431,1,0
-male,other,87,4-year college,HI,0.325586625,4,1
-male,white,91,some college,IN,0.601173095,1,0
-male,white,90,4-year college,PA,0.503755358,2,1
-female,white,79,some college,PA,0.503755358,2,1
-male,white,21,some college,PA,0.503755358,2,0
-male,other,74,post-grad,TX,0.547132256,3,1
-female,white,21,some college,TX,0.547132256,3,0
-female,black,24,some college,IL,0.409799486,1,1
-female,other,39,some college,CO,0.473166666,4,0
-male,white,19,post-grad,IN,0.601173095,1,0
-female,white,74,some college,CA,0.338717892,4,0
-female,white,56,hs,IN,0.601173095,1,0
-male,white,56,hs,TX,0.547132256,3,1
-female,white,55,4-year college,MT,0.611096643,4,0
-female,white,36,hs,IN,0.601173095,1,1
-female,other,28,some college,AZ,0.518900234,4,0
-female,white,25,hs,AR,0.642851377,3,0
-male,white,49,some college,NY,0.382275815,2,0
-female,white,39,4-year college,IL,0.409799486,1,0
-male,other,48,some college,IL,0.409799486,1,1
-male,white,99,some college,FL,0.506188355,3,0
-male,white,21,hs,MO,0.59818561,1,1
-male,white,52,some college,NC,0.519037458,3,1
-female,white,21,4-year college,PA,0.503755358,2,0
-male,white,58,post-grad,CA,0.338717892,4,1
-male,white,66,hs,VA,0.471736237,3,1
-female,white,39,some college,AR,0.642851377,3,1
-female,white,30,some college,OH,0.542676846,1,0
-male,white,32,post-grad,MI,0.501176682,1,1
-female,white,20,no hs,OH,0.542676846,1,0
-female,other,22,hs,CA,0.338717892,4,1
-male,white,55,4-year college,NY,0.382275815,2,0
-male,white,24,4-year college,KS,0.611114703,1,1
-male,white,66,post-grad,TX,0.547132256,3,1
-female,white,60,some college,NC,0.519037458,3,0
-male,other,34,4-year college,CA,0.338717892,4,1
-male,white,72,post-grad,FL,0.506188355,3,0
-male,white,45,some college,MI,0.501176682,1,0
-male,white,33,post-grad,MD,0.359837503,3,1
-female,white,28,hs,TX,0.547132256,3,1
-female,white,23,some college,WV,0.721610523,3,0
-male,other,30,4-year college,GA,0.526611726,3,0
-female,white,24,some college,MO,0.59818561,1,0
-female,white,43,hs,NY,0.382275815,2,0
-male,white,60,some college,PA,0.503755358,2,1
-male,other,27,4-year college,GA,0.526611726,3,0
-male,white,76,hs,FL,0.506188355,3,1
-female,white,55,hs,TN,0.63624343,3,1
-female,white,61,4-year college,MA,0.353487213,2,0
-male,other,31,hs,WI,0.50407989,1,1
-female,white,41,hs,TX,0.547132256,3,1
-male,white,62,4-year college,NJ,0.427158099,2,0
-female,other,52,post-grad,KS,0.611114703,1,0
-female,white,67,no hs,CA,0.338717892,4,0
-male,white,97,post-grad,VA,0.471736237,3,1
-male,white,38,4-year college,OH,0.542676846,1,0
-male,white,55,hs,OR,0.438441611,4,0
-male,white,43,post-grad,VA,0.471736237,3,0
-male,white,24,no hs,IA,0.550635478,1,0
-female,other,36,post-grad,MD,0.359837503,3,0
-male,white,59,4-year college,VA,0.471736237,3,1
-male,white,73,4-year college,CA,0.338717892,4,1
-female,white,37,hs,GA,0.526611726,3,0
-female,white,64,4-year college,NC,0.519037458,3,0
-male,white,44,some college,MO,0.59818561,1,0
-female,white,38,some college,CO,0.473166666,4,1
-female,white,58,hs,KY,0.65670629,3,0
-female,white,67,4-year college,CA,0.338717892,4,1
-female,white,34,hs,OH,0.542676846,1,0
-male,white,42,hs,OH,0.542676846,1,0
-male,white,23,some college,PA,0.503755358,2,1
-female,white,56,post-grad,NJ,0.427158099,2,0
-male,white,85,some college,KS,0.611114703,1,1
-female,other,28,some college,AZ,0.518900234,4,0
-female,other,46,post-grad,CA,0.338717892,4,0
-female,white,85,post-grad,OR,0.438441611,4,0
-male,white,67,hs,PA,0.503755358,2,1
-male,other,44,post-grad,GA,0.526611726,3,0
-male,other,32,4-year college,KY,0.65670629,3,0
-female,white,50,4-year college,CO,0.473166666,4,0
-male,white,51,some college,TN,0.63624343,3,1
-female,black,21,4-year college,NJ,0.427158099,2,0
-female,white,81,hs,TX,0.547132256,3,1
-male,white,68,hs,PA,0.503755358,2,0
-male,white,29,hs,PA,0.503755358,2,1
-female,black,36,4-year college,NJ,0.427158099,2,0
-male,white,60,hs,WI,0.50407989,1,0
-female,white,52,no hs,NY,0.382275815,2,0
-female,white,38,post-grad,NY,0.382275815,2,0
-female,white,21,4-year college,KY,0.65670629,3,0
-female,white,63,some college,AZ,0.518900234,4,0
-female,white,47,hs,AL,0.643741436,3,0
-female,black,54,some college,GA,0.526611726,3,0
+sex,race,age,edu,state,response,repvote
+male,white,38,some college,NY,0,0.382275815
+female,white,65,hs,KY,0,0.65670629
+male,white,61,hs,GA,0,0.526611726
+male,white,39,4-year college,NE,1,0.635476741
+male,white,36,some college,WI,0,0.50407989
+female,white,36,hs,WI,1,0.50407989
+male,other,85,4-year college,SC,1,0.574602564
+female,white,73,post-grad,FL,0,0.506188355
+male,white,58,4-year college,KY,0,0.65670629
+male,white,97,hs,FL,1,0.506188355
+female,black,21,hs,MA,1,0.353487213
+male,white,37,some college,NJ,0,0.427158099
+female,black,56,some college,CA,0,0.338717892
+female,other,38,hs,CA,0,0.338717892
+female,white,72,hs,IL,0,0.409799486
+female,black,30,some college,LA,1,0.601716772
+male,white,18,post-grad,TX,0,0.547132256
+male,white,67,some college,OH,1,0.542676846
+male,white,52,some college,OH,1,0.542676846
+male,white,67,post-grad,CA,1,0.338717892
+female,other,49,hs,UT,1,0.623836582
+female,white,19,4-year college,IL,0,0.409799486
+male,white,41,4-year college,MN,1,0.491681431
+male,white,36,post-grad,NY,0,0.382275815
+male,white,64,some college,AZ,1,0.518900234
+male,white,66,some college,GA,1,0.526611726
+female,other,28,some college,FL,1,0.506188355
+female,white,49,some college,IA,1,0.550635478
+female,white,59,some college,NC,0,0.519037458
+female,white,55,some college,AZ,1,0.518900234
+female,other,36,no hs,FL,0,0.506188355
+male,white,43,hs,NY,0,0.382275815
+female,other,54,post-grad,FL,0,0.506188355
+female,white,42,hs,AR,1,0.642851377
+male,white,90,post-grad,CA,0,0.338717892
+female,white,77,hs,IL,0,0.409799486
+female,white,77,some college,CA,1,0.338717892
+male,white,98,hs,VA,1,0.471736237
+female,white,53,post-grad,NH,0,0.498029716
+female,white,41,some college,IL,0,0.409799486
+male,white,59,4-year college,WA,1,0.412130688
+female,white,34,4-year college,SD,1,0.659718581
+male,white,30,post-grad,OH,0,0.542676846
+female,white,35,4-year college,NY,1,0.382275815
+female,black,56,4-year college,NC,0,0.519037458
+male,other,20,no hs,NY,0,0.382275815
+female,white,79,4-year college,AZ,0,0.518900234
+female,white,52,post-grad,NC,0,0.519037458
+female,black,26,hs,PA,0,0.503755358
+female,white,20,hs,SC,1,0.574602564
+male,white,50,4-year college,MO,1,0.59818561
+female,white,69,hs,MN,0,0.491681431
+male,white,70,some college,OK,0,0.693047372
+female,white,53,hs,PA,0,0.503755358
+female,white,57,some college,NY,0,0.382275815
+female,white,27,hs,CA,0,0.338717892
+female,white,48,some college,NC,0,0.519037458
+female,white,28,4-year college,VA,0,0.471736237
+female,white,19,hs,NY,0,0.382275815
+female,black,23,hs,SC,1,0.574602564
+male,white,88,some college,OK,1,0.693047372
+male,white,97,some college,CA,1,0.338717892
+female,white,57,hs,NJ,0,0.427158099
+female,white,26,4-year college,TN,1,0.63624343
+female,white,56,some college,FL,1,0.506188355
+male,white,50,hs,PA,0,0.503755358
+male,white,37,post-grad,MA,1,0.353487213
+female,white,91,hs,WA,0,0.412130688
+male,white,66,hs,VA,1,0.471736237
+male,white,69,4-year college,MD,0,0.359837503
+female,white,36,some college,IN,0,0.601173095
+female,white,60,hs,IN,0,0.601173095
+male,other,56,4-year college,AK,1,0.583856547
+male,white,34,hs,IL,0,0.409799486
+female,other,37,hs,AZ,1,0.518900234
+male,white,52,no hs,KY,0,0.65670629
+female,white,65,hs,CA,1,0.338717892
+female,white,48,hs,CA,0,0.338717892
+female,white,63,4-year college,NE,0,0.635476741
+male,white,46,post-grad,DE,1,0.440013786
+female,other,25,4-year college,CA,0,0.338717892
+male,white,62,hs,NC,0,0.519037458
+female,other,23,some college,WA,0,0.412130688
+male,white,44,4-year college,UT,0,0.623836582
+male,other,55,post-grad,TX,1,0.547132256
+male,other,19,some college,CA,1,0.338717892
+female,white,36,some college,FL,1,0.506188355
+female,white,54,post-grad,IL,1,0.409799486
+female,black,37,some college,IL,0,0.409799486
+male,white,33,post-grad,NY,0,0.382275815
+female,black,44,some college,CA,0,0.338717892
+female,white,38,4-year college,MO,0,0.59818561
+male,white,65,post-grad,FL,1,0.506188355
+female,white,56,hs,IL,0,0.409799486
+male,white,61,some college,IL,1,0.409799486
+female,white,60,no hs,AL,0,0.643741436
+male,white,31,some college,CA,0,0.338717892
+male,white,19,hs,IL,1,0.409799486
+female,other,78,hs,VA,1,0.471736237
+female,white,30,4-year college,FL,0,0.506188355
+male,white,18,4-year college,PA,0,0.503755358
+male,black,49,4-year college,PA,0,0.503755358
+female,white,45,hs,VA,0,0.471736237
+male,other,29,some college,WI,0,0.50407989
+female,white,30,4-year college,NJ,1,0.427158099
+male,other,41,post-grad,NJ,0,0.427158099
+female,other,30,some college,WI,0,0.50407989
+female,other,31,no hs,IL,0,0.409799486
+female,white,53,some college,GA,1,0.526611726
+female,white,68,4-year college,CT,1,0.428584525
+male,white,50,hs,MO,1,0.59818561
+female,black,42,some college,MD,0,0.359837503
+male,white,65,no hs,NY,1,0.382275815
+female,white,52,some college,FL,1,0.506188355
+female,white,91,some college,GA,1,0.526611726
+female,white,18,hs,TX,1,0.547132256
+female,white,33,post-grad,OH,1,0.542676846
+male,other,37,4-year college,FL,0,0.506188355
+female,other,26,some college,CA,0,0.338717892
+female,white,55,4-year college,AZ,0,0.518900234
+female,white,41,hs,TX,0,0.547132256
+female,other,18,some college,WA,0,0.412130688
+female,white,64,hs,MO,1,0.59818561
+female,black,100,4-year college,NY,0,0.382275815
+female,white,89,hs,WA,1,0.412130688
+female,white,24,some college,WI,0,0.50407989
+female,white,35,hs,IL,0,0.409799486
+female,white,50,hs,LA,0,0.601716772
+male,white,46,hs,NY,0,0.382275815
+female,other,23,4-year college,AZ,0,0.518900234
+male,white,62,post-grad,TX,0,0.547132256
+female,white,79,hs,KS,0,0.611114703
+female,white,18,some college,WI,0,0.50407989
+female,white,60,hs,TX,0,0.547132256
+female,white,23,some college,TN,1,0.63624343
+male,white,35,hs,SD,1,0.659718581
+female,white,98,hs,PA,0,0.503755358
+male,other,22,some college,TX,0,0.547132256
+male,white,32,some college,WV,1,0.721610523
+male,white,66,hs,IL,1,0.409799486
+male,white,86,4-year college,GA,1,0.526611726
+male,white,36,4-year college,MI,0,0.501176682
+female,white,57,some college,ME,1,0.484032089
+male,white,68,some college,PA,0,0.503755358
+female,white,60,some college,FL,0,0.506188355
+female,white,88,hs,OK,0,0.693047372
+female,white,31,post-grad,CA,0,0.338717892
+male,white,68,post-grad,VA,0,0.471736237
+female,white,20,hs,IN,0,0.601173095
+female,white,64,some college,FL,0,0.506188355
+male,white,58,hs,OK,0,0.693047372
+male,black,60,4-year college,NY,0,0.382275815
+male,white,83,post-grad,NC,0,0.519037458
+male,white,38,no hs,AR,0,0.642851377
+female,white,19,hs,MI,0,0.501176682
+female,white,26,no hs,KS,0,0.611114703
+female,other,28,some college,IN,0,0.601173095
+male,white,30,some college,TN,1,0.63624343
+female,black,39,post-grad,NJ,0,0.427158099
+male,other,29,some college,TX,1,0.547132256
+male,white,84,hs,NC,1,0.519037458
+male,white,99,post-grad,NY,1,0.382275815
+male,white,51,some college,MN,1,0.491681431
+male,white,70,4-year college,VA,1,0.471736237
+female,white,47,some college,TX,1,0.547132256
+female,white,27,4-year college,TX,0,0.547132256
+male,white,65,post-grad,KY,0,0.65670629
+male,white,54,some college,TX,1,0.547132256
+female,white,67,post-grad,VA,0,0.471736237
+female,white,64,some college,NE,1,0.635476741
+female,white,59,hs,MN,1,0.491681431
+male,white,61,4-year college,NJ,1,0.427158099
+male,white,67,some college,NC,1,0.519037458
+male,white,58,some college,DE,1,0.440013786
+female,white,51,hs,OH,0,0.542676846
+female,black,34,4-year college,OH,1,0.542676846
+female,white,95,no hs,KY,1,0.65670629
+female,white,90,some college,SC,0,0.574602564
+male,other,66,hs,NM,0,0.453492051
+male,white,85,some college,IN,0,0.601173095
+male,white,91,4-year college,WA,0,0.412130688
+female,white,18,some college,VA,0,0.471736237
+female,white,65,some college,MO,1,0.59818561
+female,white,60,some college,MI,0,0.501176682
+female,other,29,some college,SC,1,0.574602564
+male,white,29,some college,TN,0,0.63624343
+male,other,27,some college,TX,0,0.547132256
+female,other,31,4-year college,WI,1,0.50407989
+female,white,68,hs,OH,1,0.542676846
+female,other,26,some college,TX,0,0.547132256
+male,white,92,some college,FL,1,0.506188355
+male,white,54,some college,NV,1,0.487062906
+female,white,57,some college,OH,1,0.542676846
+female,white,28,4-year college,NY,1,0.382275815
+female,white,31,no hs,IN,1,0.601173095
+female,white,54,some college,NY,0,0.382275815
+male,black,44,post-grad,WA,0,0.412130688
+female,white,38,4-year college,TN,0,0.63624343
+female,white,80,post-grad,TX,0,0.547132256
+male,other,18,some college,TX,1,0.547132256
+female,other,19,4-year college,NY,0,0.382275815
+male,black,58,no hs,AZ,0,0.518900234
+female,white,30,4-year college,TX,0,0.547132256
+female,other,18,some college,TX,1,0.547132256
+female,white,24,some college,AR,1,0.642851377
+male,white,93,4-year college,CT,0,0.428584525
+female,other,27,4-year college,GA,0,0.526611726
+female,white,28,some college,OH,0,0.542676846
+male,white,64,4-year college,CA,0,0.338717892
+male,white,48,4-year college,ID,1,0.683101767
+female,white,63,4-year college,PA,1,0.503755358
+female,white,19,4-year college,PA,0,0.503755358
+female,white,22,4-year college,RI,0,0.416892959
+female,white,24,hs,OH,0,0.542676846
+female,white,56,4-year college,NC,0,0.519037458
+female,white,56,some college,OH,1,0.542676846
+male,white,57,no hs,GA,1,0.526611726
+male,white,30,4-year college,OH,1,0.542676846
+male,white,52,some college,FL,0,0.506188355
+female,black,21,some college,PA,0,0.503755358
+female,white,51,post-grad,OH,0,0.542676846
+female,white,20,some college,LA,0,0.601716772
+female,other,49,4-year college,CA,1,0.338717892
+male,white,35,post-grad,KY,0,0.65670629
+male,black,20,hs,NJ,1,0.427158099
+male,white,55,4-year college,TN,1,0.63624343
+male,black,59,hs,UT,0,0.623836582
+female,white,89,hs,TN,1,0.63624343
+female,other,39,hs,MA,0,0.353487213
+female,white,59,post-grad,GA,1,0.526611726
+female,white,65,hs,GA,1,0.526611726
+female,white,24,hs,FL,0,0.506188355
+male,white,41,hs,IL,0,0.409799486
+male,other,98,post-grad,FL,1,0.506188355
+male,white,18,hs,NJ,1,0.427158099
+male,white,27,4-year college,AZ,1,0.518900234
+female,white,69,hs,GA,1,0.526611726
+male,white,64,post-grad,WI,0,0.50407989
+male,white,43,post-grad,FL,1,0.506188355
+female,other,53,4-year college,TX,0,0.547132256
+male,white,37,4-year college,WA,1,0.412130688
+female,white,81,hs,PA,1,0.503755358
+female,white,29,some college,LA,0,0.601716772
+female,white,51,post-grad,PA,1,0.503755358
+female,other,30,4-year college,NM,0,0.453492051
+male,other,57,no hs,NY,1,0.382275815
+male,white,63,post-grad,CA,0,0.338717892
+female,white,69,hs,CT,0,0.428584525
+male,white,65,hs,MI,1,0.501176682
+female,black,33,4-year college,OH,1,0.542676846
+female,white,66,post-grad,CA,0,0.338717892
+female,other,35,some college,FL,0,0.506188355
+female,white,43,hs,OH,0,0.542676846
+male,white,56,post-grad,NJ,1,0.427158099
+female,white,100,hs,FL,1,0.506188355
+male,white,53,4-year college,VA,0,0.471736237
+female,white,40,some college,TN,1,0.63624343
+female,other,27,hs,CA,0,0.338717892
+female,white,51,hs,OH,1,0.542676846
+female,white,51,no hs,IA,0,0.550635478
+male,white,57,no hs,TN,0,0.63624343
+female,white,30,hs,CA,1,0.338717892
+male,white,45,post-grad,KY,0,0.65670629
+female,white,63,4-year college,WY,1,0.757053196
+female,white,25,hs,KY,1,0.65670629
+female,white,21,hs,WV,0,0.721610523
+female,white,62,hs,IA,0,0.550635478
+male,white,32,hs,CA,1,0.338717892
+female,white,23,hs,PA,1,0.503755358
+male,white,53,some college,VA,0,0.471736237
+male,white,18,4-year college,IA,0,0.550635478
+male,white,42,hs,NC,0,0.519037458
+male,white,59,some college,CA,1,0.338717892
+male,black,38,some college,NV,1,0.487062906
+female,white,45,hs,AZ,1,0.518900234
+male,white,42,4-year college,CA,0,0.338717892
+male,white,46,hs,PA,1,0.503755358
+female,white,35,hs,KS,1,0.611114703
+female,white,19,some college,NY,0,0.382275815
+male,other,21,4-year college,OR,0,0.438441611
+male,white,41,some college,TN,0,0.63624343
+female,white,77,hs,MO,0,0.59818561
+male,white,46,some college,TX,0,0.547132256
+female,white,65,hs,NV,1,0.487062906
+male,white,79,4-year college,FL,1,0.506188355
+female,black,33,some college,GA,1,0.526611726
+female,white,28,some college,CA,1,0.338717892
+female,white,79,hs,MN,1,0.491681431
+male,black,23,some college,MO,0,0.59818561
+male,white,33,post-grad,MO,0,0.59818561
+male,white,28,4-year college,NC,0,0.519037458
+female,black,22,some college,FL,0,0.506188355
+female,white,25,hs,NC,1,0.519037458
+female,white,61,hs,GA,0,0.526611726
+female,black,54,some college,CA,1,0.338717892
+male,other,26,no hs,AZ,0,0.518900234
+female,white,63,hs,NC,0,0.519037458
+female,white,18,some college,MO,1,0.59818561
+male,white,35,4-year college,AL,0,0.643741436
+female,white,64,hs,MO,0,0.59818561
+female,white,69,4-year college,WA,0,0.412130688
+male,black,52,4-year college,FL,0,0.506188355
+male,white,64,4-year college,CA,0,0.338717892
+female,white,49,no hs,AL,1,0.643741436
+male,white,69,4-year college,WA,0,0.412130688
+male,white,29,hs,CA,0,0.338717892
+female,white,29,4-year college,NY,1,0.382275815
+female,white,49,some college,CO,0,0.473166666
+female,white,25,4-year college,PA,0,0.503755358
+female,white,21,post-grad,CA,0,0.338717892
+female,black,36,post-grad,NC,0,0.519037458
+male,white,36,4-year college,PA,1,0.503755358
+female,black,64,hs,KY,0,0.65670629
+male,white,53,some college,IL,1,0.409799486
+female,white,26,4-year college,IN,0,0.601173095
+female,white,52,post-grad,TX,1,0.547132256
+male,black,18,some college,NC,0,0.519037458
+male,white,78,hs,CA,0,0.338717892
+female,white,24,4-year college,NY,1,0.382275815
+female,white,54,hs,IN,0,0.601173095
+female,white,62,4-year college,AZ,0,0.518900234
+female,white,88,some college,CA,0,0.338717892
+female,white,42,4-year college,MO,1,0.59818561
+male,black,66,some college,LA,1,0.601716772
+female,white,57,hs,WA,1,0.412130688
+female,black,45,post-grad,CT,0,0.428584525
+male,other,47,some college,MI,0,0.501176682
+female,white,23,hs,AL,0,0.643741436
+female,black,24,some college,GA,0,0.526611726
+male,other,20,post-grad,IL,1,0.409799486
+male,black,30,some college,CA,0,0.338717892
+male,black,55,hs,NY,0,0.382275815
+female,white,64,4-year college,NJ,0,0.427158099
+male,white,47,some college,NJ,0,0.427158099
+male,other,20,4-year college,MI,0,0.501176682
+male,white,36,post-grad,NY,1,0.382275815
+male,white,35,4-year college,MN,0,0.491681431
+male,white,94,post-grad,WA,0,0.412130688
+female,white,57,hs,OH,1,0.542676846
+male,white,31,some college,CA,1,0.338717892
+female,white,19,hs,CA,1,0.338717892
+female,white,50,hs,AZ,0,0.518900234
+female,white,30,hs,WI,0,0.50407989
+female,other,24,no hs,MA,0,0.353487213
+female,white,94,hs,FL,1,0.506188355
+female,white,68,some college,PA,1,0.503755358
+female,white,29,some college,UT,1,0.623836582
+female,white,20,4-year college,VA,1,0.471736237
+male,other,51,4-year college,CA,0,0.338717892
+male,white,30,some college,PA,0,0.503755358
+male,white,93,post-grad,TN,1,0.63624343
+female,white,18,4-year college,IL,0,0.409799486
+female,white,66,4-year college,MA,0,0.353487213
+male,white,29,some college,IN,0,0.601173095
+female,black,39,no hs,GA,0,0.526611726
+female,white,51,hs,MN,0,0.491681431
+male,white,67,4-year college,FL,1,0.506188355
+female,white,34,some college,AL,1,0.643741436
+female,white,65,4-year college,CA,0,0.338717892
+female,black,52,some college,CA,1,0.338717892
+male,white,65,hs,WV,1,0.721610523
+male,white,75,post-grad,TX,1,0.547132256
+female,white,67,hs,NY,0,0.382275815
+female,white,28,some college,NY,0,0.382275815
+female,white,44,post-grad,GA,0,0.526611726
+female,other,29,4-year college,FL,1,0.506188355
+female,black,94,post-grad,NY,0,0.382275815
+male,white,67,4-year college,NV,1,0.487062906
+female,white,28,post-grad,CA,1,0.338717892
+female,white,67,hs,HI,1,0.325586625
+male,white,19,post-grad,KY,0,0.65670629
+female,white,42,some college,MI,0,0.501176682
+female,white,62,some college,CA,1,0.338717892
+male,white,52,4-year college,OH,0,0.542676846
+male,white,68,some college,CA,0,0.338717892
+male,white,39,post-grad,MA,0,0.353487213
+female,other,20,some college,WA,0,0.412130688
+female,white,50,some college,WI,0,0.50407989
+female,white,64,hs,PA,0,0.503755358
+female,black,41,4-year college,KS,0,0.611114703
+male,black,23,hs,NC,1,0.519037458
+male,white,30,hs,TX,1,0.547132256
+female,white,26,some college,IN,1,0.601173095
+female,white,60,4-year college,NC,0,0.519037458
+female,black,57,post-grad,NY,0,0.382275815
+male,white,51,post-grad,PA,0,0.503755358
+male,other,68,some college,FL,1,0.506188355
+male,white,28,hs,NY,0,0.382275815
+male,black,43,some college,GA,0,0.526611726
+female,white,62,no hs,CA,0,0.338717892
+female,other,28,some college,MN,0,0.491681431
+female,white,30,some college,MI,0,0.501176682
+female,black,60,hs,NC,0,0.519037458
+female,white,43,some college,OH,1,0.542676846
+female,white,62,some college,NC,0,0.519037458
+male,white,65,4-year college,UT,0,0.623836582
+female,white,36,post-grad,WA,0,0.412130688
+female,white,18,hs,PA,0,0.503755358
+female,white,22,4-year college,PA,0,0.503755358
+female,other,38,4-year college,CA,1,0.338717892
+male,white,38,4-year college,PA,1,0.503755358
+female,white,27,some college,MA,0,0.353487213
+male,white,56,hs,NV,0,0.487062906
+male,white,56,some college,CT,0,0.428584525
+female,white,26,4-year college,NY,0,0.382275815
+male,white,22,4-year college,MO,1,0.59818561
+female,white,65,4-year college,GA,0,0.526611726
+male,white,25,hs,WA,0,0.412130688
+female,white,19,no hs,IL,0,0.409799486
+female,white,94,4-year college,FL,1,0.506188355
+female,black,33,some college,FL,0,0.506188355
+female,other,67,hs,FL,1,0.506188355
+female,white,69,hs,MN,0,0.491681431
+female,other,39,hs,CA,0,0.338717892
+female,white,22,4-year college,MI,1,0.501176682
+female,white,56,post-grad,IL,0,0.409799486
+female,white,69,4-year college,NM,0,0.453492051
+male,other,32,some college,WA,0,0.412130688
+male,white,53,4-year college,MD,0,0.359837503
+female,black,19,no hs,CA,1,0.338717892
+female,white,71,hs,CA,0,0.338717892
+male,white,91,post-grad,NV,1,0.487062906
+male,white,49,post-grad,FL,0,0.506188355
+female,white,62,hs,MT,0,0.611096643
+female,other,52,hs,TX,0,0.547132256
+male,white,100,hs,VA,0,0.471736237
+male,white,82,some college,TN,1,0.63624343
+female,white,23,4-year college,WI,0,0.50407989
+female,white,62,some college,CT,0,0.428584525
+female,white,30,4-year college,OR,0,0.438441611
+male,white,18,hs,NJ,0,0.427158099
+male,white,46,hs,MO,0,0.59818561
+female,white,51,post-grad,PA,0,0.503755358
+male,white,56,4-year college,ID,0,0.683101767
+male,white,62,post-grad,IN,1,0.601173095
+male,white,20,some college,MD,0,0.359837503
+female,white,28,hs,PA,1,0.503755358
+female,white,89,some college,PA,0,0.503755358
+male,white,98,no hs,FL,1,0.506188355
+female,white,86,hs,WV,0,0.721610523
+female,other,33,4-year college,GA,1,0.526611726
+male,other,37,post-grad,CA,1,0.338717892
+male,other,68,post-grad,TX,1,0.547132256
+female,white,23,hs,TN,0,0.63624343
+female,white,43,no hs,KY,0,0.65670629
+female,white,96,some college,PA,0,0.503755358
+female,white,82,post-grad,MA,0,0.353487213
+male,other,45,some college,CA,1,0.338717892
+male,white,66,hs,TN,0,0.63624343
+female,white,31,some college,PA,1,0.503755358
+female,white,74,some college,AR,0,0.642851377
+male,white,34,some college,NC,0,0.519037458
+male,other,47,4-year college,CA,1,0.338717892
+male,white,64,4-year college,FL,1,0.506188355
+male,white,56,hs,FL,0,0.506188355
+female,other,25,4-year college,WI,0,0.50407989
+female,white,27,some college,LA,0,0.601716772
+male,white,55,hs,FL,0,0.506188355
+female,white,39,4-year college,PA,0,0.503755358
+female,white,20,some college,TX,0,0.547132256
+female,white,88,hs,TX,0,0.547132256
+male,white,98,post-grad,IA,0,0.550635478
+female,other,44,some college,CA,1,0.338717892
+female,white,49,hs,NJ,1,0.427158099
+female,white,28,hs,GA,1,0.526611726
+male,white,57,hs,PA,0,0.503755358
+male,white,69,some college,AZ,1,0.518900234
+female,white,46,some college,MT,1,0.611096643
+female,white,30,4-year college,WI,0,0.50407989
+male,white,87,hs,NY,0,0.382275815
+female,white,31,hs,TX,1,0.547132256
+male,white,94,4-year college,TX,1,0.547132256
+male,white,69,hs,GA,1,0.526611726
+female,white,27,4-year college,IL,0,0.409799486
+male,white,37,post-grad,MI,0,0.501176682
+female,white,22,4-year college,AR,0,0.642851377
+female,white,78,some college,AL,0,0.643741436
+male,white,67,4-year college,TX,1,0.547132256
+female,white,62,hs,WI,0,0.50407989
+female,other,46,4-year college,UT,1,0.623836582
+male,white,45,some college,NJ,1,0.427158099
+male,white,35,some college,PA,0,0.503755358
+female,other,28,4-year college,RI,0,0.416892959
+female,other,52,hs,CA,0,0.338717892
+female,other,29,4-year college,CA,0,0.338717892
+female,white,65,hs,MN,1,0.491681431
+female,black,49,4-year college,MD,1,0.359837503
+male,white,28,some college,NC,1,0.519037458
+female,white,32,hs,CA,0,0.338717892
+female,white,70,hs,RI,1,0.416892959
+male,white,50,some college,LA,1,0.601716772
+female,white,69,post-grad,SC,1,0.574602564
+female,white,64,hs,IA,0,0.550635478
+female,white,75,hs,WA,0,0.412130688
+male,black,65,some college,GA,0,0.526611726
+female,other,33,some college,CA,0,0.338717892
+female,white,29,some college,NJ,0,0.427158099
+female,white,62,hs,PA,1,0.503755358
+female,white,58,4-year college,NJ,0,0.427158099
+male,white,54,hs,SD,0,0.659718581
+male,white,39,post-grad,NJ,0,0.427158099
+female,black,38,hs,GA,1,0.526611726
+female,white,52,some college,PA,1,0.503755358
+male,other,58,4-year college,TX,1,0.547132256
+female,other,27,4-year college,FL,0,0.506188355
+male,other,62,hs,VA,1,0.471736237
+female,white,54,no hs,CA,1,0.338717892
+female,other,27,4-year college,MI,0,0.501176682
+female,white,53,some college,OK,1,0.693047372
+female,white,44,hs,IL,1,0.409799486
+female,white,39,4-year college,CT,0,0.428584525
+female,white,84,no hs,MA,1,0.353487213
+female,white,29,4-year college,WV,1,0.721610523
+male,white,42,4-year college,OK,0,0.693047372
+female,white,28,some college,IL,1,0.409799486
+female,other,40,some college,NY,0,0.382275815
+female,white,21,hs,OK,1,0.693047372
+female,other,21,4-year college,CA,0,0.338717892
+male,white,52,4-year college,CO,1,0.473166666
+male,other,35,4-year college,CA,0,0.338717892
+male,white,58,some college,SC,1,0.574602564
+female,white,62,some college,PA,0,0.503755358
+male,other,18,some college,CA,1,0.338717892
+male,white,46,4-year college,NJ,0,0.427158099
+male,white,83,post-grad,CT,0,0.428584525
+female,white,37,some college,TX,0,0.547132256
+female,white,53,4-year college,NC,1,0.519037458
+male,white,52,some college,TX,1,0.547132256
+male,black,49,some college,NY,0,0.382275815
+male,white,57,4-year college,VA,1,0.471736237
+male,other,48,hs,WA,0,0.412130688
+female,black,34,no hs,KS,1,0.611114703
+female,white,55,post-grad,DE,1,0.440013786
+female,white,26,some college,FL,0,0.506188355
+female,white,25,post-grad,CO,0,0.473166666
+male,black,58,4-year college,CO,0,0.473166666
+female,white,72,some college,AL,1,0.643741436
+female,white,58,4-year college,LA,1,0.601716772
+female,white,91,4-year college,FL,0,0.506188355
+female,other,29,hs,TX,0,0.547132256
+female,white,58,hs,CA,1,0.338717892
+female,white,62,no hs,WV,0,0.721610523
+female,white,56,some college,FL,1,0.506188355
+male,white,69,some college,OH,0,0.542676846
+female,other,39,4-year college,CA,0,0.338717892
+female,white,90,hs,GA,1,0.526611726
+female,white,85,post-grad,NC,0,0.519037458
+female,white,54,4-year college,WI,1,0.50407989
+female,white,24,some college,TX,0,0.547132256
+male,black,68,hs,KY,0,0.65670629
+female,white,36,4-year college,VA,0,0.471736237
+male,other,44,post-grad,NJ,1,0.427158099
+male,white,52,post-grad,IN,0,0.601173095
+male,white,64,4-year college,VA,1,0.471736237
+female,white,31,4-year college,LA,1,0.601716772
+male,white,40,post-grad,MD,0,0.359837503
+female,white,77,no hs,IA,1,0.550635478
+female,white,59,some college,GA,1,0.526611726
+male,white,63,4-year college,FL,0,0.506188355
+female,white,64,some college,VA,0,0.471736237
+male,white,20,hs,GA,1,0.526611726
+male,white,96,4-year college,MI,0,0.501176682
+female,black,52,some college,OK,0,0.693047372
+male,white,63,4-year college,CO,0,0.473166666
+male,white,87,post-grad,AL,1,0.643741436
+female,black,53,some college,PA,1,0.503755358
+female,white,18,some college,FL,1,0.506188355
+male,white,47,some college,AL,1,0.643741436
+male,white,40,some college,NC,0,0.519037458
+female,white,92,some college,TX,0,0.547132256
+female,white,34,post-grad,MO,1,0.59818561
+female,white,55,4-year college,GA,1,0.526611726
+female,white,65,post-grad,MD,1,0.359837503
+female,other,36,no hs,GA,1,0.526611726
+male,white,93,post-grad,IN,1,0.601173095
+female,white,42,some college,TN,1,0.63624343
+female,white,32,some college,AZ,0,0.518900234
+female,black,58,some college,PA,0,0.503755358
+female,white,50,post-grad,IN,0,0.601173095
+female,other,21,hs,FL,1,0.506188355
+male,white,39,post-grad,VA,0,0.471736237
+female,black,34,some college,IN,0,0.601173095
+male,white,50,some college,UT,0,0.623836582
+female,white,57,hs,CA,1,0.338717892
+female,white,24,hs,MD,0,0.359837503
+female,white,59,4-year college,IN,0,0.601173095
+female,white,66,post-grad,CA,0,0.338717892
+female,white,51,post-grad,NJ,1,0.427158099
+female,white,42,some college,IN,0,0.601173095
+female,other,28,some college,NV,1,0.487062906
+male,white,57,post-grad,TN,1,0.63624343
+male,white,62,hs,MA,1,0.353487213
+female,white,81,post-grad,FL,0,0.506188355
+male,white,34,post-grad,FL,1,0.506188355
+male,white,59,post-grad,TX,0,0.547132256
+female,white,89,post-grad,MO,0,0.59818561
+female,black,64,hs,VA,1,0.471736237
+female,white,25,4-year college,IN,1,0.601173095
+female,white,52,post-grad,NY,0,0.382275815
+female,white,21,4-year college,OH,0,0.542676846
+male,white,52,4-year college,SC,0,0.574602564
+female,white,80,hs,KS,0,0.611114703
+female,white,60,hs,CO,0,0.473166666
+female,black,30,some college,CA,0,0.338717892
+female,white,57,some college,TX,1,0.547132256
+male,white,62,post-grad,WA,0,0.412130688
+male,white,37,4-year college,MD,1,0.359837503
+female,other,34,4-year college,FL,1,0.506188355
+male,white,61,4-year college,AZ,0,0.518900234
+female,white,24,some college,AL,0,0.643741436
+female,other,22,some college,MN,0,0.491681431
+female,white,22,post-grad,PA,1,0.503755358
+male,white,72,some college,CA,0,0.338717892
+male,white,22,some college,UT,0,0.623836582
+female,black,19,hs,TX,0,0.547132256
+male,white,47,4-year college,NJ,0,0.427158099
+female,white,65,some college,KY,1,0.65670629
+male,white,21,4-year college,NY,1,0.382275815
+female,white,61,some college,MI,0,0.501176682
+female,white,58,4-year college,TX,0,0.547132256
+female,black,36,4-year college,NC,0,0.519037458
+female,white,31,some college,ME,0,0.484032089
+male,white,85,4-year college,TX,1,0.547132256
+female,other,37,some college,MO,0,0.59818561
+male,black,68,some college,CA,0,0.338717892
+female,white,32,post-grad,VA,0,0.471736237
+female,white,60,hs,NC,1,0.519037458
+female,black,28,some college,LA,0,0.601716772
+male,white,19,hs,TX,0,0.547132256
+female,white,73,hs,MS,1,0.590898473
+male,white,67,some college,KS,0,0.611114703
+male,white,44,some college,ID,1,0.683101767
+female,black,53,4-year college,MS,0,0.590898473
+female,white,66,some college,TX,1,0.547132256
+male,white,32,some college,OH,1,0.542676846
+male,other,26,some college,NY,1,0.382275815
+male,white,38,hs,PA,1,0.503755358
+female,white,61,some college,WA,1,0.412130688
+male,white,74,4-year college,TX,0,0.547132256
+female,other,23,hs,GA,1,0.526611726
+male,white,26,some college,OH,0,0.542676846
+female,white,28,some college,GA,0,0.526611726
+male,white,53,hs,OH,1,0.542676846
+male,white,60,hs,WI,0,0.50407989
+female,white,40,some college,MI,1,0.501176682
+female,white,25,hs,MO,0,0.59818561
+female,white,66,some college,CA,1,0.338717892
+male,white,23,hs,MI,0,0.501176682
+female,white,56,4-year college,TX,1,0.547132256
+male,white,66,hs,CA,1,0.338717892
+male,white,70,some college,MD,1,0.359837503
+female,white,30,4-year college,NJ,0,0.427158099
+female,white,30,no hs,NH,0,0.498029716
+female,other,20,some college,MA,1,0.353487213
+female,white,59,some college,ME,0,0.484032089
+male,white,30,some college,CA,0,0.338717892
+male,other,36,4-year college,LA,0,0.601716772
+male,white,37,4-year college,CA,1,0.338717892
+female,white,31,some college,CA,1,0.338717892
+male,other,48,some college,TX,0,0.547132256
+male,white,36,some college,IN,0,0.601173095
+female,black,24,4-year college,TX,1,0.547132256
+male,white,64,hs,FL,0,0.506188355
+male,white,66,some college,TX,1,0.547132256
+female,black,56,post-grad,AL,0,0.643741436
+male,white,22,post-grad,NH,1,0.498029716
+male,white,68,4-year college,GA,1,0.526611726
+female,white,88,hs,NY,1,0.382275815
+male,other,30,some college,CA,0,0.338717892
+male,white,51,post-grad,NC,1,0.519037458
+male,white,52,some college,MN,1,0.491681431
+female,white,47,some college,CT,0,0.428584525
+female,white,93,hs,AZ,0,0.518900234
+male,white,37,some college,IN,0,0.601173095
+male,black,41,some college,NJ,1,0.427158099
+male,white,58,some college,MD,0,0.359837503
+male,other,26,some college,GA,0,0.526611726
+male,white,61,4-year college,TX,0,0.547132256
+female,white,27,hs,MI,0,0.501176682
+female,white,61,hs,IN,1,0.601173095
+female,white,56,some college,MI,0,0.501176682
+male,white,38,hs,KS,0,0.611114703
+male,other,72,4-year college,IN,1,0.601173095
+female,white,100,some college,GA,1,0.526611726
+male,white,35,some college,OH,0,0.542676846
+male,black,38,4-year college,NV,0,0.487062906
+male,black,37,some college,CA,1,0.338717892
+female,white,67,hs,IL,1,0.409799486
+female,white,42,some college,WA,0,0.412130688
+female,white,87,some college,MN,1,0.491681431
+female,white,48,4-year college,TX,1,0.547132256
+female,white,60,hs,MI,1,0.501176682
+female,other,21,hs,CA,0,0.338717892
+female,white,58,hs,FL,1,0.506188355
+female,white,63,4-year college,CA,0,0.338717892
+male,white,43,4-year college,IN,0,0.601173095
+female,white,38,post-grad,VT,0,0.348135737
+male,black,30,4-year college,IL,0,0.409799486
+female,white,19,some college,MS,1,0.590898473
+female,white,23,hs,NC,0,0.519037458
+male,white,88,4-year college,ID,1,0.683101767
+female,black,43,some college,MD,1,0.359837503
+female,white,66,some college,HI,1,0.325586625
+female,white,57,4-year college,AZ,0,0.518900234
+male,white,31,hs,WA,0,0.412130688
+female,other,52,some college,CA,0,0.338717892
+female,white,35,hs,NY,1,0.382275815
+male,white,41,some college,FL,1,0.506188355
+female,white,59,hs,MO,1,0.59818561
+female,white,21,no hs,TX,1,0.547132256
+male,black,69,4-year college,CA,0,0.338717892
+male,white,48,some college,IL,0,0.409799486
+female,white,65,post-grad,MA,0,0.353487213
+male,black,25,some college,GA,1,0.526611726
+female,white,40,some college,TX,0,0.547132256
+male,white,53,post-grad,CA,1,0.338717892
+male,black,37,some college,AR,1,0.642851377
+female,white,94,hs,NJ,1,0.427158099
+female,other,53,some college,WV,0,0.721610523
+female,white,63,some college,LA,1,0.601716772
+female,white,51,post-grad,TN,0,0.63624343
+female,black,69,no hs,TN,1,0.63624343
+male,white,37,4-year college,OR,1,0.438441611
+male,white,99,4-year college,MT,1,0.611096643
+female,other,29,some college,NC,1,0.519037458
+male,other,43,4-year college,WI,0,0.50407989
+female,black,34,post-grad,FL,0,0.506188355
+male,white,68,hs,NE,1,0.635476741
+male,black,54,hs,CA,0,0.338717892
+female,white,52,hs,MA,0,0.353487213
+female,white,64,some college,AZ,1,0.518900234
+male,white,76,no hs,TX,1,0.547132256
+female,white,56,some college,AR,0,0.642851377
+female,white,25,some college,TN,1,0.63624343
+female,other,24,hs,TN,0,0.63624343
+female,other,49,4-year college,GA,0,0.526611726
+male,white,49,4-year college,PA,1,0.503755358
+female,black,53,post-grad,SC,1,0.574602564
+female,white,21,4-year college,MN,1,0.491681431
+male,white,65,post-grad,PA,0,0.503755358
+female,other,59,some college,KY,1,0.65670629
+male,white,27,some college,FL,1,0.506188355
+male,white,45,post-grad,IN,0,0.601173095
+female,white,61,hs,AR,1,0.642851377
+female,white,88,hs,NC,1,0.519037458
+male,white,34,post-grad,NJ,0,0.427158099
+female,white,27,4-year college,IL,0,0.409799486
+male,other,20,some college,FL,1,0.506188355
+female,white,40,hs,FL,1,0.506188355
+male,white,70,post-grad,MI,1,0.501176682
+female,white,43,hs,NY,0,0.382275815
+male,white,31,post-grad,PA,1,0.503755358
+female,white,68,hs,VA,1,0.471736237
+female,white,29,some college,TX,0,0.547132256
+female,other,24,4-year college,CA,1,0.338717892
+female,other,30,some college,WA,0,0.412130688
+female,black,57,some college,IN,0,0.601173095
+female,white,59,some college,FL,0,0.506188355
+male,white,57,4-year college,CA,1,0.338717892
+female,other,61,some college,NJ,0,0.427158099
+female,black,57,some college,NY,0,0.382275815
+female,white,19,4-year college,OH,0,0.542676846
+male,white,89,some college,MD,1,0.359837503
+male,white,48,some college,IN,0,0.601173095
+female,white,37,4-year college,AL,0,0.643741436
+female,other,26,4-year college,NY,1,0.382275815
+female,other,40,hs,NY,0,0.382275815
+female,white,45,4-year college,MN,1,0.491681431
+female,white,18,hs,SC,0,0.574602564
+female,white,66,post-grad,IL,0,0.409799486
+male,white,48,4-year college,FL,0,0.506188355
+female,white,37,hs,KY,1,0.65670629
+female,white,64,4-year college,CA,0,0.338717892
+male,white,67,4-year college,WY,0,0.757053196
+female,white,62,some college,PA,0,0.503755358
+male,white,64,4-year college,TX,1,0.547132256
+male,white,39,4-year college,NY,1,0.382275815
+female,black,49,hs,AL,1,0.643741436
+male,other,32,post-grad,NC,0,0.519037458
+female,white,76,hs,WI,1,0.50407989
+female,other,35,4-year college,IL,0,0.409799486
+male,white,74,4-year college,UT,1,0.623836582
+female,white,24,hs,ME,1,0.484032089
+female,other,26,hs,CA,1,0.338717892
+female,white,19,some college,HI,0,0.325586625
+male,white,58,hs,MO,0,0.59818561
+female,white,57,4-year college,OH,0,0.542676846
+female,white,38,post-grad,NY,1,0.382275815
+female,white,44,4-year college,MI,1,0.501176682
+male,white,72,hs,PA,1,0.503755358
+female,white,32,4-year college,GA,0,0.526611726
+female,white,29,4-year college,NY,0,0.382275815
+female,white,53,4-year college,IL,1,0.409799486
+female,black,45,4-year college,NE,1,0.635476741
+female,white,45,hs,NM,0,0.453492051
+female,black,30,some college,TX,0,0.547132256
+female,white,64,4-year college,MI,1,0.501176682
+female,other,60,hs,PA,1,0.503755358
+male,white,76,post-grad,CA,0,0.338717892
+male,white,57,post-grad,TX,0,0.547132256
+female,white,67,post-grad,CT,0,0.428584525
+female,white,53,some college,MO,1,0.59818561
+female,white,28,some college,UT,1,0.623836582
+male,other,31,4-year college,NY,0,0.382275815
+male,white,41,hs,WI,1,0.50407989
+female,white,52,4-year college,FL,1,0.506188355
+male,white,32,hs,IL,1,0.409799486
+female,white,51,post-grad,NJ,1,0.427158099
+male,white,56,some college,NV,1,0.487062906
+male,white,42,some college,MD,1,0.359837503
+male,white,41,4-year college,OR,0,0.438441611
+female,white,81,hs,NY,0,0.382275815
+female,black,52,some college,WV,0,0.721610523
+female,white,34,hs,GA,1,0.526611726
+female,white,20,some college,IN,1,0.601173095
+female,white,80,hs,WA,1,0.412130688
+female,white,37,some college,MI,0,0.501176682
+female,white,57,no hs,IL,1,0.409799486
+female,black,36,hs,LA,1,0.601716772
+female,white,23,hs,AL,0,0.643741436
+female,other,25,some college,CA,0,0.338717892
+female,white,63,hs,FL,1,0.506188355
+female,white,68,hs,OK,1,0.693047372
+male,white,32,4-year college,OH,1,0.542676846
+female,white,62,some college,OR,1,0.438441611
+female,white,65,hs,PA,1,0.503755358
+female,black,20,some college,CA,1,0.338717892
+female,white,46,4-year college,WY,1,0.757053196
+female,white,27,hs,IN,1,0.601173095
+male,black,55,some college,MO,0,0.59818561
+female,white,25,some college,MI,1,0.501176682
+male,white,43,hs,CO,1,0.473166666
+male,white,74,post-grad,NY,0,0.382275815
+male,other,37,4-year college,KY,0,0.65670629
+female,white,21,some college,NY,0,0.382275815
+male,white,38,4-year college,TN,1,0.63624343
+female,white,63,post-grad,KY,0,0.65670629
+male,white,37,no hs,PA,1,0.503755358
+male,white,84,4-year college,AZ,0,0.518900234
+male,white,30,4-year college,UT,0,0.623836582
+female,white,48,hs,OK,1,0.693047372
+female,black,39,some college,IL,0,0.409799486
+female,white,46,hs,WV,1,0.721610523
+female,other,21,some college,TX,0,0.547132256
+male,white,29,some college,FL,0,0.506188355
+male,white,72,4-year college,AL,1,0.643741436
+female,white,55,4-year college,CA,0,0.338717892
+male,other,94,some college,MN,1,0.491681431
+female,other,22,some college,IL,0,0.409799486
+male,white,38,4-year college,MD,1,0.359837503
+female,white,23,some college,WI,0,0.50407989
+female,white,18,some college,TN,1,0.63624343
+female,white,48,4-year college,NM,0,0.453492051
+male,black,53,hs,CA,0,0.338717892
+female,white,32,4-year college,NY,0,0.382275815
+female,black,53,4-year college,CO,0,0.473166666
+female,white,63,4-year college,MI,0,0.501176682
+female,white,61,hs,WA,0,0.412130688
+female,white,52,4-year college,FL,1,0.506188355
+male,white,78,4-year college,AR,1,0.642851377
+male,white,100,hs,TX,1,0.547132256
+female,white,42,some college,KS,0,0.611114703
+male,white,53,some college,MI,1,0.501176682
+female,black,45,4-year college,VA,0,0.471736237
+female,other,20,4-year college,OR,0,0.438441611
+female,white,53,some college,WI,1,0.50407989
+male,white,69,hs,GA,0,0.526611726
+female,white,51,4-year college,OK,0,0.693047372
+male,white,51,4-year college,OH,0,0.542676846
+male,white,53,4-year college,MA,0,0.353487213
+male,other,42,some college,TN,0,0.63624343
+male,black,43,4-year college,UT,0,0.623836582
+male,black,42,some college,TN,0,0.63624343
+male,white,50,4-year college,GA,0,0.526611726
+female,white,83,some college,OK,1,0.693047372
+male,other,18,hs,TX,0,0.547132256
+female,white,31,4-year college,CO,1,0.473166666
+female,white,86,some college,HI,0,0.325586625
+male,other,33,4-year college,PA,0,0.503755358
+female,white,20,4-year college,IL,0,0.409799486
+male,white,29,hs,OK,0,0.693047372
+female,white,65,post-grad,MA,0,0.353487213
+male,white,31,hs,ND,1,0.698092429
+female,white,42,4-year college,NE,1,0.635476741
+male,white,52,hs,TN,1,0.63624343
+female,black,35,hs,MS,0,0.590898473
+female,white,90,some college,KY,1,0.65670629
+male,white,44,post-grad,WA,0,0.412130688
+male,other,38,some college,CA,0,0.338717892
+male,white,39,4-year college,FL,0,0.506188355
+female,white,99,hs,TX,0,0.547132256
+female,white,26,some college,AR,1,0.642851377
+female,white,39,hs,OH,0,0.542676846
+male,other,58,hs,TX,0,0.547132256
+male,other,33,some college,WA,1,0.412130688
+female,black,55,some college,CA,0,0.338717892
+female,white,38,some college,CA,0,0.338717892
+female,black,38,no hs,MO,0,0.59818561
+female,white,35,hs,NC,1,0.519037458
+male,black,68,some college,NC,0,0.519037458
+male,white,30,post-grad,VA,0,0.471736237
+male,white,30,post-grad,FL,0,0.506188355
+female,other,24,4-year college,TX,0,0.547132256
+male,other,40,some college,WV,1,0.721610523
+female,white,86,some college,NC,1,0.519037458
+male,white,52,some college,MO,0,0.59818561
+male,other,56,4-year college,MO,1,0.59818561
+female,white,22,some college,NC,0,0.519037458
+male,white,59,some college,TX,1,0.547132256
+male,white,78,hs,PA,0,0.503755358
+female,other,21,no hs,TX,1,0.547132256
+female,black,85,some college,AR,0,0.642851377
+male,white,38,4-year college,NY,1,0.382275815
+female,other,75,4-year college,AZ,1,0.518900234
+female,white,53,some college,FL,1,0.506188355
+female,white,68,some college,GA,1,0.526611726
+male,other,32,some college,CA,1,0.338717892
+female,other,48,some college,CA,1,0.338717892
+male,white,37,some college,FL,0,0.506188355
+female,other,32,some college,CA,1,0.338717892
+female,white,74,hs,NY,1,0.382275815
+female,white,53,hs,ME,0,0.484032089
+female,white,65,hs,OH,0,0.542676846
+female,white,43,some college,IL,1,0.409799486
+female,white,58,post-grad,OH,0,0.542676846
+female,white,75,4-year college,AZ,1,0.518900234
+female,white,99,4-year college,IN,1,0.601173095
+male,white,91,some college,MA,1,0.353487213
+male,white,53,hs,NY,0,0.382275815
+female,white,62,hs,MA,1,0.353487213
+female,other,29,hs,ID,0,0.683101767
+male,white,56,hs,TN,1,0.63624343
+male,white,29,4-year college,AL,1,0.643741436
+male,white,43,hs,IL,1,0.409799486
+female,white,47,some college,PA,0,0.503755358
+female,white,54,some college,AZ,0,0.518900234
+male,white,25,post-grad,NY,0,0.382275815
+female,white,28,4-year college,MO,1,0.59818561
+male,white,55,hs,NC,0,0.519037458
+male,white,40,post-grad,IL,0,0.409799486
+male,other,41,4-year college,TX,0,0.547132256
+male,white,70,hs,IA,0,0.550635478
+male,white,50,4-year college,IN,0,0.601173095
+male,white,47,4-year college,VA,0,0.471736237
+male,white,65,post-grad,CA,0,0.338717892
+male,white,41,some college,MI,0,0.501176682
+male,other,32,4-year college,TX,1,0.547132256
+male,white,68,4-year college,CO,1,0.473166666
+female,white,38,hs,WA,0,0.412130688
+male,white,57,hs,KY,1,0.65670629
+male,white,62,some college,IN,1,0.601173095
+male,other,36,4-year college,GA,1,0.526611726
+female,black,40,some college,PA,1,0.503755358
+female,white,53,hs,NY,1,0.382275815
+male,white,61,some college,KY,1,0.65670629
+female,white,54,4-year college,NJ,1,0.427158099
+female,white,39,4-year college,FL,0,0.506188355
+female,white,30,hs,IL,1,0.409799486
+male,other,37,hs,CA,0,0.338717892
+male,white,30,some college,MI,0,0.501176682
+female,white,49,hs,PA,1,0.503755358
+male,white,48,some college,MD,0,0.359837503
+female,white,19,4-year college,OR,0,0.438441611
+female,white,70,some college,CA,1,0.338717892
+female,white,24,4-year college,NY,0,0.382275815
+female,white,65,some college,PA,1,0.503755358
+male,white,30,4-year college,AZ,0,0.518900234
+male,other,67,post-grad,RI,0,0.416892959
+female,black,63,some college,GA,0,0.526611726
+female,black,45,4-year college,GA,0,0.526611726
+female,other,25,hs,NY,1,0.382275815
+female,white,24,4-year college,NY,1,0.382275815
+male,white,66,no hs,KY,1,0.65670629
+male,other,53,4-year college,NC,0,0.519037458
+female,white,34,4-year college,IA,0,0.550635478
+male,white,47,4-year college,FL,0,0.506188355
+male,white,48,no hs,MO,1,0.59818561
+male,white,64,4-year college,AZ,1,0.518900234
+female,white,22,4-year college,KS,1,0.611114703
+female,other,57,some college,FL,0,0.506188355
+female,black,59,hs,NY,1,0.382275815
+male,white,53,4-year college,KS,0,0.611114703
+female,white,61,4-year college,SC,1,0.574602564
+female,white,19,hs,MD,0,0.359837503
+female,black,52,post-grad,WV,0,0.721610523
+male,white,69,4-year college,OH,0,0.542676846
+male,other,46,4-year college,AZ,0,0.518900234
+female,white,89,some college,PA,1,0.503755358
+male,white,56,post-grad,VA,1,0.471736237
+female,white,46,post-grad,NY,0,0.382275815
+female,black,54,some college,VA,0,0.471736237
+male,white,22,4-year college,FL,1,0.506188355
+female,other,25,no hs,IL,1,0.409799486
+female,other,19,hs,FL,1,0.506188355
+male,white,40,4-year college,AZ,1,0.518900234
+female,white,48,some college,OH,1,0.542676846
+female,white,67,some college,NJ,1,0.427158099
+male,white,39,some college,SC,0,0.574602564
+male,white,72,hs,OH,1,0.542676846
+male,black,35,4-year college,NY,0,0.382275815
+male,white,73,some college,CA,1,0.338717892
+female,white,87,hs,PA,1,0.503755358
+male,white,91,hs,CA,1,0.338717892
+male,white,33,some college,KY,0,0.65670629
+male,white,46,some college,KY,0,0.65670629
+male,white,42,4-year college,IL,0,0.409799486
+male,white,41,some college,OK,1,0.693047372
+female,white,47,post-grad,OH,0,0.542676846
+female,white,46,hs,KY,0,0.65670629
+male,white,67,post-grad,MN,1,0.491681431
+female,white,43,hs,TN,1,0.63624343
+female,white,32,post-grad,TX,0,0.547132256
+female,white,83,some college,MO,0,0.59818561
+male,other,37,4-year college,VA,0,0.471736237
+female,white,86,post-grad,NY,0,0.382275815
+female,white,46,hs,WA,0,0.412130688
+male,black,31,4-year college,IL,0,0.409799486
+female,white,24,4-year college,ID,0,0.683101767
+male,white,42,some college,IN,0,0.601173095
+male,white,30,hs,TN,1,0.63624343
+male,other,35,4-year college,CA,0,0.338717892
+female,white,34,4-year college,TX,0,0.547132256
+female,white,32,4-year college,HI,0,0.325586625
+male,white,20,hs,OK,1,0.693047372
+female,white,37,some college,VA,1,0.471736237
+male,white,53,hs,CA,0,0.338717892
+female,white,86,some college,WA,1,0.412130688
+female,white,42,hs,NY,0,0.382275815
+female,other,54,hs,PA,1,0.503755358
+male,white,59,hs,NY,0,0.382275815
+female,black,90,4-year college,MI,1,0.501176682
+female,white,70,hs,CA,1,0.338717892
+male,white,21,some college,PA,0,0.503755358
+male,white,38,some college,FL,1,0.506188355
+female,other,20,4-year college,NY,0,0.382275815
+male,other,69,some college,TX,0,0.547132256
+male,white,67,hs,OH,0,0.542676846
+female,white,41,hs,PA,1,0.503755358
+female,white,31,4-year college,WA,0,0.412130688
+female,white,46,4-year college,IN,0,0.601173095
+female,white,43,hs,FL,1,0.506188355
+male,white,37,some college,ID,1,0.683101767
+female,white,63,post-grad,GA,0,0.526611726
+female,white,51,hs,AZ,1,0.518900234
+female,white,64,some college,SD,0,0.659718581
+male,black,19,some college,NY,1,0.382275815
+female,other,24,hs,KY,0,0.65670629
+female,black,26,some college,CA,0,0.338717892
+female,white,81,post-grad,MN,1,0.491681431
+female,black,50,some college,AL,0,0.643741436
+female,white,57,some college,FL,0,0.506188355
+female,white,59,post-grad,CT,0,0.428584525
+male,white,78,hs,OH,0,0.542676846
+female,white,76,4-year college,CA,1,0.338717892
+female,black,50,hs,VA,0,0.471736237
+male,white,26,hs,KY,0,0.65670629
+female,white,58,post-grad,OH,0,0.542676846
+female,white,70,4-year college,CA,0,0.338717892
+male,white,36,4-year college,NY,0,0.382275815
+female,white,86,some college,MS,0,0.590898473
+female,white,26,some college,OR,0,0.438441611
+male,white,28,post-grad,TX,1,0.547132256
+female,white,78,hs,CO,0,0.473166666
+male,white,76,4-year college,NY,0,0.382275815
+male,black,62,hs,TX,0,0.547132256
+male,other,42,some college,AZ,1,0.518900234
+female,black,52,4-year college,TX,0,0.547132256
+female,white,48,hs,MA,0,0.353487213
+female,other,47,some college,VA,0,0.471736237
+female,other,35,4-year college,CA,1,0.338717892
+female,other,30,4-year college,FL,1,0.506188355
+female,white,49,some college,TX,1,0.547132256
+female,white,50,some college,MD,1,0.359837503
+male,white,26,hs,WA,1,0.412130688
+female,black,54,4-year college,SC,0,0.574602564
+male,white,32,post-grad,TX,0,0.547132256
+female,white,26,4-year college,IL,0,0.409799486
+female,other,34,some college,FL,0,0.506188355
+female,white,64,4-year college,MD,1,0.359837503
+male,white,78,some college,TX,1,0.547132256
+female,other,51,4-year college,CA,0,0.338717892
+male,white,79,4-year college,KY,0,0.65670629
+female,white,46,some college,PA,0,0.503755358
+male,white,73,some college,MA,0,0.353487213
+male,other,57,some college,NY,0,0.382275815
+female,white,23,hs,MI,0,0.501176682
+male,white,54,some college,MA,1,0.353487213
+male,white,42,4-year college,TX,0,0.547132256
+female,white,38,some college,WA,0,0.412130688
+female,white,77,hs,OH,0,0.542676846
+male,white,50,some college,AL,1,0.643741436
+male,white,23,hs,FL,1,0.506188355
+female,black,27,some college,SC,0,0.574602564
+female,white,52,some college,TX,0,0.547132256
+male,white,65,some college,NV,0,0.487062906
+male,white,51,hs,TX,0,0.547132256
+male,white,50,hs,NC,0,0.519037458
+female,white,32,some college,TX,0,0.547132256
+female,black,60,some college,IN,0,0.601173095
+male,white,82,some college,MI,1,0.501176682
+male,white,19,post-grad,OH,0,0.542676846
+female,other,77,post-grad,FL,1,0.506188355
+male,other,55,some college,WA,1,0.412130688
+female,other,31,some college,TX,1,0.547132256
+male,white,100,4-year college,WA,0,0.412130688
+male,white,57,some college,PA,1,0.503755358
+male,white,73,post-grad,TX,0,0.547132256
+male,other,39,4-year college,NV,1,0.487062906
+female,white,35,no hs,NY,0,0.382275815
+male,white,63,post-grad,PA,0,0.503755358
+male,white,51,post-grad,VA,1,0.471736237
+male,white,63,some college,NY,0,0.382275815
+male,white,63,hs,PA,1,0.503755358
+female,white,42,4-year college,TX,0,0.547132256
+female,white,27,4-year college,MS,1,0.590898473
+female,other,20,some college,CA,0,0.338717892
+male,white,33,some college,VA,1,0.471736237
+female,white,99,hs,HI,1,0.325586625
+male,white,62,some college,WA,1,0.412130688
+female,white,82,some college,TX,0,0.547132256
+female,other,18,4-year college,TX,0,0.547132256
+female,white,38,some college,IL,0,0.409799486
+male,white,48,hs,IL,0,0.409799486
+male,white,37,post-grad,WA,1,0.412130688
+female,white,50,post-grad,NJ,0,0.427158099
+female,white,28,4-year college,NY,0,0.382275815
+female,white,63,some college,FL,0,0.506188355
+male,white,76,4-year college,NY,1,0.382275815
+female,white,25,some college,ND,1,0.698092429
+female,white,35,4-year college,NC,1,0.519037458
+female,black,57,some college,PA,1,0.503755358
+female,white,22,hs,VA,1,0.471736237
+female,white,41,hs,LA,1,0.601716772
+female,white,65,hs,IL,1,0.409799486
+male,white,94,some college,MI,1,0.501176682
+female,white,93,some college,NY,1,0.382275815
+male,white,39,post-grad,FL,1,0.506188355
+female,other,21,4-year college,UT,1,0.623836582
+male,black,24,some college,TX,1,0.547132256
+female,white,69,post-grad,CA,0,0.338717892
+male,other,20,4-year college,TX,0,0.547132256
+female,white,38,post-grad,NE,1,0.635476741
+female,white,39,some college,MI,1,0.501176682
+female,white,53,hs,UT,0,0.623836582
+female,white,30,some college,NY,1,0.382275815
+male,white,63,4-year college,GA,0,0.526611726
+female,white,27,4-year college,IL,0,0.409799486
+male,white,59,4-year college,NJ,1,0.427158099
+female,other,40,some college,NV,0,0.487062906
+female,other,38,4-year college,IN,1,0.601173095
+male,white,39,4-year college,IL,0,0.409799486
+male,white,61,4-year college,TX,1,0.547132256
+male,white,31,hs,AZ,0,0.518900234
+female,white,60,post-grad,IN,1,0.601173095
+female,white,52,hs,KS,0,0.611114703
+male,white,54,4-year college,CA,0,0.338717892
+male,other,22,hs,CA,1,0.338717892
+female,other,39,no hs,TX,1,0.547132256
+female,white,33,some college,NC,0,0.519037458
+female,white,68,hs,MO,0,0.59818561
+female,white,61,some college,WA,1,0.412130688
+male,white,64,post-grad,AZ,1,0.518900234
+female,white,47,some college,OH,1,0.542676846
+female,black,63,hs,SC,1,0.574602564
+male,white,33,some college,WA,1,0.412130688
+female,other,26,no hs,FL,1,0.506188355
+male,white,44,some college,VA,0,0.471736237
+male,white,39,some college,TN,0,0.63624343
+male,other,28,some college,TX,0,0.547132256
+male,white,58,some college,MO,0,0.59818561
+female,white,26,4-year college,MA,0,0.353487213
+male,white,39,hs,SD,1,0.659718581
+male,white,25,hs,IN,1,0.601173095
+male,other,33,4-year college,TX,0,0.547132256
+male,white,68,hs,PA,0,0.503755358
+female,white,87,no hs,IN,1,0.601173095
+female,other,29,post-grad,TX,0,0.547132256
+female,white,57,4-year college,AR,0,0.642851377
+female,white,22,some college,WI,0,0.50407989
+female,black,26,some college,TX,0,0.547132256
+female,white,18,some college,GA,0,0.526611726
+male,white,64,some college,IL,1,0.409799486
+male,white,65,some college,CA,1,0.338717892
+female,white,58,4-year college,AR,1,0.642851377
+female,black,36,some college,CT,1,0.428584525
+female,other,39,4-year college,HI,0,0.325586625
+female,white,64,some college,FL,1,0.506188355
+female,white,54,some college,LA,0,0.601716772
+female,white,20,no hs,OR,1,0.438441611
+male,white,61,post-grad,TX,1,0.547132256
+female,white,50,some college,OH,1,0.542676846
+female,white,22,4-year college,NJ,0,0.427158099
+female,black,23,some college,TX,0,0.547132256
+male,other,31,some college,VA,0,0.471736237
+male,white,18,some college,TX,0,0.547132256
+female,white,55,4-year college,CT,1,0.428584525
+male,other,55,hs,OK,1,0.693047372
+male,white,76,4-year college,NJ,1,0.427158099
+male,white,67,4-year college,OH,1,0.542676846
+female,white,61,some college,CA,1,0.338717892
+male,other,26,4-year college,GA,0,0.526611726
+female,white,68,hs,IN,1,0.601173095
+male,white,31,4-year college,CA,0,0.338717892
+female,other,52,post-grad,CA,0,0.338717892
+male,white,48,4-year college,OH,1,0.542676846
+male,white,48,4-year college,WA,0,0.412130688
+male,white,43,some college,IL,1,0.409799486
+male,white,20,some college,AK,0,0.583856547
+male,other,25,post-grad,VA,0,0.471736237
+female,white,33,hs,SC,1,0.574602564
+female,other,20,some college,OH,0,0.542676846
+female,white,50,some college,MD,1,0.359837503
+male,other,64,4-year college,MD,0,0.359837503
+female,white,41,hs,NJ,0,0.427158099
+female,white,65,some college,VT,0,0.348135737
+male,white,23,some college,IA,1,0.550635478
+female,other,30,4-year college,TX,1,0.547132256
+male,white,89,4-year college,IL,0,0.409799486
+female,black,32,some college,SC,1,0.574602564
+female,white,19,hs,ME,0,0.484032089
+male,white,51,4-year college,NC,1,0.519037458
+female,white,25,some college,PA,0,0.503755358
+male,white,38,some college,NJ,0,0.427158099
+female,other,23,some college,CA,0,0.338717892
+female,white,67,4-year college,OR,0,0.438441611
+female,other,32,post-grad,CA,0,0.338717892
+female,black,23,no hs,MS,1,0.590898473
+female,other,69,hs,NV,0,0.487062906
+male,white,57,4-year college,TX,1,0.547132256
+male,other,41,4-year college,NY,0,0.382275815
+female,other,36,some college,CA,0,0.338717892
+female,white,37,4-year college,TN,1,0.63624343
+female,white,18,4-year college,CA,0,0.338717892
+male,white,76,4-year college,AL,1,0.643741436
+female,white,69,hs,NV,0,0.487062906
+female,white,63,no hs,OH,1,0.542676846
+female,other,54,hs,PA,0,0.503755358
+male,white,78,post-grad,TN,0,0.63624343
+female,white,58,some college,OH,1,0.542676846
+male,black,28,hs,NV,0,0.487062906
+female,white,50,hs,AL,1,0.643741436
+female,black,33,hs,AL,0,0.643741436
+female,white,42,4-year college,IL,0,0.409799486
+male,other,68,4-year college,NV,1,0.487062906
+male,white,66,4-year college,TN,0,0.63624343
+female,white,40,4-year college,IL,1,0.409799486
+male,white,87,some college,FL,1,0.506188355
+female,white,38,post-grad,CA,0,0.338717892
+male,white,76,post-grad,TX,1,0.547132256
+male,white,61,post-grad,MI,0,0.501176682
+female,white,55,hs,TN,1,0.63624343
+female,white,63,hs,SC,1,0.574602564
+female,other,78,post-grad,CA,0,0.338717892
+female,white,22,hs,PA,0,0.503755358
+male,other,54,post-grad,TX,1,0.547132256
+male,white,58,4-year college,IL,0,0.409799486
+male,white,51,hs,FL,1,0.506188355
+female,black,50,some college,PA,0,0.503755358
+male,white,58,hs,AL,1,0.643741436
+male,white,44,no hs,AR,0,0.642851377
+female,white,67,hs,IN,0,0.601173095
+female,white,44,post-grad,KS,1,0.611114703
+female,white,48,hs,TN,1,0.63624343
+female,white,41,hs,IL,1,0.409799486
+female,white,85,no hs,NM,1,0.453492051
+female,white,90,hs,MO,1,0.59818561
+male,other,64,4-year college,FL,1,0.506188355
+female,black,25,some college,TX,1,0.547132256
+female,black,48,hs,VA,0,0.471736237
+female,white,87,hs,GA,1,0.526611726
+male,white,51,hs,OH,0,0.542676846
+female,other,47,hs,HI,0,0.325586625
+female,white,66,hs,SC,1,0.574602564
+male,white,24,hs,CA,0,0.338717892
+male,white,18,some college,CA,1,0.338717892
+female,black,53,hs,PA,1,0.503755358
+female,white,57,hs,MS,1,0.590898473
+female,white,59,4-year college,MI,0,0.501176682
+male,other,48,some college,WA,1,0.412130688
+female,black,28,some college,TN,0,0.63624343
+male,white,64,hs,CT,1,0.428584525
+male,white,84,post-grad,TX,1,0.547132256
+female,white,46,4-year college,WA,0,0.412130688
+female,white,41,4-year college,FL,0,0.506188355
+female,white,57,post-grad,PA,1,0.503755358
+female,white,23,post-grad,WI,0,0.50407989
+male,other,34,hs,CA,1,0.338717892
+female,white,29,4-year college,NY,0,0.382275815
+female,other,39,4-year college,NJ,0,0.427158099
+male,other,50,some college,AR,1,0.642851377
+female,black,40,some college,NY,0,0.382275815
+male,white,84,hs,MO,0,0.59818561
+female,black,24,some college,CA,0,0.338717892
+male,white,35,4-year college,PA,1,0.503755358
+female,white,66,4-year college,OR,0,0.438441611
+female,white,96,hs,AZ,1,0.518900234
+female,white,67,hs,OR,0,0.438441611
+female,white,47,4-year college,AZ,0,0.518900234
+female,black,81,some college,MI,0,0.501176682
+male,black,50,4-year college,WA,1,0.412130688
+male,white,86,post-grad,WA,0,0.412130688
+female,white,63,post-grad,MI,0,0.501176682
+female,white,45,4-year college,OR,0,0.438441611
+female,white,42,hs,NY,0,0.382275815
+male,black,24,hs,NJ,1,0.427158099
+male,white,37,4-year college,TX,0,0.547132256
+female,white,53,hs,NE,0,0.635476741
+male,white,36,4-year college,IL,0,0.409799486
+male,white,79,post-grad,ID,1,0.683101767
+female,black,49,post-grad,IN,0,0.601173095
+female,white,60,4-year college,CA,0,0.338717892
+female,other,34,4-year college,NY,0,0.382275815
+female,white,94,some college,WV,0,0.721610523
+female,white,38,post-grad,MO,1,0.59818561
+female,white,55,some college,FL,0,0.506188355
+female,white,54,post-grad,CO,0,0.473166666
+female,other,18,hs,WY,0,0.757053196
+female,white,31,some college,CO,1,0.473166666
+female,white,62,post-grad,MD,1,0.359837503
+female,white,68,hs,LA,1,0.601716772
+male,white,59,some college,VA,1,0.471736237
+female,other,49,4-year college,OH,0,0.542676846
+male,white,46,hs,SC,1,0.574602564
+female,other,21,post-grad,OH,0,0.542676846
+female,white,26,hs,MI,0,0.501176682
+female,white,29,no hs,OH,1,0.542676846
+male,black,82,post-grad,CA,0,0.338717892
+female,white,28,some college,AR,1,0.642851377
+male,white,54,post-grad,VA,0,0.471736237
+female,white,56,post-grad,CO,0,0.473166666
+male,other,64,4-year college,NC,1,0.519037458
+female,white,38,post-grad,KS,0,0.611114703
+female,white,100,hs,AZ,1,0.518900234
+female,other,25,hs,CA,0,0.338717892
+male,white,25,hs,MI,0,0.501176682
+female,black,30,4-year college,IL,0,0.409799486
+male,white,18,hs,NC,0,0.519037458
+female,white,73,some college,PA,0,0.503755358
+female,white,47,hs,IA,0,0.550635478
+male,other,32,4-year college,CA,0,0.338717892
+male,other,40,some college,MA,0,0.353487213
+female,white,88,some college,NY,1,0.382275815
+female,white,61,4-year college,CA,1,0.338717892
+male,white,55,some college,KS,0,0.611114703
+female,white,47,hs,PA,1,0.503755358
+female,white,21,some college,OH,0,0.542676846
+female,white,35,some college,ND,0,0.698092429
+male,other,95,4-year college,GA,1,0.526611726
+male,white,83,post-grad,FL,1,0.506188355
+female,black,43,some college,FL,1,0.506188355
+male,white,58,hs,NY,0,0.382275815
+female,white,86,no hs,IL,1,0.409799486
+female,white,54,some college,NE,0,0.635476741
+female,white,33,hs,NJ,0,0.427158099
+female,black,68,some college,IN,0,0.601173095
+female,black,19,hs,VA,1,0.471736237
+female,white,70,hs,OH,0,0.542676846
+female,white,23,4-year college,NY,0,0.382275815
+male,white,72,hs,FL,1,0.506188355
+male,white,40,post-grad,CT,1,0.428584525
+female,white,69,hs,KY,0,0.65670629
+male,white,28,some college,PA,0,0.503755358
+female,other,42,4-year college,NC,0,0.519037458
+female,white,51,some college,OR,0,0.438441611
+female,black,67,some college,AR,0,0.642851377
+female,other,42,some college,FL,1,0.506188355
+female,white,54,hs,PA,1,0.503755358
+male,other,27,some college,MI,0,0.501176682
+male,white,52,4-year college,MD,1,0.359837503
+male,white,56,4-year college,OH,0,0.542676846
+female,white,44,some college,MO,1,0.59818561
+female,white,39,post-grad,OH,0,0.542676846
+female,white,28,some college,LA,1,0.601716772
+male,white,59,some college,WV,1,0.721610523
+male,white,23,hs,CA,0,0.338717892
+male,white,25,4-year college,TX,0,0.547132256
+male,white,18,hs,NH,1,0.498029716
+male,white,24,4-year college,NY,1,0.382275815
+female,white,18,some college,OH,0,0.542676846
+female,white,21,hs,ND,0,0.698092429
+male,white,51,4-year college,IN,1,0.601173095
+female,white,65,hs,KY,1,0.65670629
+female,white,30,4-year college,OR,1,0.438441611
+female,white,30,post-grad,IA,0,0.550635478
+female,other,23,hs,NC,1,0.519037458
+female,white,48,no hs,FL,0,0.506188355
+female,white,31,no hs,CO,0,0.473166666
+male,white,86,post-grad,NH,0,0.498029716
+female,white,69,4-year college,AL,0,0.643741436
+female,white,24,hs,FL,0,0.506188355
+female,white,66,hs,FL,1,0.506188355
+male,white,66,no hs,OH,1,0.542676846
+female,white,94,hs,AL,1,0.643741436
+female,white,39,some college,LA,1,0.601716772
+male,black,50,hs,IN,1,0.601173095
+male,white,50,some college,NJ,0,0.427158099
+female,white,96,no hs,UT,1,0.623836582
+male,white,59,hs,TX,0,0.547132256
+male,white,63,hs,NJ,0,0.427158099
+male,white,79,hs,TX,1,0.547132256
+female,white,49,4-year college,IL,0,0.409799486
+female,white,30,some college,MA,0,0.353487213
+female,white,61,hs,WI,1,0.50407989
+male,white,67,some college,UT,0,0.623836582
+male,white,45,post-grad,GA,0,0.526611726
+female,white,57,4-year college,MT,0,0.611096643
+female,white,64,hs,MI,0,0.501176682
+female,black,45,no hs,TN,0,0.63624343
+male,white,45,hs,MI,1,0.501176682
+female,white,31,no hs,FL,0,0.506188355
+female,black,64,some college,MD,0,0.359837503
+male,other,40,some college,CA,0,0.338717892
+male,black,44,some college,AL,1,0.643741436
+male,white,18,some college,IL,0,0.409799486
+female,black,40,some college,AL,0,0.643741436
+male,white,57,4-year college,MD,1,0.359837503
+female,white,19,hs,WI,1,0.50407989
+female,white,42,hs,FL,0,0.506188355
+male,white,38,4-year college,MA,0,0.353487213
+female,white,46,some college,MI,1,0.501176682
+male,white,97,post-grad,MI,0,0.501176682
+male,white,18,hs,AZ,1,0.518900234
+female,white,24,some college,IL,1,0.409799486
+male,white,86,post-grad,SC,1,0.574602564
+male,white,47,hs,NC,1,0.519037458
+female,white,53,4-year college,MI,0,0.501176682
+male,white,36,some college,ND,0,0.698092429
+female,white,34,4-year college,AL,1,0.643741436
+female,other,29,4-year college,AZ,0,0.518900234
+male,white,75,some college,FL,1,0.506188355
+male,white,33,4-year college,OH,0,0.542676846
+female,white,23,4-year college,KS,1,0.611114703
+male,other,54,some college,DE,0,0.440013786
+female,other,31,some college,GA,1,0.526611726
+female,white,52,hs,PA,0,0.503755358
+male,white,85,hs,AZ,0,0.518900234
+female,white,22,hs,OK,0,0.693047372
+male,black,29,some college,PA,0,0.503755358
+male,white,42,hs,KS,0,0.611114703
+female,other,21,some college,CA,0,0.338717892
+male,white,45,post-grad,OR,0,0.438441611
+male,other,31,post-grad,FL,0,0.506188355
+male,white,50,some college,MI,1,0.501176682
+male,other,34,some college,AZ,0,0.518900234
+female,white,21,some college,NJ,0,0.427158099
+male,white,72,4-year college,IL,1,0.409799486
+male,black,40,some college,TX,1,0.547132256
+male,white,24,some college,CA,0,0.338717892
+female,white,50,some college,WI,1,0.50407989
+male,white,85,post-grad,MO,1,0.59818561
+male,other,18,some college,TX,0,0.547132256
+male,white,53,some college,OH,1,0.542676846
+female,white,44,some college,NC,0,0.519037458
+female,white,67,some college,AZ,0,0.518900234
+female,white,66,no hs,AL,0,0.643741436
+female,white,59,some college,FL,1,0.506188355
+female,white,32,post-grad,OH,0,0.542676846
+male,white,49,some college,TX,0,0.547132256
+female,other,26,hs,TX,0,0.547132256
+female,white,18,hs,OH,0,0.542676846
+female,other,35,some college,TX,1,0.547132256
+female,other,68,post-grad,TX,0,0.547132256
+female,white,49,4-year college,PA,1,0.503755358
+female,black,18,some college,AL,0,0.643741436
+female,other,64,some college,NY,0,0.382275815
+male,white,69,post-grad,TX,0,0.547132256
+female,other,19,some college,TX,1,0.547132256
+male,other,20,some college,NY,0,0.382275815
+male,white,61,post-grad,MD,0,0.359837503
+female,white,24,post-grad,MA,0,0.353487213
+female,white,22,hs,PA,0,0.503755358
+male,white,71,some college,TX,1,0.547132256
+female,white,22,some college,NY,1,0.382275815
+female,white,35,some college,MI,0,0.501176682
+female,white,94,hs,MD,1,0.359837503
+female,white,63,post-grad,NE,0,0.635476741
+female,white,41,some college,NY,0,0.382275815
+male,white,27,4-year college,NC,0,0.519037458
+female,other,47,hs,TX,1,0.547132256
+female,white,30,4-year college,FL,0,0.506188355
+male,white,35,4-year college,NC,1,0.519037458
+male,black,30,4-year college,TN,1,0.63624343
+female,white,56,hs,WI,1,0.50407989
+female,white,35,post-grad,TX,0,0.547132256
+female,white,64,hs,FL,1,0.506188355
+male,white,77,hs,MD,1,0.359837503
+female,white,58,hs,IL,0,0.409799486
+female,white,66,hs,IL,0,0.409799486
+female,black,32,some college,NY,0,0.382275815
+female,other,20,4-year college,FL,0,0.506188355
+female,white,51,some college,IN,0,0.601173095
+female,white,45,some college,OR,1,0.438441611
+male,black,40,hs,IL,1,0.409799486
+female,white,19,some college,OH,0,0.542676846
+male,other,47,some college,TX,1,0.547132256
+female,white,27,some college,CA,1,0.338717892
+female,white,65,hs,IL,1,0.409799486
+male,white,79,4-year college,MS,1,0.590898473
+male,white,65,some college,IA,0,0.550635478
+female,white,60,hs,AZ,0,0.518900234
+male,white,80,4-year college,PA,1,0.503755358
+female,white,66,post-grad,MD,1,0.359837503
+male,white,37,post-grad,TN,0,0.63624343
+female,white,54,hs,OH,0,0.542676846
+female,other,24,some college,TN,0,0.63624343
+female,white,19,some college,MO,1,0.59818561
+male,white,53,some college,VA,1,0.471736237
+female,white,71,hs,KY,1,0.65670629
+female,white,52,some college,WI,0,0.50407989
+female,other,24,some college,NJ,0,0.427158099
+female,other,65,4-year college,TX,0,0.547132256
+male,white,88,4-year college,MA,1,0.353487213
+female,white,51,hs,MA,0,0.353487213
+female,white,34,4-year college,OR,0,0.438441611
+male,white,47,some college,TX,1,0.547132256
+female,white,27,4-year college,OH,0,0.542676846
+female,other,29,hs,GA,0,0.526611726
+female,white,25,4-year college,TX,1,0.547132256
+male,white,55,4-year college,MS,1,0.590898473
+male,white,36,some college,KY,0,0.65670629
+female,white,48,4-year college,OR,0,0.438441611
+female,other,68,4-year college,FL,1,0.506188355
+female,black,24,some college,FL,0,0.506188355
+male,white,83,4-year college,SC,1,0.574602564
+male,white,61,some college,CA,0,0.338717892
+male,white,57,post-grad,KS,0,0.611114703
+female,white,63,some college,TN,0,0.63624343
+female,black,40,post-grad,NY,0,0.382275815
+female,white,55,hs,IL,0,0.409799486
+female,white,32,4-year college,IL,0,0.409799486
+female,white,28,some college,NJ,1,0.427158099
+female,other,20,hs,NJ,1,0.427158099
+female,other,44,some college,CA,0,0.338717892
+male,white,68,some college,OH,1,0.542676846
+female,white,46,some college,NM,1,0.453492051
+male,white,25,4-year college,CA,1,0.338717892
+male,white,36,hs,NM,0,0.453492051
+female,white,88,some college,LA,1,0.601716772
+male,black,46,some college,NY,0,0.382275815
+female,white,45,some college,SC,0,0.574602564
+female,white,42,4-year college,WI,0,0.50407989
+male,white,53,some college,FL,1,0.506188355
+female,white,58,hs,NH,0,0.498029716
+female,white,99,hs,IL,1,0.409799486
+male,white,40,some college,NY,0,0.382275815
+male,white,85,hs,MD,0,0.359837503
+female,white,81,hs,TN,0,0.63624343
+female,white,63,some college,FL,1,0.506188355
+female,other,26,some college,CA,0,0.338717892
+female,white,24,some college,MI,0,0.501176682
+female,white,41,4-year college,NY,0,0.382275815
+female,white,67,hs,RI,0,0.416892959
+male,white,65,some college,KS,0,0.611114703
+female,white,25,4-year college,PA,0,0.503755358
+female,white,63,post-grad,OH,1,0.542676846
+male,white,97,4-year college,NH,0,0.498029716
+male,white,56,4-year college,SD,1,0.659718581
+female,white,48,hs,TX,1,0.547132256
+female,white,84,post-grad,WA,0,0.412130688
+male,white,52,no hs,CA,0,0.338717892
+female,white,69,4-year college,CA,0,0.338717892
+female,white,64,hs,NC,1,0.519037458
+male,white,55,post-grad,CA,0,0.338717892
+female,white,42,post-grad,OH,1,0.542676846
+female,white,68,4-year college,AZ,0,0.518900234
+female,white,58,hs,CA,1,0.338717892
+female,white,26,4-year college,KY,0,0.65670629
+female,other,22,4-year college,FL,1,0.506188355
+male,white,25,hs,IL,1,0.409799486
+female,other,29,hs,CA,0,0.338717892
+female,white,23,hs,GA,0,0.526611726
+male,white,47,no hs,GA,0,0.526611726
+male,white,78,some college,SC,1,0.574602564
+male,black,18,hs,CA,0,0.338717892
+female,black,61,no hs,TN,0,0.63624343
+female,white,47,4-year college,PA,1,0.503755358
+female,white,59,some college,NY,0,0.382275815
+male,white,30,4-year college,NY,0,0.382275815
+female,white,38,some college,PA,0,0.503755358
+female,white,23,some college,NC,1,0.519037458
+female,white,29,no hs,CA,0,0.338717892
+female,other,45,post-grad,NC,1,0.519037458
+male,white,37,some college,OH,0,0.542676846
+male,white,32,4-year college,IL,0,0.409799486
+male,white,71,4-year college,FL,1,0.506188355
+male,black,60,hs,IL,0,0.409799486
+male,white,56,hs,AL,1,0.643741436
+female,white,26,hs,TX,1,0.547132256
+male,white,18,hs,TX,0,0.547132256
+female,white,65,4-year college,OH,0,0.542676846
+female,white,51,hs,MO,1,0.59818561
+male,white,47,post-grad,PA,0,0.503755358
+male,white,67,4-year college,FL,1,0.506188355
+male,white,62,some college,IL,0,0.409799486
+male,white,27,hs,OH,0,0.542676846
+female,other,22,post-grad,CA,0,0.338717892
+female,black,41,some college,OH,1,0.542676846
+male,other,55,some college,CA,0,0.338717892
+male,black,42,hs,CT,1,0.428584525
+female,white,29,4-year college,MI,1,0.501176682
+female,white,18,4-year college,CA,0,0.338717892
+female,black,57,some college,WI,0,0.50407989
+female,white,41,some college,MD,0,0.359837503
+female,white,59,post-grad,MO,0,0.59818561
+female,white,26,hs,TX,0,0.547132256
+male,white,33,hs,NC,1,0.519037458
+female,white,39,post-grad,IN,0,0.601173095
+female,white,61,some college,AL,1,0.643741436
+female,other,34,some college,TX,0,0.547132256
+female,white,37,hs,PA,1,0.503755358
+male,white,29,4-year college,ND,0,0.698092429
+male,white,34,post-grad,PA,1,0.503755358
+male,white,89,post-grad,GA,0,0.526611726
+male,white,53,post-grad,WV,1,0.721610523
+female,white,66,some college,NY,0,0.382275815
+female,white,63,some college,IA,0,0.550635478
+female,white,69,some college,CO,0,0.473166666
+male,white,89,some college,IA,1,0.550635478
+female,other,43,some college,NV,0,0.487062906
+female,white,47,some college,PA,0,0.503755358
+female,white,18,4-year college,WI,0,0.50407989
+female,white,33,some college,GA,1,0.526611726
+female,white,63,4-year college,MI,1,0.501176682
+male,white,48,post-grad,WI,0,0.50407989
+female,other,25,some college,CA,1,0.338717892
+male,white,25,4-year college,FL,1,0.506188355
+female,white,30,hs,NJ,1,0.427158099
+male,white,43,some college,CA,1,0.338717892
+female,white,56,some college,HI,1,0.325586625
+female,white,57,some college,WA,0,0.412130688
+female,black,22,hs,NC,1,0.519037458
+female,other,20,some college,CA,1,0.338717892
+female,other,28,some college,TX,0,0.547132256
+male,white,59,4-year college,VA,1,0.471736237
+female,white,23,hs,CA,1,0.338717892
+female,other,35,post-grad,PA,0,0.503755358
+female,black,45,hs,IL,1,0.409799486
+male,white,46,hs,NY,0,0.382275815
+male,white,67,some college,PA,0,0.503755358
+male,white,40,post-grad,GA,1,0.526611726
+male,white,69,some college,TN,0,0.63624343
+male,white,32,post-grad,FL,1,0.506188355
+female,black,30,some college,GA,0,0.526611726
+male,white,53,4-year college,WI,0,0.50407989
+female,white,22,hs,PA,0,0.503755358
+male,white,91,post-grad,FL,0,0.506188355
+female,white,29,4-year college,NY,0,0.382275815
+male,white,26,4-year college,IL,1,0.409799486
+male,white,31,4-year college,MD,0,0.359837503
+female,black,53,some college,TX,0,0.547132256
+female,white,27,4-year college,ME,0,0.484032089
+male,white,55,some college,KY,0,0.65670629
+female,white,28,some college,CA,0,0.338717892
+female,white,34,no hs,AL,1,0.643741436
+female,white,65,some college,PA,1,0.503755358
+female,black,21,hs,NY,0,0.382275815
+female,white,61,hs,CT,0,0.428584525
+female,other,28,post-grad,AZ,0,0.518900234
+female,white,43,some college,MN,1,0.491681431
+female,white,59,hs,MO,0,0.59818561
+male,white,36,some college,OH,0,0.542676846
+female,other,84,some college,AZ,1,0.518900234
+male,white,66,hs,MO,0,0.59818561
+female,white,49,4-year college,MI,0,0.501176682
+female,white,26,hs,FL,1,0.506188355
+female,white,45,hs,OH,0,0.542676846
+female,black,23,hs,NM,0,0.453492051
+female,other,55,4-year college,NY,0,0.382275815
+female,other,20,some college,FL,1,0.506188355
+male,other,43,post-grad,CA,0,0.338717892
+female,white,20,some college,FL,0,0.506188355
+male,white,82,4-year college,CA,0,0.338717892
+male,white,63,4-year college,CA,1,0.338717892
+female,other,39,some college,HI,1,0.325586625
+female,white,98,hs,MA,1,0.353487213
+female,white,43,4-year college,TX,0,0.547132256
+male,other,35,4-year college,CT,0,0.428584525
+female,other,47,some college,AL,1,0.643741436
+male,white,62,4-year college,PA,0,0.503755358
+male,white,55,some college,PA,1,0.503755358
+male,white,69,hs,PA,1,0.503755358
+female,black,38,some college,IN,0,0.601173095
+female,other,19,some college,MA,0,0.353487213
+female,white,54,post-grad,TX,0,0.547132256
+male,white,54,hs,CA,1,0.338717892
+female,other,59,4-year college,TX,0,0.547132256
+male,white,60,no hs,IL,0,0.409799486
+female,white,27,some college,IN,0,0.601173095
+male,white,30,some college,VA,0,0.471736237
+male,white,38,some college,MS,0,0.590898473
+female,white,37,post-grad,TX,0,0.547132256
+female,white,70,some college,MD,0,0.359837503
+female,white,62,hs,LA,1,0.601716772
+male,white,93,some college,AZ,1,0.518900234
+female,white,63,some college,MA,0,0.353487213
+male,white,67,hs,MD,0,0.359837503
+female,white,61,4-year college,MO,1,0.59818561
+male,other,62,post-grad,NY,0,0.382275815
+female,white,54,hs,WI,1,0.50407989
+male,other,18,some college,GA,0,0.526611726
+female,white,78,some college,CA,1,0.338717892
+female,white,28,hs,UT,1,0.623836582
+male,black,29,some college,PA,1,0.503755358
+female,white,33,4-year college,CA,0,0.338717892
+female,white,54,hs,MS,0,0.590898473
+female,white,65,hs,SC,1,0.574602564
+female,black,59,some college,PA,0,0.503755358
+male,white,52,4-year college,UT,0,0.623836582
+male,other,54,4-year college,PA,1,0.503755358
+male,white,98,4-year college,FL,1,0.506188355
+female,white,47,no hs,WY,1,0.757053196
+female,other,23,some college,OH,0,0.542676846
+male,white,73,post-grad,MO,0,0.59818561
+male,white,65,post-grad,GA,0,0.526611726
+female,black,97,post-grad,WI,0,0.50407989
+female,white,51,some college,AZ,1,0.518900234
+female,white,92,some college,WA,1,0.412130688
+female,white,83,some college,AZ,1,0.518900234
+female,white,36,some college,GA,0,0.526611726
+female,white,99,some college,FL,0,0.506188355
+female,white,60,some college,TX,1,0.547132256
+female,black,21,4-year college,MN,0,0.491681431
+female,white,74,hs,AZ,0,0.518900234
+male,white,22,no hs,OH,1,0.542676846
+male,white,35,4-year college,PA,1,0.503755358
+female,white,75,hs,SC,0,0.574602564
+male,other,42,hs,NY,0,0.382275815
+female,white,28,hs,OH,1,0.542676846
+male,white,61,hs,CA,1,0.338717892
+female,white,69,hs,TN,0,0.63624343
+female,white,77,some college,CA,1,0.338717892
+male,other,51,some college,FL,0,0.506188355
+female,black,51,hs,MO,1,0.59818561
+female,other,37,no hs,AZ,1,0.518900234
+male,other,29,some college,CA,0,0.338717892
+female,other,25,no hs,AZ,0,0.518900234
+male,white,28,some college,MO,0,0.59818561
+male,white,44,4-year college,VA,1,0.471736237
+male,white,35,some college,OH,1,0.542676846
+female,white,54,4-year college,IL,0,0.409799486
+female,white,29,hs,IL,1,0.409799486
+female,white,33,post-grad,TX,1,0.547132256
+male,other,41,4-year college,NY,0,0.382275815
+female,white,43,some college,VA,0,0.471736237
+male,white,83,some college,PA,1,0.503755358
+male,white,77,post-grad,NY,0,0.382275815
+female,white,67,post-grad,MS,0,0.590898473
+male,other,48,post-grad,TX,0,0.547132256
+male,white,57,4-year college,NM,0,0.453492051
+male,other,29,4-year college,TX,0,0.547132256
+female,white,50,some college,FL,0,0.506188355
+female,white,70,4-year college,CA,0,0.338717892
+male,white,76,some college,FL,1,0.506188355
+female,white,69,some college,WV,1,0.721610523
+female,white,32,4-year college,CA,0,0.338717892
+female,other,31,hs,TX,0,0.547132256
+male,white,55,some college,UT,1,0.623836582
+male,white,56,4-year college,NC,1,0.519037458
+female,other,57,post-grad,VA,1,0.471736237
+female,white,72,hs,PA,1,0.503755358
+female,white,68,some college,FL,1,0.506188355
+female,white,74,4-year college,TN,1,0.63624343
+male,white,50,some college,OR,0,0.438441611
+male,white,27,no hs,LA,0,0.601716772
+female,white,18,some college,MI,0,0.501176682
+female,white,40,hs,SC,0,0.574602564
+male,other,21,some college,CA,1,0.338717892
+female,white,82,hs,FL,1,0.506188355
+female,white,30,hs,NH,0,0.498029716
+female,white,55,post-grad,OR,1,0.438441611
+female,white,38,post-grad,PA,0,0.503755358
+female,white,66,some college,CO,0,0.473166666
+male,white,64,post-grad,MD,1,0.359837503
+male,other,43,post-grad,NY,0,0.382275815
+male,white,54,some college,NY,0,0.382275815
+female,white,62,hs,NY,1,0.382275815
+male,white,64,some college,FL,0,0.506188355
+male,white,47,some college,KS,0,0.611114703
+female,white,47,hs,PA,1,0.503755358
+male,white,74,post-grad,IL,1,0.409799486
+female,black,63,4-year college,GA,0,0.526611726
+female,white,56,hs,TN,1,0.63624343
+male,white,82,some college,MN,0,0.491681431
+female,white,81,hs,FL,1,0.506188355
+female,white,30,4-year college,AZ,0,0.518900234
+male,other,39,some college,MN,1,0.491681431
+female,white,54,hs,OR,1,0.438441611
+male,other,26,some college,NJ,0,0.427158099
+female,white,45,hs,NY,0,0.382275815
+female,white,49,no hs,MI,0,0.501176682
+female,white,49,some college,IL,1,0.409799486
+female,white,62,some college,AL,0,0.643741436
+female,white,52,hs,NY,1,0.382275815
+male,white,32,4-year college,IN,0,0.601173095
+male,white,63,hs,ID,0,0.683101767
+female,white,32,4-year college,IL,0,0.409799486
+female,white,21,4-year college,TX,0,0.547132256
+female,other,32,post-grad,ND,0,0.698092429
+male,white,59,hs,NJ,0,0.427158099
+female,white,20,hs,NY,0,0.382275815
+female,white,86,post-grad,IN,1,0.601173095
+female,white,67,some college,OH,0,0.542676846
+male,white,23,some college,OH,0,0.542676846
+female,white,29,4-year college,LA,1,0.601716772
+male,white,38,post-grad,IL,0,0.409799486
+female,black,23,some college,CA,0,0.338717892
+male,white,58,4-year college,VA,0,0.471736237
+male,white,59,post-grad,FL,1,0.506188355
+male,white,19,4-year college,NY,0,0.382275815
+female,white,50,some college,WA,1,0.412130688
+female,white,24,4-year college,IA,0,0.550635478
+female,other,24,some college,UT,0,0.623836582
+female,white,18,4-year college,PA,1,0.503755358
+female,white,49,4-year college,WI,0,0.50407989
+female,black,47,some college,NC,1,0.519037458
+female,white,44,some college,IA,1,0.550635478
+female,white,61,hs,OR,0,0.438441611
+female,white,42,post-grad,IA,1,0.550635478
+female,white,21,4-year college,WI,0,0.50407989
+female,white,23,some college,IN,1,0.601173095
+female,black,27,hs,PA,1,0.503755358
+male,white,59,hs,CA,1,0.338717892
+male,white,83,post-grad,NV,1,0.487062906
+male,other,53,post-grad,CA,0,0.338717892
+female,white,96,some college,CA,0,0.338717892
+female,black,61,hs,OH,1,0.542676846
+female,white,60,some college,KY,1,0.65670629
+female,white,100,post-grad,MD,0,0.359837503
+female,white,36,some college,KY,1,0.65670629
+female,white,66,some college,AR,1,0.642851377
+female,white,21,hs,ME,0,0.484032089
+female,white,25,some college,TX,0,0.547132256
+female,other,27,hs,OK,0,0.693047372
+male,white,27,hs,MI,0,0.501176682
+female,white,19,hs,FL,1,0.506188355
+female,white,23,4-year college,FL,0,0.506188355
+female,black,40,some college,IN,1,0.601173095
+female,white,68,hs,IL,0,0.409799486
+male,white,65,hs,PA,0,0.503755358
+male,white,20,some college,FL,0,0.506188355
+male,white,68,4-year college,IL,1,0.409799486
+female,white,28,hs,ME,0,0.484032089
+male,white,51,hs,FL,1,0.506188355
+male,white,18,some college,NY,0,0.382275815
+male,other,26,4-year college,TX,0,0.547132256
+female,black,30,4-year college,NY,1,0.382275815
+male,white,92,4-year college,UT,0,0.623836582
+female,other,65,hs,OR,0,0.438441611
+female,white,92,some college,VA,0,0.471736237
+female,white,60,hs,CA,0,0.338717892
+male,white,56,hs,OR,0,0.438441611
+male,white,56,some college,NY,0,0.382275815
+female,black,58,post-grad,VA,1,0.471736237
+female,black,56,4-year college,TX,0,0.547132256
+female,other,32,4-year college,NY,1,0.382275815
+male,white,64,4-year college,MI,1,0.501176682
+female,other,43,4-year college,NJ,0,0.427158099
+female,black,46,4-year college,MD,0,0.359837503
+female,white,28,4-year college,MI,1,0.501176682
+male,white,39,some college,IL,0,0.409799486
+male,black,21,some college,DE,1,0.440013786
+female,black,46,4-year college,LA,0,0.601716772
+male,white,31,hs,NY,1,0.382275815
+female,white,48,4-year college,MA,0,0.353487213
+female,black,69,some college,VA,0,0.471736237
+female,white,33,some college,OH,0,0.542676846
+female,white,51,4-year college,GA,0,0.526611726
+male,other,44,post-grad,TN,0,0.63624343
+male,white,95,4-year college,AL,1,0.643741436
+male,black,26,no hs,TX,0,0.547132256
+male,white,28,hs,LA,0,0.601716772
+female,white,44,4-year college,AR,1,0.642851377
+male,white,60,4-year college,AR,0,0.642851377
+female,other,32,hs,MN,0,0.491681431
+female,white,22,hs,IN,1,0.601173095
+female,other,51,post-grad,WA,1,0.412130688
+male,white,62,post-grad,GA,1,0.526611726
+male,white,66,hs,IL,0,0.409799486
+female,white,23,4-year college,WI,0,0.50407989
+male,white,38,post-grad,MI,0,0.501176682
+male,white,66,hs,IN,1,0.601173095
+female,white,49,4-year college,VA,0,0.471736237
+female,other,25,some college,TX,0,0.547132256
+male,white,54,hs,NC,0,0.519037458
+male,white,66,hs,MI,0,0.501176682
+male,white,32,some college,NJ,1,0.427158099
+male,white,25,4-year college,CA,0,0.338717892
+female,white,66,some college,WI,0,0.50407989
+female,white,92,some college,IL,0,0.409799486
+female,white,65,post-grad,GA,1,0.526611726
+male,white,34,hs,WA,0,0.412130688
+female,other,60,hs,NY,0,0.382275815
+male,black,60,some college,MI,1,0.501176682
+male,black,30,hs,CO,1,0.473166666
+male,white,29,some college,MO,0,0.59818561
+female,white,23,4-year college,NY,0,0.382275815
+male,white,43,4-year college,CO,0,0.473166666
+female,white,66,hs,FL,0,0.506188355
+male,white,63,some college,FL,1,0.506188355
+female,other,52,hs,OH,1,0.542676846
+male,white,86,4-year college,IL,1,0.409799486
+female,white,43,hs,NY,0,0.382275815
+male,white,47,hs,IL,0,0.409799486
+female,white,44,some college,VA,0,0.471736237
+female,other,43,no hs,AR,1,0.642851377
+female,white,35,4-year college,MT,0,0.611096643
+male,white,63,some college,IN,1,0.601173095
+female,white,20,some college,CT,0,0.428584525
+female,white,24,4-year college,WI,0,0.50407989
+female,white,55,some college,FL,0,0.506188355
+male,white,50,hs,NC,1,0.519037458
+female,white,63,no hs,AR,0,0.642851377
+male,white,25,some college,CA,1,0.338717892
+male,white,32,post-grad,AK,0,0.583856547
+male,white,66,some college,NY,0,0.382275815
+male,white,57,hs,KY,0,0.65670629
+female,white,57,some college,AL,0,0.643741436
+male,other,37,hs,CA,0,0.338717892
+female,white,40,post-grad,IL,0,0.409799486
+male,other,26,post-grad,MI,0,0.501176682
+female,white,58,hs,TN,1,0.63624343
+male,white,41,some college,UT,1,0.623836582
+female,white,81,some college,TX,1,0.547132256
+female,black,49,4-year college,VA,0,0.471736237
+male,white,45,post-grad,OH,1,0.542676846
+female,white,32,4-year college,IL,0,0.409799486
+male,white,55,post-grad,MA,0,0.353487213
+male,white,37,some college,IN,1,0.601173095
+female,white,26,some college,PA,1,0.503755358
+male,white,61,some college,NJ,0,0.427158099
+male,white,38,hs,NY,0,0.382275815
+male,white,75,hs,IN,1,0.601173095
+male,white,44,post-grad,WA,0,0.412130688
+female,white,64,hs,WI,0,0.50407989
+female,other,45,post-grad,MA,0,0.353487213
+female,white,28,4-year college,AL,0,0.643741436
+male,white,42,post-grad,IN,1,0.601173095
+male,white,57,some college,OH,0,0.542676846
+female,black,37,4-year college,CA,0,0.338717892
+male,white,93,hs,WI,1,0.50407989
+male,white,52,some college,TX,1,0.547132256
+male,white,62,post-grad,VA,1,0.471736237
+male,black,35,4-year college,NC,1,0.519037458
+female,white,30,hs,NV,0,0.487062906
+female,other,29,hs,FL,0,0.506188355
+female,white,68,4-year college,IN,1,0.601173095
+female,white,86,some college,WA,1,0.412130688
+male,white,85,post-grad,OR,1,0.438441611
+female,white,52,hs,NY,1,0.382275815
+male,white,35,hs,IL,1,0.409799486
+female,white,64,some college,NH,0,0.498029716
+male,white,81,some college,WA,1,0.412130688
+female,white,70,post-grad,MI,0,0.501176682
+male,other,21,some college,CA,0,0.338717892
+female,white,95,4-year college,MA,0,0.353487213
+female,white,34,4-year college,WA,0,0.412130688
+female,other,19,hs,IN,0,0.601173095
+female,other,23,no hs,TX,1,0.547132256
+male,white,92,some college,IN,0,0.601173095
+male,white,21,some college,LA,1,0.601716772
+female,black,34,some college,TX,0,0.547132256
+female,white,27,some college,PA,0,0.503755358
+male,white,64,hs,CA,1,0.338717892
+female,white,65,some college,MO,1,0.59818561
+female,black,42,4-year college,MD,0,0.359837503
+male,other,36,some college,CA,0,0.338717892
+male,white,69,no hs,PA,1,0.503755358
+female,white,62,hs,FL,1,0.506188355
+female,white,56,some college,WI,0,0.50407989
+female,black,45,4-year college,MD,0,0.359837503
+female,white,57,some college,MA,0,0.353487213
+male,white,58,hs,AL,1,0.643741436
+male,other,38,post-grad,IL,0,0.409799486
+female,white,82,4-year college,ND,1,0.698092429
+female,other,23,hs,CA,1,0.338717892
+male,black,19,4-year college,GA,1,0.526611726
+male,other,31,4-year college,PA,1,0.503755358
+female,black,21,hs,GA,0,0.526611726
+male,other,29,hs,NC,0,0.519037458
+male,white,52,some college,NY,0,0.382275815
+female,white,57,post-grad,NY,1,0.382275815
+male,white,67,4-year college,CA,1,0.338717892
+female,white,19,4-year college,NY,0,0.382275815
+female,white,41,hs,IL,0,0.409799486
+female,white,33,some college,CA,1,0.338717892
+male,white,72,some college,NV,1,0.487062906
+female,other,52,some college,TX,0,0.547132256
+female,black,33,post-grad,MD,0,0.359837503
+female,white,36,no hs,NC,0,0.519037458
+female,white,69,some college,NE,0,0.635476741
+female,white,22,4-year college,WA,0,0.412130688
+female,white,48,some college,PA,0,0.503755358
+male,white,80,post-grad,IN,1,0.601173095
+male,white,43,hs,UT,0,0.623836582
+female,black,47,hs,OH,0,0.542676846
+female,other,59,some college,TX,1,0.547132256
+male,white,89,hs,OH,0,0.542676846
+female,other,37,hs,CA,0,0.338717892
+female,white,35,some college,OH,0,0.542676846
+female,white,69,some college,TX,1,0.547132256
+female,white,69,hs,FL,1,0.506188355
+female,other,30,4-year college,GA,0,0.526611726
+female,white,94,hs,PA,1,0.503755358
+female,white,36,some college,PA,0,0.503755358
+female,other,49,some college,CA,0,0.338717892
+female,white,35,some college,WI,0,0.50407989
+male,white,93,post-grad,WI,0,0.50407989
+female,other,23,post-grad,FL,0,0.506188355
+female,white,93,some college,NY,0,0.382275815
+male,white,31,post-grad,NC,1,0.519037458
+female,black,38,no hs,MD,0,0.359837503
+male,white,52,hs,SC,0,0.574602564
+female,white,62,post-grad,PA,1,0.503755358
+male,other,29,some college,IL,1,0.409799486
+female,white,18,4-year college,MA,0,0.353487213
+male,white,19,some college,OH,0,0.542676846
+male,white,82,post-grad,CT,1,0.428584525
+male,white,83,some college,MS,1,0.590898473
+female,white,74,no hs,UT,1,0.623836582
+male,white,61,hs,KY,1,0.65670629
+male,white,34,some college,IN,1,0.601173095
+male,white,37,4-year college,WI,1,0.50407989
+male,white,47,hs,MA,0,0.353487213
+female,white,49,hs,DE,1,0.440013786
+male,white,53,hs,MA,1,0.353487213
+female,white,68,post-grad,SC,1,0.574602564
+female,white,65,some college,NV,0,0.487062906
+female,white,33,hs,CA,0,0.338717892
+male,white,53,hs,WA,0,0.412130688
+female,white,51,4-year college,MN,0,0.491681431
+female,black,59,hs,IL,0,0.409799486
+male,white,43,hs,NY,0,0.382275815
+male,white,65,post-grad,HI,0,0.325586625
+male,white,66,hs,CT,0,0.428584525
+female,other,23,4-year college,NC,0,0.519037458
+female,white,68,hs,OH,0,0.542676846
+male,white,89,hs,OR,0,0.438441611
+male,white,35,hs,TX,1,0.547132256
+female,other,39,hs,OK,0,0.693047372
+female,black,26,some college,CO,0,0.473166666
+male,white,69,some college,KY,0,0.65670629
+female,other,38,post-grad,CA,0,0.338717892
+female,white,38,post-grad,FL,0,0.506188355
+female,black,34,no hs,PA,0,0.503755358
+male,white,53,some college,RI,0,0.416892959
+female,white,29,some college,NC,0,0.519037458
+male,white,98,hs,FL,1,0.506188355
+female,white,47,some college,CA,0,0.338717892
+male,white,62,hs,SC,0,0.574602564
+female,white,37,hs,NY,0,0.382275815
+male,white,40,hs,NY,0,0.382275815
+female,white,77,post-grad,AL,0,0.643741436
+female,white,20,some college,PA,1,0.503755358
+male,white,54,hs,NY,0,0.382275815
+female,white,54,4-year college,NY,0,0.382275815
+female,white,19,no hs,WV,1,0.721610523
+female,white,54,post-grad,CA,0,0.338717892
+female,white,27,some college,RI,0,0.416892959
+female,white,23,some college,WV,1,0.721610523
+female,other,48,some college,IL,0,0.409799486
+female,white,47,hs,OR,1,0.438441611
+male,other,28,some college,CA,1,0.338717892
+male,white,23,4-year college,NY,0,0.382275815
+male,other,58,4-year college,FL,1,0.506188355
+male,other,62,4-year college,NH,1,0.498029716
+male,white,36,4-year college,NH,1,0.498029716
+female,other,27,post-grad,MA,1,0.353487213
+female,white,66,4-year college,MA,0,0.353487213
+female,black,51,hs,IL,0,0.409799486
+female,white,22,some college,TX,0,0.547132256
+male,white,65,hs,IN,1,0.601173095
+female,white,40,hs,WI,0,0.50407989
+male,other,33,some college,FL,0,0.506188355
+female,other,32,hs,IL,0,0.409799486
+male,other,51,hs,NY,0,0.382275815
+male,white,65,hs,IL,0,0.409799486
+female,other,33,hs,MN,1,0.491681431
+female,white,18,4-year college,TX,0,0.547132256
+female,white,64,some college,GA,1,0.526611726
+male,other,26,some college,CA,0,0.338717892
+female,other,25,4-year college,AL,0,0.643741436
+female,white,66,post-grad,GA,1,0.526611726
+female,black,62,4-year college,LA,0,0.601716772
+female,white,55,hs,MA,0,0.353487213
+female,white,71,4-year college,CA,0,0.338717892
+female,white,37,no hs,GA,0,0.526611726
+female,white,47,hs,LA,0,0.601716772
+female,white,37,some college,CT,1,0.428584525
+female,white,97,hs,NC,1,0.519037458
+male,white,69,post-grad,AZ,0,0.518900234
+female,other,39,hs,TX,1,0.547132256
+female,white,68,post-grad,MN,0,0.491681431
+male,white,66,post-grad,UT,1,0.623836582
+female,white,63,hs,KY,0,0.65670629
+female,white,37,some college,NV,1,0.487062906
+female,white,40,hs,CO,0,0.473166666
+female,white,30,post-grad,GA,0,0.526611726
+female,black,49,some college,NC,1,0.519037458
+male,white,67,hs,NJ,1,0.427158099
+female,other,27,some college,CA,1,0.338717892
+female,white,44,post-grad,TN,0,0.63624343
+male,white,75,post-grad,CA,1,0.338717892
+female,white,24,some college,TX,1,0.547132256
+female,white,49,post-grad,VA,1,0.471736237
+female,white,47,4-year college,NJ,0,0.427158099
+male,white,39,some college,OK,1,0.693047372
+male,other,65,hs,MO,0,0.59818561
+male,white,59,4-year college,TX,1,0.547132256
+female,white,48,4-year college,WI,1,0.50407989
+female,white,36,post-grad,PA,0,0.503755358
+female,black,52,some college,MD,0,0.359837503
+male,other,21,hs,CA,0,0.338717892
+female,white,34,4-year college,IN,1,0.601173095
+male,white,22,post-grad,MD,0,0.359837503
+male,white,83,4-year college,FL,1,0.506188355
+male,white,77,hs,NY,1,0.382275815
+female,white,46,some college,NY,1,0.382275815
+male,white,50,post-grad,UT,1,0.623836582
+female,white,96,some college,PA,0,0.503755358
+female,white,24,hs,PA,1,0.503755358
+female,white,47,post-grad,MI,0,0.501176682
+female,white,29,4-year college,FL,0,0.506188355
+female,white,57,hs,NV,1,0.487062906
+female,white,65,4-year college,TX,0,0.547132256
+female,white,67,hs,GA,1,0.526611726
+female,white,63,hs,PA,0,0.503755358
+female,white,30,4-year college,OK,1,0.693047372
+female,white,33,4-year college,CT,0,0.428584525
+female,white,58,hs,NJ,0,0.427158099
+female,white,81,4-year college,CA,1,0.338717892
+male,other,26,some college,AZ,0,0.518900234
+female,white,51,some college,NY,0,0.382275815
+female,other,22,post-grad,TX,0,0.547132256
+male,white,61,some college,IL,1,0.409799486
+male,white,62,4-year college,OK,1,0.693047372
+female,white,33,hs,NY,0,0.382275815
+male,white,25,some college,ND,0,0.698092429
+female,other,56,4-year college,NJ,0,0.427158099
+female,black,53,hs,VA,1,0.471736237
+female,black,61,hs,SC,0,0.574602564
+male,white,25,some college,VA,0,0.471736237
+female,other,82,some college,TX,1,0.547132256
+male,white,29,no hs,OR,1,0.438441611
+male,white,36,4-year college,NJ,0,0.427158099
+female,white,54,4-year college,TX,0,0.547132256
+female,white,18,4-year college,IL,1,0.409799486
+male,white,27,hs,WI,1,0.50407989
+female,white,46,some college,FL,0,0.506188355
+female,other,22,no hs,NY,0,0.382275815
+female,white,57,some college,HI,1,0.325586625
+female,black,39,post-grad,TN,0,0.63624343
+male,white,33,hs,KS,0,0.611114703
+female,other,32,some college,NY,0,0.382275815
+female,white,69,some college,PA,0,0.503755358
+male,white,36,4-year college,MI,1,0.501176682
+male,white,51,post-grad,PA,0,0.503755358
+female,other,25,post-grad,IL,0,0.409799486
+female,white,62,hs,ID,1,0.683101767
+female,white,80,hs,MD,0,0.359837503
+female,other,28,some college,IN,1,0.601173095
+male,white,40,hs,IA,0,0.550635478
+male,black,43,4-year college,TX,0,0.547132256
+male,other,27,hs,FL,1,0.506188355
+male,black,58,some college,FL,0,0.506188355
+male,white,84,some college,CA,0,0.338717892
+female,white,50,some college,WI,0,0.50407989
+female,other,30,hs,NY,0,0.382275815
+female,white,32,hs,NE,0,0.635476741
+female,white,64,hs,FL,1,0.506188355
+male,white,92,some college,ID,1,0.683101767
+male,other,46,hs,FL,0,0.506188355
+male,white,61,4-year college,CA,0,0.338717892
+male,white,39,4-year college,TX,0,0.547132256
+male,white,60,no hs,NC,1,0.519037458
+male,white,88,hs,TX,1,0.547132256
+female,white,28,hs,PA,0,0.503755358
+female,white,68,some college,KY,1,0.65670629
+female,black,48,some college,TX,1,0.547132256
+female,other,26,post-grad,CA,0,0.338717892
+male,white,48,hs,AL,1,0.643741436
+female,white,50,some college,TX,1,0.547132256
+female,black,58,4-year college,MI,0,0.501176682
+female,white,28,hs,MA,0,0.353487213
+male,white,81,hs,GA,1,0.526611726
+female,other,28,some college,CA,0,0.338717892
+male,white,95,post-grad,HI,0,0.325586625
+female,white,21,4-year college,NY,0,0.382275815
+female,white,48,hs,NY,1,0.382275815
+female,other,30,4-year college,CO,0,0.473166666
+female,white,32,hs,TX,1,0.547132256
+female,white,66,some college,GA,1,0.526611726
+male,white,38,some college,TX,0,0.547132256
+female,white,32,some college,PA,0,0.503755358
+male,black,45,4-year college,OH,0,0.542676846
+female,white,93,hs,NY,0,0.382275815
+female,white,26,4-year college,OR,0,0.438441611
+female,black,54,some college,MS,1,0.590898473
+female,white,66,hs,PA,0,0.503755358
+female,white,62,post-grad,GA,1,0.526611726
+female,other,57,hs,NY,1,0.382275815
+male,other,47,4-year college,NY,1,0.382275815
+female,white,42,some college,CO,1,0.473166666
+female,other,43,some college,CA,0,0.338717892
+male,white,97,hs,FL,0,0.506188355
+male,white,18,4-year college,TX,0,0.547132256
+male,white,54,some college,NC,1,0.519037458
+female,white,49,post-grad,CT,0,0.428584525
+male,white,97,post-grad,WA,1,0.412130688
+male,white,28,some college,CA,1,0.338717892
+female,white,74,hs,NY,0,0.382275815
+female,white,44,4-year college,FL,1,0.506188355
+male,white,39,some college,CA,1,0.338717892
+female,white,66,hs,WI,0,0.50407989
+female,white,37,some college,MA,1,0.353487213
+male,white,59,4-year college,OH,0,0.542676846
+male,white,21,4-year college,FL,0,0.506188355
+female,white,68,4-year college,MI,0,0.501176682
+female,white,29,4-year college,CA,0,0.338717892
+female,white,47,hs,MA,0,0.353487213
+female,white,62,post-grad,ND,0,0.698092429
+male,white,40,no hs,GA,1,0.526611726
+male,white,46,4-year college,TN,1,0.63624343
+female,white,60,some college,MI,0,0.501176682
+female,white,50,4-year college,MO,1,0.59818561
+male,white,65,hs,PA,1,0.503755358
+female,white,49,no hs,TX,1,0.547132256
+male,white,62,hs,TN,1,0.63624343
+female,white,64,hs,RI,0,0.416892959
+male,white,47,4-year college,TN,1,0.63624343
+female,white,28,4-year college,PA,0,0.503755358
+female,white,42,hs,GA,0,0.526611726
+female,white,19,some college,IN,1,0.601173095
+female,white,23,hs,AZ,1,0.518900234
+female,other,28,4-year college,WI,0,0.50407989
+female,white,66,hs,NJ,1,0.427158099
+male,white,37,some college,CT,1,0.428584525
+female,black,56,hs,TN,1,0.63624343
+female,white,51,hs,FL,1,0.506188355
+male,other,55,4-year college,CA,1,0.338717892
+female,other,30,4-year college,NY,0,0.382275815
+male,other,53,post-grad,TX,1,0.547132256
+male,white,62,some college,MD,1,0.359837503
+female,white,38,4-year college,WA,1,0.412130688
+male,white,60,some college,AZ,1,0.518900234
+female,other,46,some college,FL,0,0.506188355
+female,other,29,some college,CA,0,0.338717892
+male,white,85,post-grad,MO,0,0.59818561
+male,black,22,some college,CA,0,0.338717892
+male,other,51,4-year college,MA,0,0.353487213
+female,black,20,some college,TN,0,0.63624343
+male,white,73,post-grad,TX,0,0.547132256
+male,white,34,post-grad,NV,1,0.487062906
+male,white,36,some college,FL,0,0.506188355
+male,white,59,some college,TX,1,0.547132256
+male,other,95,4-year college,TX,1,0.547132256
+female,white,54,some college,NH,0,0.498029716
+female,white,26,no hs,GA,0,0.526611726
+male,black,55,4-year college,NC,0,0.519037458
+male,white,38,4-year college,CO,0,0.473166666
+female,white,70,some college,IL,1,0.409799486
+male,white,50,hs,OR,1,0.438441611
+male,white,46,4-year college,MN,1,0.491681431
+female,white,90,hs,FL,0,0.506188355
+female,other,25,hs,SC,1,0.574602564
+female,white,30,hs,TX,1,0.547132256
+female,black,44,4-year college,TX,1,0.547132256
+female,white,31,hs,NH,1,0.498029716
+female,white,66,hs,MA,0,0.353487213
+female,white,96,post-grad,AZ,0,0.518900234
+female,white,89,hs,PA,1,0.503755358
+female,white,55,hs,AL,1,0.643741436
+male,white,61,4-year college,TX,1,0.547132256
+male,white,42,some college,ME,0,0.484032089
+male,white,66,some college,FL,0,0.506188355
+female,white,67,some college,TX,1,0.547132256
+female,white,56,hs,OK,1,0.693047372
+male,white,63,some college,CA,0,0.338717892
+female,white,100,post-grad,MD,1,0.359837503
+male,other,45,some college,FL,1,0.506188355
+female,white,85,post-grad,MA,0,0.353487213
+female,white,95,no hs,NY,1,0.382275815
+female,white,57,hs,UT,1,0.623836582
+male,white,55,hs,CO,1,0.473166666
+male,white,48,hs,TX,0,0.547132256
+male,white,36,some college,AZ,0,0.518900234
+female,white,20,some college,NJ,0,0.427158099
+male,black,57,some college,TX,0,0.547132256
+female,white,51,no hs,NY,0,0.382275815
+male,white,58,some college,CA,0,0.338717892
+female,white,55,some college,TX,0,0.547132256
+female,black,35,some college,TX,1,0.547132256
+female,other,39,4-year college,WA,1,0.412130688
+female,other,41,hs,CA,0,0.338717892
+female,white,51,post-grad,IL,0,0.409799486
+male,white,60,hs,KY,0,0.65670629
+female,white,66,hs,OH,1,0.542676846
+female,white,53,4-year college,MI,1,0.501176682
+female,white,20,no hs,OH,0,0.542676846
+female,white,69,some college,TX,1,0.547132256
+female,white,44,hs,TN,0,0.63624343
+male,white,52,some college,CA,0,0.338717892
+male,white,33,hs,CA,1,0.338717892
+female,white,24,hs,NC,1,0.519037458
+female,white,26,some college,WV,0,0.721610523
+male,white,53,some college,NV,0,0.487062906
+female,white,78,4-year college,TX,1,0.547132256
+male,black,25,hs,NV,0,0.487062906
+male,other,37,some college,CA,1,0.338717892
+female,other,77,some college,CA,1,0.338717892
+male,white,39,hs,KY,0,0.65670629
+female,white,49,some college,IN,1,0.601173095
+female,white,56,some college,MO,1,0.59818561
+female,other,34,some college,MA,0,0.353487213
+male,white,44,post-grad,WA,0,0.412130688
+female,white,64,post-grad,TX,1,0.547132256
+female,white,39,4-year college,ND,0,0.698092429
+female,white,26,4-year college,SC,0,0.574602564
+female,white,76,some college,TX,1,0.547132256
+male,white,94,post-grad,AZ,0,0.518900234
+male,white,57,some college,MI,1,0.501176682
+female,white,21,some college,MD,0,0.359837503
+male,other,63,some college,CA,0,0.338717892
+female,white,55,post-grad,FL,0,0.506188355
+female,white,21,4-year college,NY,1,0.382275815
+female,other,53,some college,CO,1,0.473166666
+male,other,65,4-year college,TN,1,0.63624343
+female,white,76,hs,TX,1,0.547132256
+male,white,20,some college,FL,1,0.506188355
+female,other,27,hs,OH,0,0.542676846
+male,other,39,some college,NC,0,0.519037458
+female,white,61,hs,CA,0,0.338717892
+female,white,20,hs,MO,0,0.59818561
+female,other,59,hs,TX,0,0.547132256
+male,other,45,4-year college,IL,1,0.409799486
+male,white,74,post-grad,CA,0,0.338717892
+male,white,53,4-year college,IN,0,0.601173095
+female,other,19,hs,PA,1,0.503755358
+male,white,91,post-grad,ID,0,0.683101767
+female,black,38,some college,FL,0,0.506188355
+female,white,51,hs,FL,0,0.506188355
+female,white,41,hs,MA,0,0.353487213
+female,white,96,hs,NC,1,0.519037458
+male,other,53,4-year college,TX,1,0.547132256
+male,other,61,some college,IN,0,0.601173095
+female,white,40,some college,MN,1,0.491681431
+male,white,55,hs,IL,1,0.409799486
+male,white,65,hs,FL,1,0.506188355
+female,white,30,post-grad,MO,0,0.59818561
+female,white,57,4-year college,NJ,1,0.427158099
+male,white,82,some college,IN,0,0.601173095
+female,white,38,some college,AL,1,0.643741436
+male,white,62,some college,IL,0,0.409799486
+male,white,50,some college,TX,1,0.547132256
+female,white,49,some college,WV,0,0.721610523
+female,white,37,some college,MD,0,0.359837503
+male,white,65,hs,MI,0,0.501176682
+female,white,35,4-year college,CO,1,0.473166666
+female,other,59,4-year college,NY,1,0.382275815
+male,white,63,post-grad,CA,0,0.338717892
+male,white,37,4-year college,NH,0,0.498029716
+male,other,25,some college,CA,1,0.338717892
+male,black,44,4-year college,OK,0,0.693047372
+female,white,65,hs,TX,1,0.547132256
+male,white,51,hs,CA,1,0.338717892
+male,white,71,hs,KY,1,0.65670629
+female,black,30,4-year college,AL,0,0.643741436
+female,white,61,some college,PA,1,0.503755358
+male,white,77,post-grad,NC,0,0.519037458
+female,other,59,some college,AZ,0,0.518900234
+male,white,45,4-year college,SD,0,0.659718581
+male,white,36,post-grad,CA,1,0.338717892
+female,other,55,some college,CA,0,0.338717892
+female,white,33,some college,AZ,0,0.518900234
+female,white,68,some college,ME,1,0.484032089
+female,black,34,hs,VA,1,0.471736237
+female,white,68,post-grad,NY,0,0.382275815
+male,white,24,4-year college,OH,0,0.542676846
+male,white,38,4-year college,ND,1,0.698092429
+female,white,100,hs,PA,1,0.503755358
+female,white,71,post-grad,AR,0,0.642851377
+male,white,29,hs,MS,1,0.590898473
+female,white,44,some college,PA,1,0.503755358
+female,white,23,no hs,NY,0,0.382275815
+male,other,29,hs,MI,1,0.501176682
+female,white,38,hs,OR,1,0.438441611
+female,white,54,some college,TX,0,0.547132256
+male,other,53,4-year college,CT,1,0.428584525
+male,white,67,hs,AR,1,0.642851377
+male,white,42,hs,SC,1,0.574602564
+female,white,41,hs,NY,1,0.382275815
+male,white,34,some college,OH,0,0.542676846
+male,white,27,some college,OH,0,0.542676846
+male,white,69,4-year college,NY,1,0.382275815
+female,white,39,some college,AR,1,0.642851377
+male,white,50,post-grad,WI,0,0.50407989
+male,black,23,4-year college,MD,0,0.359837503
+female,other,22,no hs,FL,0,0.506188355
+female,white,39,hs,TX,0,0.547132256
+female,white,41,hs,NC,1,0.519037458
+male,other,37,4-year college,CO,1,0.473166666
+female,black,35,hs,VA,0,0.471736237
+female,white,52,post-grad,VA,0,0.471736237
+male,white,89,post-grad,LA,0,0.601716772
+male,white,78,hs,FL,1,0.506188355
+female,white,57,some college,AZ,1,0.518900234
+female,white,69,4-year college,MT,1,0.611096643
+male,white,58,post-grad,VT,0,0.348135737
+male,white,60,hs,NH,0,0.498029716
+female,white,51,some college,LA,0,0.601716772
+female,white,70,4-year college,FL,0,0.506188355
+male,white,69,hs,FL,1,0.506188355
+male,black,66,4-year college,OH,1,0.542676846
+female,white,60,post-grad,NY,0,0.382275815
+male,white,65,some college,PA,0,0.503755358
+female,other,34,some college,TX,1,0.547132256
+male,white,74,some college,OR,0,0.438441611
+female,other,55,post-grad,FL,0,0.506188355
+male,white,86,hs,MI,1,0.501176682
+female,white,94,hs,MS,1,0.590898473
+male,white,87,post-grad,AZ,0,0.518900234
+male,other,24,post-grad,OH,0,0.542676846
+female,white,22,4-year college,FL,0,0.506188355
+male,white,42,no hs,NY,0,0.382275815
+female,white,95,hs,TN,1,0.63624343
+female,white,59,some college,NC,1,0.519037458
+male,white,23,post-grad,VA,0,0.471736237
+male,white,18,some college,FL,1,0.506188355
+male,white,68,some college,NV,1,0.487062906
+female,white,18,some college,CA,0,0.338717892
+male,black,58,4-year college,LA,0,0.601716772
+male,white,49,4-year college,DE,1,0.440013786
+male,white,68,4-year college,NY,1,0.382275815
+male,white,59,post-grad,PA,1,0.503755358
+female,white,37,hs,MI,0,0.501176682
+female,other,33,4-year college,CO,0,0.473166666
+female,white,22,4-year college,MD,0,0.359837503
+female,white,45,post-grad,SC,0,0.574602564
+female,white,38,no hs,UT,0,0.623836582
+female,white,37,4-year college,MA,0,0.353487213
+female,white,57,some college,NY,0,0.382275815
+female,other,28,no hs,NY,1,0.382275815
+female,white,53,hs,NJ,1,0.427158099
+male,white,58,4-year college,OH,1,0.542676846
+male,white,33,hs,NY,0,0.382275815
+female,white,55,some college,IL,1,0.409799486
+female,white,67,4-year college,GA,0,0.526611726
+male,white,85,post-grad,FL,0,0.506188355
+female,white,49,4-year college,MS,0,0.590898473
+female,white,20,hs,WV,0,0.721610523
+male,white,44,some college,CO,0,0.473166666
+female,black,30,some college,FL,0,0.506188355
+female,white,21,some college,MN,0,0.491681431
+male,white,45,post-grad,TN,0,0.63624343
+male,white,31,some college,FL,0,0.506188355
+female,white,23,hs,IA,1,0.550635478
+female,white,50,some college,OH,0,0.542676846
+male,white,43,some college,IL,1,0.409799486
+female,white,41,some college,TN,0,0.63624343
+female,white,62,post-grad,FL,0,0.506188355
+male,white,100,hs,IN,0,0.601173095
+female,white,100,post-grad,FL,0,0.506188355
+male,white,51,post-grad,FL,1,0.506188355
+female,white,62,some college,AZ,1,0.518900234
+male,white,55,some college,HI,0,0.325586625
+male,white,69,4-year college,TX,1,0.547132256
+male,other,24,some college,CA,0,0.338717892
+female,white,31,some college,FL,0,0.506188355
+female,white,42,no hs,MI,0,0.501176682
+female,other,31,4-year college,KY,0,0.65670629
+male,white,41,hs,MA,0,0.353487213
+female,black,36,some college,IL,1,0.409799486
+female,white,63,4-year college,MD,0,0.359837503
+male,white,22,some college,GA,0,0.526611726
+female,white,23,4-year college,CO,0,0.473166666
+male,white,56,hs,TN,0,0.63624343
+female,white,41,hs,CA,0,0.338717892
+female,white,74,hs,ND,0,0.698092429
+female,black,57,some college,NE,0,0.635476741
+male,white,24,4-year college,WI,0,0.50407989
+female,white,51,some college,FL,1,0.506188355
+female,white,49,some college,MT,1,0.611096643
+male,other,25,4-year college,OH,0,0.542676846
+female,white,33,hs,TX,0,0.547132256
+female,white,29,some college,OH,0,0.542676846
+male,white,96,post-grad,VA,0,0.471736237
+male,white,51,hs,VA,1,0.471736237
+female,black,55,no hs,MD,1,0.359837503
+female,white,55,4-year college,FL,0,0.506188355
+female,other,33,4-year college,MO,1,0.59818561
+female,white,89,hs,UT,0,0.623836582
+female,white,22,post-grad,WV,0,0.721610523
+female,white,53,some college,OH,1,0.542676846
+female,white,71,hs,MN,0,0.491681431
+male,other,18,no hs,OK,0,0.693047372
+male,white,37,hs,VA,0,0.471736237
+male,white,67,hs,IN,0,0.601173095
+male,white,59,some college,OR,0,0.438441611
+male,other,25,post-grad,CA,0,0.338717892
+male,white,59,hs,NH,1,0.498029716
+male,white,62,some college,IL,0,0.409799486
+male,white,65,some college,PA,1,0.503755358
+female,white,54,hs,RI,0,0.416892959
+male,white,31,4-year college,TX,1,0.547132256
+male,white,32,no hs,OH,1,0.542676846
+female,black,39,hs,OK,0,0.693047372
+female,white,79,hs,MI,1,0.501176682
+female,white,66,4-year college,NM,1,0.453492051
+female,white,57,some college,PA,1,0.503755358
+female,white,21,hs,NC,0,0.519037458
+female,white,32,post-grad,LA,0,0.601716772
+female,white,69,some college,CA,1,0.338717892
+female,white,68,hs,VA,0,0.471736237
+female,other,45,4-year college,CA,0,0.338717892
+female,white,43,some college,TN,1,0.63624343
+female,other,41,post-grad,NY,0,0.382275815
+female,white,23,hs,KY,1,0.65670629
+female,white,41,some college,WY,0,0.757053196
+male,black,23,hs,LA,1,0.601716772
+female,other,18,post-grad,FL,0,0.506188355
+female,other,42,hs,FL,1,0.506188355
+male,white,25,4-year college,NY,0,0.382275815
+female,white,69,some college,NV,1,0.487062906
+male,other,24,4-year college,AZ,0,0.518900234
+female,white,45,hs,TN,1,0.63624343
+female,white,66,4-year college,TX,1,0.547132256
+male,white,29,4-year college,MO,1,0.59818561
+female,other,51,some college,FL,1,0.506188355
+female,other,28,4-year college,VA,0,0.471736237
+male,white,63,post-grad,CA,0,0.338717892
+female,black,23,some college,GA,0,0.526611726
+female,white,69,some college,OH,0,0.542676846
+female,white,59,hs,FL,0,0.506188355
+female,white,40,post-grad,AL,0,0.643741436
+female,white,52,some college,AZ,0,0.518900234
+female,black,55,post-grad,NC,0,0.519037458
+male,white,77,post-grad,IA,0,0.550635478
+female,black,30,4-year college,MD,0,0.359837503
+female,white,22,4-year college,ME,0,0.484032089
+female,other,37,some college,TX,1,0.547132256
+female,black,52,hs,NY,0,0.382275815
+female,white,57,hs,MA,1,0.353487213
+female,white,84,hs,CO,0,0.473166666
+female,black,45,4-year college,CA,0,0.338717892
+female,other,34,hs,AR,0,0.642851377
+female,white,42,some college,OH,0,0.542676846
+male,white,22,some college,NH,1,0.498029716
+female,other,39,some college,FL,0,0.506188355
+male,white,62,some college,VA,0,0.471736237
+female,white,58,post-grad,AZ,1,0.518900234
+male,white,79,hs,AZ,1,0.518900234
+male,white,42,hs,NC,0,0.519037458
+female,white,21,hs,WA,0,0.412130688
+female,white,18,some college,MI,0,0.501176682
+female,white,64,hs,NY,0,0.382275815
+male,white,98,4-year college,TX,0,0.547132256
+male,white,79,some college,NC,1,0.519037458
+female,white,45,4-year college,NY,0,0.382275815
+male,white,59,4-year college,CA,0,0.338717892
+male,black,45,4-year college,GA,1,0.526611726
+male,other,57,4-year college,AZ,0,0.518900234
+male,white,56,4-year college,NC,0,0.519037458
+female,black,37,4-year college,OH,1,0.542676846
+female,white,33,some college,CA,0,0.338717892
+female,other,37,some college,TN,1,0.63624343
+female,white,63,some college,NC,0,0.519037458
+female,white,24,4-year college,MI,0,0.501176682
+male,other,41,4-year college,FL,0,0.506188355
+male,white,49,4-year college,OR,1,0.438441611
+male,white,24,hs,WA,0,0.412130688
+male,white,63,hs,MO,0,0.59818561
+female,white,59,hs,OH,1,0.542676846
+female,other,34,some college,TX,0,0.547132256
+female,white,32,post-grad,MI,0,0.501176682
+male,white,59,4-year college,FL,1,0.506188355
+female,other,36,some college,TX,0,0.547132256
+male,black,57,4-year college,NY,0,0.382275815
+male,black,29,hs,CA,0,0.338717892
+male,white,21,hs,MD,1,0.359837503
+female,black,41,some college,IL,0,0.409799486
+male,white,36,some college,PA,0,0.503755358
+male,white,42,some college,WI,0,0.50407989
+female,other,43,4-year college,KY,1,0.65670629
+male,white,53,4-year college,PA,0,0.503755358
+female,black,55,post-grad,IL,0,0.409799486
+male,other,25,hs,NY,0,0.382275815
+male,other,51,some college,CA,0,0.338717892
+female,white,22,some college,VA,0,0.471736237
+female,white,55,4-year college,AZ,0,0.518900234
+female,white,55,4-year college,TX,1,0.547132256
+female,white,24,some college,TX,0,0.547132256
+female,white,53,hs,PA,0,0.503755358
+male,white,58,some college,IL,1,0.409799486
+female,white,21,some college,NC,1,0.519037458
+male,other,23,some college,CA,0,0.338717892
+female,other,25,4-year college,VT,0,0.348135737
+female,white,52,some college,MN,0,0.491681431
+male,white,48,no hs,NC,1,0.519037458
+male,other,35,some college,CA,0,0.338717892
+female,white,51,some college,CA,1,0.338717892
+male,white,46,post-grad,NE,0,0.635476741
+male,white,35,4-year college,NE,0,0.635476741
+male,white,24,4-year college,TX,0,0.547132256
+female,other,21,post-grad,IL,1,0.409799486
+male,white,66,some college,IL,1,0.409799486
+female,white,91,post-grad,NY,0,0.382275815
+male,white,61,4-year college,CA,0,0.338717892
+female,white,68,some college,PA,1,0.503755358
+male,white,58,some college,CA,0,0.338717892
+male,other,25,4-year college,FL,0,0.506188355
+female,white,73,hs,NY,0,0.382275815
+female,white,34,post-grad,CO,0,0.473166666
+male,white,90,4-year college,WA,0,0.412130688
+male,white,62,some college,IA,0,0.550635478
+male,white,19,hs,NC,1,0.519037458
+female,white,28,some college,IL,1,0.409799486
+female,white,21,some college,PA,0,0.503755358
+female,other,20,4-year college,FL,1,0.506188355
+female,white,23,hs,VA,1,0.471736237
+female,black,19,4-year college,GA,1,0.526611726
+male,white,30,hs,WV,0,0.721610523
+female,other,36,post-grad,AZ,1,0.518900234
+female,black,61,hs,NY,0,0.382275815
+female,black,90,no hs,IL,0,0.409799486
+female,other,26,no hs,CA,1,0.338717892
+male,white,63,hs,MA,0,0.353487213
+male,white,29,no hs,IN,1,0.601173095
+female,white,39,post-grad,CO,0,0.473166666
+female,white,56,hs,TN,1,0.63624343
+male,white,39,4-year college,GA,1,0.526611726
+male,white,24,4-year college,CA,0,0.338717892
+female,other,30,hs,OH,0,0.542676846
+female,white,37,4-year college,TX,1,0.547132256
+female,black,31,some college,NJ,1,0.427158099
+male,white,85,post-grad,CA,1,0.338717892
+female,white,26,4-year college,VA,0,0.471736237
+female,white,18,4-year college,CT,0,0.428584525
+female,white,62,hs,IN,0,0.601173095
+male,other,35,hs,NY,0,0.382275815
+male,white,59,hs,TX,1,0.547132256
+female,white,67,post-grad,IN,1,0.601173095
+male,white,37,some college,LA,0,0.601716772
+female,other,26,4-year college,OH,0,0.542676846
+female,black,69,some college,GA,1,0.526611726
+male,white,77,post-grad,FL,1,0.506188355
+female,other,22,some college,CA,0,0.338717892
+female,white,62,4-year college,NJ,0,0.427158099
+female,other,67,hs,TX,1,0.547132256
+male,white,24,some college,OH,1,0.542676846
+female,white,37,some college,TN,0,0.63624343
+male,white,53,some college,AZ,0,0.518900234
+female,white,37,hs,PA,0,0.503755358
+female,white,59,hs,CA,0,0.338717892
+female,white,40,some college,FL,0,0.506188355
+female,white,56,some college,CA,1,0.338717892
+female,white,20,hs,FL,0,0.506188355
+female,other,28,post-grad,CA,1,0.338717892
+female,white,54,hs,PA,0,0.503755358
+male,white,90,post-grad,HI,1,0.325586625
+female,white,53,hs,FL,1,0.506188355
+female,black,89,hs,FL,0,0.506188355
+female,white,39,4-year college,CA,0,0.338717892
+female,other,22,hs,NM,1,0.453492051
+male,white,85,post-grad,IL,1,0.409799486
+female,white,30,hs,TX,1,0.547132256
+male,black,18,hs,NC,1,0.519037458
+male,white,63,hs,IA,0,0.550635478
+female,white,48,hs,NY,0,0.382275815
+male,white,90,hs,NC,1,0.519037458
+male,other,29,some college,CO,0,0.473166666
+male,white,64,some college,MI,0,0.501176682
+male,white,25,post-grad,AR,1,0.642851377
+male,other,45,post-grad,FL,1,0.506188355
+female,white,63,hs,NY,1,0.382275815
+male,white,51,some college,NY,0,0.382275815
+female,white,23,post-grad,CA,0,0.338717892
+female,white,41,4-year college,OH,0,0.542676846
+female,white,19,some college,MS,1,0.590898473
+male,other,43,4-year college,FL,0,0.506188355
+male,white,78,no hs,PA,0,0.503755358
+female,white,70,post-grad,AR,0,0.642851377
+female,white,63,post-grad,MT,0,0.611096643
+female,white,28,some college,GA,0,0.526611726
+female,other,36,some college,KY,1,0.65670629
+female,black,52,4-year college,NY,0,0.382275815
+female,white,23,hs,OK,0,0.693047372
+female,white,70,post-grad,PA,1,0.503755358
+male,white,58,4-year college,TX,0,0.547132256
+male,black,53,some college,NC,0,0.519037458
+male,white,57,post-grad,KY,0,0.65670629
+female,other,25,4-year college,WA,0,0.412130688
+female,white,57,some college,CA,0,0.338717892
+male,white,89,4-year college,DE,1,0.440013786
+male,white,54,4-year college,AZ,1,0.518900234
+male,white,67,no hs,MS,1,0.590898473
+male,white,65,hs,FL,1,0.506188355
+female,white,34,4-year college,MI,1,0.501176682
+male,other,50,post-grad,CA,0,0.338717892
+male,white,19,hs,MI,0,0.501176682
+female,white,36,some college,MI,1,0.501176682
+female,white,37,post-grad,FL,0,0.506188355
+female,white,54,post-grad,MO,0,0.59818561
+female,white,37,4-year college,CO,0,0.473166666
+female,white,66,hs,OR,0,0.438441611
+male,black,24,hs,FL,0,0.506188355
+male,white,77,some college,TX,1,0.547132256
+male,white,83,some college,CA,1,0.338717892
+female,white,36,post-grad,MN,1,0.491681431
+female,white,22,post-grad,AR,0,0.642851377
+female,white,20,some college,UT,1,0.623836582
+female,white,46,4-year college,NM,0,0.453492051
+female,other,30,hs,TX,0,0.547132256
+female,white,92,hs,OH,0,0.542676846
+male,black,56,4-year college,MO,0,0.59818561
+female,white,22,hs,TX,0,0.547132256
+female,white,24,some college,MI,0,0.501176682
+female,white,18,some college,MN,0,0.491681431
+male,white,76,hs,DE,0,0.440013786
+female,white,35,some college,NY,0,0.382275815
+female,white,59,no hs,TX,1,0.547132256
+female,black,45,4-year college,OH,0,0.542676846
+male,white,58,hs,MD,1,0.359837503
+male,white,89,post-grad,TN,0,0.63624343
+female,white,88,some college,CA,1,0.338717892
+male,other,34,4-year college,NC,0,0.519037458
+male,other,52,post-grad,TX,0,0.547132256
+female,white,24,hs,AL,1,0.643741436
+female,white,62,hs,TX,1,0.547132256
+male,white,41,hs,CT,1,0.428584525
+male,white,37,some college,TX,0,0.547132256
+female,other,50,some college,MT,0,0.611096643
+female,white,36,some college,MI,0,0.501176682
+female,white,86,hs,FL,0,0.506188355
+male,white,65,hs,IL,0,0.409799486
+female,white,57,some college,CT,1,0.428584525
+male,white,50,post-grad,GA,1,0.526611726
+female,white,61,some college,TN,1,0.63624343
+female,white,29,4-year college,OK,0,0.693047372
+female,white,47,hs,AZ,1,0.518900234
+female,white,18,some college,NE,1,0.635476741
+male,white,86,hs,NC,0,0.519037458
+male,white,98,post-grad,MA,0,0.353487213
+male,white,21,some college,IL,1,0.409799486
+female,white,62,some college,NC,1,0.519037458
+female,white,52,some college,AZ,1,0.518900234
+female,white,55,hs,PA,0,0.503755358
+male,other,22,post-grad,NY,1,0.382275815
+female,other,46,hs,TX,0,0.547132256
+female,white,40,hs,MI,0,0.501176682
+female,white,62,some college,TX,1,0.547132256
+female,white,38,some college,TN,1,0.63624343
+female,white,36,4-year college,WA,0,0.412130688
+female,white,51,hs,TX,1,0.547132256
+male,white,85,hs,RI,0,0.416892959
+female,black,28,post-grad,IL,0,0.409799486
+female,white,75,hs,NJ,0,0.427158099
+male,white,24,some college,PA,0,0.503755358
+male,white,87,post-grad,AZ,0,0.518900234
+female,white,68,some college,OH,1,0.542676846
+female,white,22,some college,CA,1,0.338717892
+female,white,27,some college,NJ,0,0.427158099
+male,white,48,4-year college,TN,1,0.63624343
+female,white,38,some college,CA,0,0.338717892
+male,other,25,some college,UT,0,0.623836582
+male,white,74,some college,CA,1,0.338717892
+male,other,40,hs,NY,1,0.382275815
+male,black,40,hs,GA,1,0.526611726
+female,white,67,hs,WI,1,0.50407989
+female,white,53,hs,NJ,0,0.427158099
+male,white,64,post-grad,CA,0,0.338717892
+male,white,36,some college,VA,1,0.471736237
+female,white,19,some college,VA,1,0.471736237
+female,white,36,hs,TX,1,0.547132256
+female,black,76,4-year college,NC,1,0.519037458
+female,white,47,hs,WA,0,0.412130688
+female,white,27,4-year college,CA,0,0.338717892
+female,black,25,some college,GA,1,0.526611726
+female,white,88,some college,NY,0,0.382275815
+female,white,58,no hs,KY,1,0.65670629
+female,white,42,hs,AL,0,0.643741436
+male,black,23,some college,TX,0,0.547132256
+male,white,39,some college,TN,1,0.63624343
+female,white,68,some college,NY,1,0.382275815
+female,white,69,post-grad,FL,0,0.506188355
+female,white,47,4-year college,CA,1,0.338717892
+female,white,30,4-year college,IL,0,0.409799486
+male,white,44,some college,NC,0,0.519037458
+male,white,81,post-grad,MO,1,0.59818561
+female,white,34,some college,MS,1,0.590898473
+male,white,31,post-grad,MI,0,0.501176682
+female,white,83,some college,TX,1,0.547132256
+female,white,49,some college,NY,0,0.382275815
+female,white,72,hs,UT,1,0.623836582
+male,white,53,post-grad,CA,0,0.338717892
+male,white,80,hs,WI,0,0.50407989
+male,black,43,hs,VA,1,0.471736237
+female,white,82,hs,NJ,0,0.427158099
+male,white,59,post-grad,TX,0,0.547132256
+female,white,68,4-year college,NJ,1,0.427158099
+male,white,36,post-grad,MN,1,0.491681431
+male,other,46,some college,WV,1,0.721610523
+male,white,61,4-year college,CA,0,0.338717892
+male,white,27,some college,IL,0,0.409799486
+male,white,65,post-grad,CA,1,0.338717892
+female,white,59,hs,FL,1,0.506188355
+female,white,28,some college,SD,0,0.659718581
+female,white,21,4-year college,CO,1,0.473166666
+male,white,77,some college,WA,0,0.412130688
+male,white,86,post-grad,NE,0,0.635476741
+male,white,62,post-grad,CT,1,0.428584525
+female,other,32,4-year college,AZ,0,0.518900234
+female,white,21,some college,MS,1,0.590898473
+male,black,59,some college,TX,0,0.547132256
+male,other,66,post-grad,WA,0,0.412130688
+female,white,52,hs,PA,0,0.503755358
+male,white,36,post-grad,MT,1,0.611096643
+female,white,50,no hs,TN,0,0.63624343
+female,white,21,4-year college,CA,1,0.338717892
+male,white,48,some college,NJ,0,0.427158099
+female,white,24,some college,PA,0,0.503755358
+male,white,69,4-year college,MO,1,0.59818561
+female,white,49,4-year college,IL,1,0.409799486
+male,white,36,hs,MT,0,0.611096643
+female,white,40,some college,FL,0,0.506188355
+female,white,35,4-year college,OH,0,0.542676846
+male,white,55,post-grad,CT,0,0.428584525
+female,white,34,post-grad,OR,0,0.438441611
+male,other,26,hs,WI,1,0.50407989
+female,white,65,some college,ND,0,0.698092429
+female,white,40,post-grad,IL,0,0.409799486
+female,black,36,4-year college,CA,1,0.338717892
+male,white,48,some college,NE,0,0.635476741
+male,white,62,post-grad,NY,0,0.382275815
+male,white,52,4-year college,OH,0,0.542676846
+female,white,66,hs,WI,1,0.50407989
+female,other,29,some college,TX,1,0.547132256
+male,white,46,some college,OH,1,0.542676846
+male,white,67,hs,TX,0,0.547132256
+male,other,35,no hs,GA,1,0.526611726
+female,white,18,some college,TX,1,0.547132256
+female,white,72,4-year college,FL,1,0.506188355
+female,white,57,hs,WV,1,0.721610523
+female,white,62,some college,GA,1,0.526611726
+female,other,27,some college,TX,1,0.547132256
+female,other,57,some college,OH,1,0.542676846
+female,white,96,post-grad,VA,1,0.471736237
+male,white,64,post-grad,WI,1,0.50407989
+female,white,98,4-year college,PA,0,0.503755358
+female,white,54,hs,IL,1,0.409799486
+male,white,74,4-year college,NY,0,0.382275815
+male,black,33,some college,MD,0,0.359837503
+male,white,27,some college,NJ,1,0.427158099
+male,white,38,post-grad,TN,0,0.63624343
+male,white,45,4-year college,TN,0,0.63624343
+female,black,29,some college,MI,0,0.501176682
+male,white,96,some college,FL,0,0.506188355
+female,other,50,4-year college,AZ,1,0.518900234
+female,other,57,no hs,TX,1,0.547132256
+male,white,43,some college,WI,1,0.50407989
+male,other,53,some college,OH,1,0.542676846
+male,white,62,some college,VA,0,0.471736237
+male,white,55,post-grad,TX,1,0.547132256
+male,white,21,hs,KY,0,0.65670629
+female,white,67,post-grad,NC,0,0.519037458
+female,white,62,hs,FL,0,0.506188355
+female,white,67,4-year college,CA,1,0.338717892
+female,white,50,hs,PA,1,0.503755358
+male,white,66,post-grad,CO,1,0.473166666
+male,other,26,no hs,LA,1,0.601716772
+female,white,53,hs,VA,1,0.471736237
+female,white,62,hs,WA,0,0.412130688
+male,white,90,some college,WV,1,0.721610523
+male,other,31,some college,HI,0,0.325586625
+female,other,18,some college,TX,0,0.547132256
+male,white,37,hs,NJ,0,0.427158099
+male,white,56,some college,IL,1,0.409799486
+female,white,25,hs,MI,0,0.501176682
+female,white,27,4-year college,AL,0,0.643741436
+female,white,28,4-year college,MN,0,0.491681431
+female,white,69,no hs,SC,0,0.574602564
+female,white,26,post-grad,CT,0,0.428584525
+female,white,49,some college,CT,0,0.428584525
+female,white,50,some college,NH,1,0.498029716
+female,white,89,hs,WI,1,0.50407989
+male,white,45,post-grad,CA,1,0.338717892
+male,white,59,4-year college,TX,0,0.547132256
+female,white,66,hs,FL,1,0.506188355
+male,other,87,4-year college,OK,1,0.693047372
+female,white,30,4-year college,NJ,0,0.427158099
+male,white,56,some college,MN,1,0.491681431
+female,black,18,hs,AL,0,0.643741436
+male,white,60,some college,NY,0,0.382275815
+male,white,35,post-grad,MA,0,0.353487213
+female,white,95,some college,AL,0,0.643741436
+male,white,78,4-year college,CA,0,0.338717892
+male,white,51,some college,AL,1,0.643741436
+male,white,50,4-year college,MN,0,0.491681431
+female,other,77,4-year college,AZ,0,0.518900234
+female,other,57,4-year college,FL,0,0.506188355
+female,other,46,hs,TX,1,0.547132256
+female,other,24,4-year college,CA,0,0.338717892
+male,other,99,some college,CA,1,0.338717892
+male,other,20,some college,CA,1,0.338717892
+female,other,60,hs,CA,1,0.338717892
+female,white,53,some college,TX,1,0.547132256
+female,white,52,hs,TN,1,0.63624343
+female,white,20,4-year college,OR,0,0.438441611
+male,white,73,hs,NC,0,0.519037458
+female,white,38,some college,WA,1,0.412130688
+male,white,46,post-grad,IN,0,0.601173095
+male,white,61,post-grad,FL,0,0.506188355
+male,white,63,no hs,OR,0,0.438441611
+male,white,45,no hs,GA,1,0.526611726
+male,white,69,some college,TX,1,0.547132256
+male,white,41,some college,AL,1,0.643741436
+female,white,34,hs,TX,1,0.547132256
+female,white,21,some college,OH,0,0.542676846
+female,other,20,4-year college,NY,1,0.382275815
+female,white,38,4-year college,SC,1,0.574602564
+male,white,64,4-year college,MI,1,0.501176682
+female,white,49,some college,AR,1,0.642851377
+female,white,54,hs,ME,0,0.484032089
+male,white,52,post-grad,TX,0,0.547132256
+female,other,28,some college,CA,0,0.338717892
+female,white,44,some college,TX,1,0.547132256
+female,black,50,some college,CA,0,0.338717892
+female,white,34,post-grad,MI,0,0.501176682
+female,other,28,hs,CA,1,0.338717892
+female,white,55,post-grad,FL,0,0.506188355
+male,white,47,some college,CA,1,0.338717892
+female,other,51,hs,OK,0,0.693047372
+male,white,75,post-grad,NM,1,0.453492051
+male,white,31,some college,PA,0,0.503755358
+female,white,72,some college,IA,0,0.550635478
+male,white,74,post-grad,FL,1,0.506188355
+female,white,22,some college,VA,0,0.471736237
+male,other,63,4-year college,WV,1,0.721610523
+male,white,40,post-grad,GA,1,0.526611726
+male,other,40,post-grad,AZ,0,0.518900234
+male,white,51,hs,ID,0,0.683101767
+male,white,31,some college,TN,0,0.63624343
+female,black,42,some college,NJ,0,0.427158099
+female,white,49,hs,AR,1,0.642851377
+male,white,39,4-year college,MI,0,0.501176682
+male,white,59,hs,NC,0,0.519037458
+female,white,67,hs,MO,1,0.59818561
+female,white,66,hs,LA,1,0.601716772
+female,white,35,some college,MN,0,0.491681431
+male,white,79,4-year college,OH,0,0.542676846
+male,white,53,hs,MD,0,0.359837503
+male,white,81,no hs,NC,1,0.519037458
+male,white,77,4-year college,TX,1,0.547132256
+male,other,57,post-grad,NY,0,0.382275815
+female,white,22,post-grad,LA,1,0.601716772
+male,white,28,some college,GA,1,0.526611726
+male,black,45,post-grad,TN,0,0.63624343
+female,white,66,hs,MI,1,0.501176682
+female,white,90,hs,NC,0,0.519037458
+female,white,61,hs,MA,0,0.353487213
+female,white,27,some college,CA,0,0.338717892
+male,other,29,some college,NY,0,0.382275815
+male,white,41,some college,AL,0,0.643741436
+female,white,64,no hs,CT,1,0.428584525
+female,white,31,hs,NY,0,0.382275815
+female,other,21,some college,CA,0,0.338717892
+female,white,79,hs,NY,0,0.382275815
+female,white,52,some college,SC,0,0.574602564
+female,black,61,4-year college,GA,1,0.526611726
+female,white,55,some college,FL,1,0.506188355
+female,black,58,some college,IL,0,0.409799486
+female,white,52,hs,MN,0,0.491681431
+male,white,38,4-year college,OK,0,0.693047372
+male,other,22,post-grad,TX,0,0.547132256
+male,black,37,4-year college,TX,0,0.547132256
+male,white,22,4-year college,WV,1,0.721610523
+female,white,94,some college,ND,0,0.698092429
+female,white,52,post-grad,NE,0,0.635476741
+female,white,44,4-year college,GA,1,0.526611726
+female,white,50,post-grad,OH,1,0.542676846
+male,white,67,some college,OH,0,0.542676846
+female,white,25,some college,CA,0,0.338717892
+female,white,69,some college,OR,1,0.438441611
+female,white,57,hs,NY,0,0.382275815
+male,white,42,post-grad,OR,0,0.438441611
+male,white,30,some college,MN,0,0.491681431
+male,other,79,some college,OH,1,0.542676846
+female,white,59,post-grad,MD,0,0.359837503
+female,white,19,no hs,WA,0,0.412130688
+female,other,29,post-grad,FL,0,0.506188355
+male,white,38,post-grad,MD,0,0.359837503
+female,white,53,post-grad,OK,0,0.693047372
+male,white,57,hs,OH,1,0.542676846
+female,other,22,some college,IL,1,0.409799486
+female,black,21,4-year college,GA,1,0.526611726
+female,black,25,some college,MA,0,0.353487213
+female,white,54,post-grad,OH,0,0.542676846
+female,black,24,post-grad,GA,1,0.526611726
+female,white,53,some college,OH,0,0.542676846
+female,white,83,post-grad,NY,0,0.382275815
+male,white,51,4-year college,WA,0,0.412130688
+female,other,29,some college,CA,0,0.338717892
+female,white,61,post-grad,CO,1,0.473166666
+female,white,74,hs,DE,0,0.440013786
+male,other,26,some college,CA,1,0.338717892
+male,white,84,hs,NJ,1,0.427158099
+male,white,20,hs,FL,1,0.506188355
+female,white,52,4-year college,CA,0,0.338717892
+female,other,28,some college,TX,0,0.547132256
+female,white,47,4-year college,KY,0,0.65670629
+male,white,43,hs,CA,0,0.338717892
+male,other,38,4-year college,TN,1,0.63624343
+male,white,35,hs,CA,1,0.338717892
+female,white,100,some college,LA,1,0.601716772
+female,white,37,hs,VA,0,0.471736237
+female,white,42,hs,PA,1,0.503755358
+male,white,49,post-grad,OH,1,0.542676846
+female,white,54,some college,CO,0,0.473166666
+female,white,22,hs,OK,0,0.693047372
+male,black,43,some college,GA,0,0.526611726
+male,white,52,some college,OH,0,0.542676846
+female,white,43,post-grad,CA,0,0.338717892
+male,white,64,hs,GA,0,0.526611726
+male,black,29,some college,NC,0,0.519037458
+female,black,19,hs,PA,0,0.503755358
+male,white,26,4-year college,AR,0,0.642851377
+male,white,85,some college,PA,1,0.503755358
+female,white,66,some college,CA,0,0.338717892
+male,white,94,4-year college,CA,1,0.338717892
+female,white,96,4-year college,HI,1,0.325586625
+female,white,20,some college,CA,0,0.338717892
+female,black,51,hs,NY,0,0.382275815
+female,black,27,some college,NY,1,0.382275815
+male,white,20,hs,NC,1,0.519037458
+male,white,89,hs,MI,1,0.501176682
+male,white,61,post-grad,FL,1,0.506188355
+male,white,39,4-year college,WI,0,0.50407989
+female,other,33,post-grad,NY,1,0.382275815
+female,white,65,post-grad,PA,0,0.503755358
+male,white,31,post-grad,MD,0,0.359837503
+male,white,39,post-grad,UT,1,0.623836582
+female,black,53,post-grad,PA,0,0.503755358
+male,other,27,4-year college,TX,0,0.547132256
+female,white,59,some college,AR,1,0.642851377
+female,other,34,hs,CA,0,0.338717892
+female,white,62,post-grad,CA,0,0.338717892
+female,other,58,no hs,IA,1,0.550635478
+male,white,55,4-year college,NJ,0,0.427158099
+female,white,83,some college,IL,0,0.409799486
+female,white,35,some college,CA,0,0.338717892
+male,white,70,4-year college,IA,1,0.550635478
+male,white,54,some college,WA,0,0.412130688
+male,white,69,4-year college,TX,1,0.547132256
+female,white,22,4-year college,WA,0,0.412130688
+male,white,68,some college,SD,1,0.659718581
+female,other,19,hs,CA,0,0.338717892
+male,other,78,post-grad,VA,1,0.471736237
+male,white,21,4-year college,VA,0,0.471736237
+female,white,65,4-year college,GA,1,0.526611726
+female,white,30,hs,DE,0,0.440013786
+male,white,76,some college,NJ,1,0.427158099
+female,other,30,hs,TX,0,0.547132256
+male,white,60,hs,FL,0,0.506188355
+male,white,46,some college,NC,1,0.519037458
+female,white,67,4-year college,VA,0,0.471736237
+male,white,56,hs,TX,1,0.547132256
+male,white,65,some college,NC,0,0.519037458
+female,white,50,hs,AL,0,0.643741436
+female,white,33,4-year college,LA,0,0.601716772
+female,other,27,4-year college,OK,0,0.693047372
+female,other,35,post-grad,CA,0,0.338717892
+male,white,57,some college,FL,0,0.506188355
+male,white,38,post-grad,NH,1,0.498029716
+female,other,31,some college,TX,1,0.547132256
+female,white,68,some college,AR,1,0.642851377
+female,white,19,hs,OH,0,0.542676846
+female,white,27,some college,TX,0,0.547132256
+female,white,59,some college,VT,1,0.348135737
+female,white,52,hs,NC,1,0.519037458
+male,black,33,some college,TX,0,0.547132256
+female,white,41,some college,WY,1,0.757053196
+male,white,60,some college,OH,0,0.542676846
+female,white,71,4-year college,FL,1,0.506188355
+male,white,76,some college,IN,1,0.601173095
+male,white,85,hs,NC,1,0.519037458
+male,white,64,4-year college,CA,1,0.338717892
+male,white,41,4-year college,OH,1,0.542676846
+female,white,53,hs,PA,1,0.503755358
+female,black,21,no hs,FL,0,0.506188355
+male,other,48,post-grad,CA,1,0.338717892
+female,other,19,some college,AZ,0,0.518900234
+female,other,34,hs,GA,1,0.526611726
+female,white,60,post-grad,NE,1,0.635476741
+male,white,95,4-year college,MA,0,0.353487213
+female,other,47,4-year college,NJ,1,0.427158099
+male,white,40,4-year college,NC,1,0.519037458
+female,white,32,some college,FL,0,0.506188355
+female,white,98,some college,VA,0,0.471736237
+male,white,57,some college,NV,0,0.487062906
+female,white,60,some college,TX,1,0.547132256
+female,black,54,4-year college,TX,0,0.547132256
+male,black,23,some college,GA,0,0.526611726
+female,other,38,4-year college,NJ,0,0.427158099
+male,white,78,4-year college,NY,1,0.382275815
+female,white,64,post-grad,OH,1,0.542676846
+male,white,19,hs,VT,1,0.348135737
+male,white,25,4-year college,MN,0,0.491681431
+male,white,82,some college,GA,0,0.526611726
+female,white,56,post-grad,AL,1,0.643741436
+male,other,28,some college,NM,1,0.453492051
+female,white,42,hs,VA,0,0.471736237
+male,black,42,some college,SC,0,0.574602564
+female,white,29,4-year college,OH,0,0.542676846
+male,white,81,some college,KY,1,0.65670629
+female,other,27,4-year college,TX,1,0.547132256
+male,white,34,hs,PA,1,0.503755358
+female,white,83,hs,TX,1,0.547132256
+female,white,32,hs,MA,0,0.353487213
+male,other,62,some college,NM,0,0.453492051
+female,white,57,some college,LA,1,0.601716772
+female,black,43,post-grad,GA,0,0.526611726
+female,other,64,4-year college,NV,1,0.487062906
+female,white,22,some college,MS,1,0.590898473
+female,white,29,4-year college,OK,1,0.693047372
+female,white,53,post-grad,CA,0,0.338717892
+male,other,55,4-year college,MT,1,0.611096643
+female,white,52,hs,MD,0,0.359837503
+female,other,40,hs,CA,0,0.338717892
+female,white,57,hs,FL,0,0.506188355
+female,white,33,hs,VA,1,0.471736237
+female,white,18,hs,WV,0,0.721610523
+male,white,26,4-year college,MD,0,0.359837503
+female,black,20,hs,FL,1,0.506188355
+female,white,55,hs,PA,0,0.503755358
+male,other,21,some college,MO,0,0.59818561
+female,white,77,hs,OH,0,0.542676846
+male,white,67,some college,AZ,1,0.518900234
+female,other,63,some college,CA,0,0.338717892
+female,other,59,post-grad,MN,0,0.491681431
+female,white,66,some college,GA,1,0.526611726
+female,white,49,some college,CT,1,0.428584525
+male,white,60,some college,CO,0,0.473166666
+female,white,99,hs,NE,0,0.635476741
+male,white,55,some college,MO,0,0.59818561
+female,white,38,post-grad,CA,0,0.338717892
+male,white,70,4-year college,AL,1,0.643741436
+female,white,21,hs,FL,1,0.506188355
+male,white,73,some college,NM,1,0.453492051
+male,black,84,some college,TX,1,0.547132256
+male,white,56,4-year college,FL,0,0.506188355
+female,white,71,hs,MO,1,0.59818561
+male,white,44,some college,TX,1,0.547132256
+female,white,35,post-grad,NY,0,0.382275815
+male,black,22,some college,MS,1,0.590898473
+female,white,23,no hs,MA,1,0.353487213
+male,other,20,hs,IN,0,0.601173095
+female,white,47,hs,NJ,1,0.427158099
+male,white,35,4-year college,NY,0,0.382275815
+male,white,87,post-grad,AZ,0,0.518900234
+male,white,64,some college,CA,0,0.338717892
+female,white,39,4-year college,IN,1,0.601173095
+female,black,53,hs,NC,0,0.519037458
+male,white,50,4-year college,CO,1,0.473166666
+male,other,41,some college,NV,0,0.487062906
+male,white,83,some college,GA,1,0.526611726
+female,black,35,hs,VA,0,0.471736237
+male,white,51,hs,PA,1,0.503755358
+female,white,44,post-grad,OH,0,0.542676846
+female,other,20,some college,OH,0,0.542676846
+male,other,57,some college,CT,0,0.428584525
+female,white,32,some college,UT,0,0.623836582
+male,white,26,hs,IN,0,0.601173095
+male,white,40,post-grad,MA,0,0.353487213
+female,white,72,some college,KS,1,0.611114703
+male,white,39,4-year college,IN,0,0.601173095
+female,white,55,hs,PA,0,0.503755358
+female,white,50,hs,GA,1,0.526611726
+female,white,68,some college,MN,0,0.491681431
+male,white,18,hs,CT,1,0.428584525
+male,white,62,some college,OH,0,0.542676846
+female,white,68,hs,IN,0,0.601173095
+female,black,67,hs,TX,0,0.547132256
+male,white,57,post-grad,CA,0,0.338717892
+female,other,28,some college,CA,0,0.338717892
+male,white,35,some college,TX,0,0.547132256
+male,white,58,post-grad,TX,1,0.547132256
+female,other,82,hs,IL,1,0.409799486
+male,white,62,post-grad,CA,0,0.338717892
+female,white,93,some college,AL,1,0.643741436
+female,white,37,hs,NY,1,0.382275815
+female,white,41,4-year college,SC,1,0.574602564
+male,black,34,no hs,CA,1,0.338717892
+male,white,48,hs,ID,1,0.683101767
+female,white,45,hs,SC,1,0.574602564
+male,white,42,hs,FL,1,0.506188355
+male,white,52,post-grad,MO,0,0.59818561
+female,white,63,4-year college,NY,0,0.382275815
+male,other,64,hs,FL,1,0.506188355
+male,white,49,some college,MA,0,0.353487213
+female,white,51,post-grad,WV,0,0.721610523
+female,white,39,hs,CT,1,0.428584525
+female,other,29,4-year college,TX,0,0.547132256
+female,white,92,hs,OR,0,0.438441611
+female,white,45,some college,CA,0,0.338717892
+female,black,25,hs,LA,0,0.601716772
+female,white,43,some college,AR,1,0.642851377
+male,other,30,4-year college,NY,1,0.382275815
+female,other,30,4-year college,TX,0,0.547132256
+male,white,56,4-year college,UT,1,0.623836582
+female,white,65,4-year college,MI,0,0.501176682
+male,white,59,post-grad,TX,0,0.547132256
+female,white,45,4-year college,GA,1,0.526611726
+female,white,25,hs,WI,1,0.50407989
+male,white,45,some college,WI,0,0.50407989
+female,white,64,some college,NC,1,0.519037458
+female,white,45,post-grad,ID,1,0.683101767
+female,white,54,4-year college,PA,1,0.503755358
+female,other,42,4-year college,GA,0,0.526611726
+female,white,63,hs,PA,0,0.503755358
+female,white,58,hs,MD,0,0.359837503
+female,white,67,some college,FL,1,0.506188355
+female,white,67,hs,GA,0,0.526611726
+male,black,52,some college,NY,0,0.382275815
+male,white,45,some college,AZ,0,0.518900234
+female,white,68,4-year college,CA,0,0.338717892
+male,white,49,4-year college,VA,0,0.471736237
+male,white,34,post-grad,WA,1,0.412130688
+female,white,27,hs,VA,0,0.471736237
+female,white,88,some college,UT,1,0.623836582
+male,white,29,4-year college,NC,1,0.519037458
+male,white,33,hs,WV,0,0.721610523
+female,white,60,4-year college,TX,0,0.547132256
+male,white,50,4-year college,IL,1,0.409799486
+female,white,60,hs,TX,1,0.547132256
+male,white,60,post-grad,MD,0,0.359837503
+male,other,28,some college,FL,0,0.506188355
+female,white,56,post-grad,MD,0,0.359837503
+female,other,30,post-grad,PA,0,0.503755358
+female,other,25,hs,SD,1,0.659718581
+female,white,34,4-year college,MD,0,0.359837503
+female,white,43,post-grad,IN,1,0.601173095
+female,white,29,4-year college,FL,1,0.506188355
+female,black,75,hs,NJ,0,0.427158099
+male,white,47,hs,OH,1,0.542676846
+male,black,68,4-year college,MI,0,0.501176682
+female,white,85,hs,PA,1,0.503755358
+female,white,65,hs,PA,1,0.503755358
+female,other,58,some college,PA,1,0.503755358
+male,white,54,post-grad,CA,0,0.338717892
+male,white,43,some college,IL,0,0.409799486
+male,other,58,some college,IN,1,0.601173095
+male,white,32,some college,WI,0,0.50407989
+male,white,21,hs,NY,1,0.382275815
+female,white,48,4-year college,FL,0,0.506188355
+female,black,98,post-grad,NC,1,0.519037458
+female,white,30,hs,AL,1,0.643741436
+female,black,59,4-year college,SC,1,0.574602564
+male,white,48,some college,AZ,1,0.518900234
+male,white,81,4-year college,CA,0,0.338717892
+female,white,52,post-grad,WA,0,0.412130688
+female,white,74,some college,OR,0,0.438441611
+female,white,76,hs,VA,1,0.471736237
+male,white,60,no hs,PA,0,0.503755358
+female,black,34,4-year college,OH,0,0.542676846
+female,other,75,some college,FL,0,0.506188355
+female,white,44,post-grad,TX,0,0.547132256
+female,white,51,some college,PA,1,0.503755358
+male,white,33,some college,NH,1,0.498029716
+male,white,84,post-grad,TX,0,0.547132256
+male,other,57,4-year college,AZ,0,0.518900234
+female,white,23,4-year college,CA,0,0.338717892
+female,white,54,hs,AZ,0,0.518900234
+male,other,19,some college,NV,1,0.487062906
+female,white,58,hs,AR,1,0.642851377
+male,white,73,hs,AR,1,0.642851377
+female,other,29,some college,LA,1,0.601716772
+female,white,64,hs,GA,1,0.526611726
+female,other,56,post-grad,NY,0,0.382275815
+female,white,61,post-grad,NV,1,0.487062906
+female,white,18,post-grad,NC,0,0.519037458
+female,white,53,some college,OH,0,0.542676846
+male,other,20,some college,CA,0,0.338717892
+female,white,60,hs,CA,0,0.338717892
+female,other,48,some college,AZ,0,0.518900234
+female,black,58,some college,MN,0,0.491681431
+female,other,37,some college,UT,1,0.623836582
+female,white,38,hs,WA,0,0.412130688
+female,white,20,some college,AR,0,0.642851377
+female,other,48,some college,CA,0,0.338717892
+male,white,44,post-grad,SC,1,0.574602564
+male,white,96,hs,TN,1,0.63624343
+male,white,69,hs,OH,0,0.542676846
+female,white,29,some college,NY,1,0.382275815
+female,other,38,hs,TX,1,0.547132256
+female,white,53,no hs,CA,0,0.338717892
+male,white,37,4-year college,TX,1,0.547132256
+male,white,87,some college,NY,1,0.382275815
+male,white,60,post-grad,CT,0,0.428584525
+female,white,51,some college,WA,0,0.412130688
+female,white,50,4-year college,NJ,0,0.427158099
+female,black,51,hs,VA,1,0.471736237
+male,white,37,some college,RI,0,0.416892959
+male,white,19,4-year college,TX,0,0.547132256
+female,white,22,some college,TX,1,0.547132256
+female,other,29,hs,WA,0,0.412130688
+male,white,57,4-year college,OK,1,0.693047372
+female,white,47,post-grad,TX,1,0.547132256
+female,black,58,some college,MD,0,0.359837503
+female,white,53,post-grad,PA,1,0.503755358
+female,black,23,some college,CT,0,0.428584525
+female,black,39,no hs,NY,1,0.382275815
+female,white,54,hs,IL,0,0.409799486
+female,white,29,4-year college,UT,0,0.623836582
+male,white,37,no hs,PA,0,0.503755358
+female,white,51,no hs,IN,0,0.601173095
+female,white,33,hs,IL,0,0.409799486
+male,white,47,hs,NY,0,0.382275815
+male,white,66,4-year college,MI,1,0.501176682
+female,white,50,post-grad,MD,1,0.359837503
+female,other,38,4-year college,MA,1,0.353487213
+female,white,55,hs,ID,0,0.683101767
+female,white,55,hs,NC,1,0.519037458
+female,black,44,4-year college,MO,0,0.59818561
+female,white,31,hs,NY,0,0.382275815
+male,white,62,some college,AZ,1,0.518900234
+female,white,27,hs,WI,1,0.50407989
+male,white,22,hs,LA,1,0.601716772
+male,other,19,4-year college,NJ,0,0.427158099
+male,white,62,4-year college,AZ,0,0.518900234
+male,white,53,4-year college,UT,1,0.623836582
+female,white,69,hs,IA,0,0.550635478
+female,white,36,some college,OR,0,0.438441611
+male,white,100,4-year college,MO,1,0.59818561
+female,white,60,4-year college,MO,0,0.59818561
+female,other,33,hs,IN,1,0.601173095
+female,white,27,hs,KY,0,0.65670629
+female,other,24,hs,CA,0,0.338717892
+female,white,22,4-year college,GA,0,0.526611726
+female,white,21,4-year college,PA,0,0.503755358
+male,white,20,some college,KY,0,0.65670629
+female,white,24,no hs,WA,0,0.412130688
+male,white,62,4-year college,CT,0,0.428584525
+female,white,26,some college,TN,0,0.63624343
+female,white,19,4-year college,OH,0,0.542676846
+male,other,42,4-year college,HI,0,0.325586625
+male,white,90,some college,ID,1,0.683101767
+male,white,35,some college,UT,0,0.623836582
+female,other,25,hs,MI,0,0.501176682
+male,white,51,4-year college,CT,0,0.428584525
+male,white,45,hs,CT,0,0.428584525
+male,white,55,4-year college,MD,0,0.359837503
+male,black,49,4-year college,IN,1,0.601173095
+male,white,94,some college,KS,1,0.611114703
+female,white,55,some college,PA,0,0.503755358
+male,white,44,some college,AZ,0,0.518900234
+male,white,18,some college,TN,0,0.63624343
+male,white,46,4-year college,OH,1,0.542676846
+male,white,51,some college,AR,0,0.642851377
+female,white,23,some college,PA,0,0.503755358
+female,white,51,no hs,AR,1,0.642851377
+female,white,56,post-grad,OK,0,0.693047372
+female,other,33,some college,FL,0,0.506188355
+female,white,46,4-year college,OR,0,0.438441611
+female,white,45,4-year college,FL,0,0.506188355
+female,white,68,post-grad,MO,1,0.59818561
+female,other,28,hs,CA,1,0.338717892
+male,white,87,post-grad,WV,1,0.721610523
+male,white,75,post-grad,CA,1,0.338717892
+male,white,67,post-grad,PA,0,0.503755358
+female,white,35,hs,FL,1,0.506188355
+male,white,89,post-grad,TN,1,0.63624343
+male,other,33,post-grad,CT,0,0.428584525
+female,white,44,some college,CO,0,0.473166666
+female,white,46,hs,IA,0,0.550635478
+female,other,61,some college,FL,1,0.506188355
+female,white,24,some college,GA,0,0.526611726
+female,white,63,some college,FL,1,0.506188355
+male,other,56,hs,CA,1,0.338717892
+male,white,51,some college,FL,0,0.506188355
+female,other,54,some college,TX,1,0.547132256
+male,black,19,hs,CA,0,0.338717892
+male,white,55,hs,GA,0,0.526611726
+female,white,34,hs,GA,1,0.526611726
+female,white,67,hs,OH,1,0.542676846
+female,other,37,4-year college,WA,0,0.412130688
+male,white,78,4-year college,CA,0,0.338717892
+male,white,19,post-grad,CA,1,0.338717892
+female,white,20,some college,VT,0,0.348135737
+male,white,28,no hs,FL,0,0.506188355
+female,black,67,some college,PA,1,0.503755358
+male,white,30,4-year college,PA,1,0.503755358
+female,white,75,post-grad,ME,0,0.484032089
+male,white,42,4-year college,MD,1,0.359837503
+male,other,40,no hs,MA,0,0.353487213
+male,white,39,4-year college,VA,0,0.471736237
+male,white,48,post-grad,WY,1,0.757053196
+female,other,59,4-year college,NY,0,0.382275815
+male,white,48,hs,TX,0,0.547132256
+female,white,60,hs,MO,1,0.59818561
+male,black,39,hs,GA,1,0.526611726
+male,white,79,some college,VT,1,0.348135737
+male,white,65,some college,NM,0,0.453492051
+female,white,72,no hs,FL,0,0.506188355
+male,white,35,post-grad,IN,0,0.601173095
+female,other,47,post-grad,DE,0,0.440013786
+female,white,53,hs,OH,1,0.542676846
+female,white,94,hs,PA,0,0.503755358
+female,white,64,some college,AR,1,0.642851377
+male,black,39,4-year college,MD,1,0.359837503
+male,other,37,some college,VA,0,0.471736237
+female,white,60,hs,OH,0,0.542676846
+male,white,46,some college,TX,1,0.547132256
+female,other,25,hs,CA,0,0.338717892
+female,black,52,some college,VA,0,0.471736237
+male,white,21,hs,WA,0,0.412130688
+male,white,34,hs,OR,1,0.438441611
+male,white,30,some college,MD,0,0.359837503
+male,black,51,some college,NY,0,0.382275815
+female,white,65,hs,TX,1,0.547132256
+male,other,27,hs,MO,0,0.59818561
+female,white,54,post-grad,WA,0,0.412130688
+female,black,51,4-year college,NY,0,0.382275815
+female,other,22,post-grad,WA,0,0.412130688
+male,white,50,post-grad,TX,0,0.547132256
+female,black,52,4-year college,MD,1,0.359837503
+female,other,18,4-year college,FL,0,0.506188355
+male,white,65,post-grad,MS,1,0.590898473
+female,white,40,some college,NY,0,0.382275815
+female,white,24,some college,MO,1,0.59818561
+female,white,36,hs,AZ,0,0.518900234
+male,other,39,hs,NC,1,0.519037458
+female,white,54,hs,OH,1,0.542676846
+female,white,22,some college,MI,0,0.501176682
+male,white,78,post-grad,VA,1,0.471736237
+male,white,57,4-year college,CA,0,0.338717892
+female,other,51,some college,TX,1,0.547132256
+male,white,33,post-grad,MO,0,0.59818561
+male,white,77,hs,WA,0,0.412130688
+female,white,68,some college,PA,0,0.503755358
+male,white,62,4-year college,WA,1,0.412130688
+male,other,20,some college,AR,0,0.642851377
+female,other,22,4-year college,NJ,0,0.427158099
+female,other,35,hs,CA,1,0.338717892
+female,white,32,hs,WI,1,0.50407989
+male,white,46,hs,WA,1,0.412130688
+male,white,66,hs,FL,0,0.506188355
+male,white,98,post-grad,FL,0,0.506188355
+female,white,34,post-grad,KY,0,0.65670629
+female,other,27,hs,OK,0,0.693047372
+female,white,42,some college,NY,1,0.382275815
+female,white,24,4-year college,CA,0,0.338717892
+female,white,28,some college,RI,0,0.416892959
+female,white,85,hs,MI,1,0.501176682
+female,white,75,hs,WI,1,0.50407989
+female,white,57,hs,PA,1,0.503755358
+male,white,26,some college,VA,1,0.471736237
+male,white,50,some college,TN,1,0.63624343
+female,white,54,4-year college,CA,0,0.338717892
+male,other,51,post-grad,LA,1,0.601716772
+female,white,59,hs,NC,1,0.519037458
+male,white,39,4-year college,SC,1,0.574602564
+female,other,38,hs,TX,0,0.547132256
+female,other,37,post-grad,TX,0,0.547132256
+female,other,19,4-year college,TX,1,0.547132256
+female,white,32,4-year college,FL,0,0.506188355
+male,white,60,hs,FL,0,0.506188355
+male,white,61,4-year college,VA,1,0.471736237
+male,other,48,hs,NJ,0,0.427158099
+male,black,38,some college,TX,0,0.547132256
+female,white,100,hs,CA,0,0.338717892
+female,white,66,4-year college,MO,0,0.59818561
+female,white,33,hs,PA,0,0.503755358
+female,white,28,4-year college,NY,0,0.382275815
+male,white,85,some college,TX,1,0.547132256
+female,white,37,some college,IL,0,0.409799486
+male,white,22,some college,IN,1,0.601173095
+female,white,35,some college,IL,0,0.409799486
+male,other,66,4-year college,FL,0,0.506188355
+female,white,63,some college,WI,0,0.50407989
+female,white,55,4-year college,NH,0,0.498029716
+male,white,68,hs,KY,1,0.65670629
+female,white,62,4-year college,PA,1,0.503755358
+female,white,67,some college,MO,0,0.59818561
+female,other,53,some college,MI,1,0.501176682
+female,white,30,hs,NY,0,0.382275815
+male,other,65,hs,VA,1,0.471736237
+female,white,60,4-year college,CO,1,0.473166666
+female,white,49,4-year college,CA,0,0.338717892
+male,white,36,hs,AL,1,0.643741436
+male,white,52,4-year college,OK,1,0.693047372
+female,white,55,hs,CA,0,0.338717892
+male,white,53,4-year college,KS,1,0.611114703
+female,white,20,no hs,GA,0,0.526611726
+male,white,63,4-year college,MS,1,0.590898473
+male,white,89,post-grad,CA,1,0.338717892
+male,other,50,4-year college,PA,0,0.503755358
+male,white,36,4-year college,KY,0,0.65670629
+female,white,19,4-year college,MO,1,0.59818561
+male,white,66,some college,WA,1,0.412130688
+female,black,48,4-year college,TX,0,0.547132256
+male,white,65,4-year college,GA,1,0.526611726
+female,black,59,post-grad,PA,0,0.503755358
+female,black,53,post-grad,IL,0,0.409799486
+female,white,34,hs,IL,1,0.409799486
+female,white,58,hs,MO,0,0.59818561
+female,white,62,no hs,MD,1,0.359837503
+female,white,21,post-grad,FL,0,0.506188355
+male,white,63,4-year college,WI,1,0.50407989
+female,other,32,post-grad,TX,1,0.547132256
+male,white,38,some college,SC,0,0.574602564
+male,other,34,post-grad,TX,1,0.547132256
+female,white,32,some college,IL,1,0.409799486
+male,white,43,some college,AL,0,0.643741436
+male,white,75,post-grad,CO,0,0.473166666
+male,other,79,4-year college,TX,1,0.547132256
+male,white,31,4-year college,KS,0,0.611114703
+female,other,23,hs,FL,0,0.506188355
+male,white,32,4-year college,AZ,1,0.518900234
+male,white,45,no hs,WA,1,0.412130688
+male,white,92,4-year college,VA,1,0.471736237
+female,white,53,some college,NV,0,0.487062906
+female,white,69,post-grad,CA,1,0.338717892
+female,white,20,no hs,OH,1,0.542676846
+female,white,38,hs,WI,0,0.50407989
+male,white,36,4-year college,UT,0,0.623836582
+male,white,95,4-year college,FL,0,0.506188355
+male,other,41,some college,NJ,0,0.427158099
+male,other,45,4-year college,MN,1,0.491681431
+female,black,41,4-year college,FL,1,0.506188355
+female,white,52,hs,OR,1,0.438441611
+female,white,78,some college,PA,0,0.503755358
+female,white,65,4-year college,TN,1,0.63624343
+male,black,40,no hs,NY,0,0.382275815
+male,white,70,hs,NY,0,0.382275815
+female,other,43,hs,CA,1,0.338717892
+female,white,79,4-year college,ID,0,0.683101767
+female,white,31,post-grad,WA,0,0.412130688
+female,white,100,some college,CA,0,0.338717892
+male,white,90,some college,CA,1,0.338717892
+male,white,60,post-grad,MA,1,0.353487213
+female,white,65,hs,WV,1,0.721610523
+female,other,29,4-year college,CA,0,0.338717892
+male,other,62,post-grad,OR,1,0.438441611
+female,white,80,some college,WI,0,0.50407989
+female,white,83,some college,OK,1,0.693047372
+female,white,26,hs,TN,1,0.63624343
+female,white,37,some college,CA,1,0.338717892
+male,other,48,no hs,ND,1,0.698092429
+female,white,24,hs,GA,1,0.526611726
+male,white,68,4-year college,VA,1,0.471736237
+female,other,23,4-year college,CA,1,0.338717892
+male,white,66,4-year college,TX,1,0.547132256
+female,white,64,4-year college,MI,0,0.501176682
+female,white,55,no hs,PA,1,0.503755358
+male,white,55,4-year college,MO,0,0.59818561
+male,black,24,hs,NJ,0,0.427158099
+male,black,29,some college,TN,0,0.63624343
+female,white,60,post-grad,TX,0,0.547132256
+female,white,37,post-grad,MO,0,0.59818561
+female,white,68,hs,NY,1,0.382275815
+female,black,33,4-year college,MO,0,0.59818561
+male,white,52,hs,WA,0,0.412130688
+male,other,51,4-year college,NJ,0,0.427158099
+female,white,95,hs,NY,1,0.382275815
+male,white,33,hs,FL,0,0.506188355
+female,black,56,post-grad,IL,0,0.409799486
+male,white,62,hs,IL,1,0.409799486
+male,white,25,4-year college,GA,0,0.526611726
+female,white,27,hs,OH,0,0.542676846
+female,white,34,4-year college,OR,0,0.438441611
+male,black,20,hs,TX,0,0.547132256
+female,white,63,hs,AZ,0,0.518900234
+female,white,63,some college,TX,0,0.547132256
+male,other,25,hs,NV,1,0.487062906
+male,white,54,no hs,FL,0,0.506188355
+female,white,86,hs,CA,1,0.338717892
+female,white,55,some college,WY,0,0.757053196
+male,white,56,some college,PA,0,0.503755358
+male,white,68,post-grad,NE,1,0.635476741
+male,white,38,some college,KY,1,0.65670629
+female,black,18,some college,OH,0,0.542676846
+female,black,32,some college,LA,1,0.601716772
+male,white,43,hs,UT,0,0.623836582
+male,white,63,hs,PA,1,0.503755358
+female,white,45,4-year college,FL,1,0.506188355
+male,white,55,hs,CA,0,0.338717892
+female,other,38,post-grad,MA,0,0.353487213
+female,white,39,hs,PA,1,0.503755358
+female,black,52,hs,NJ,1,0.427158099
+female,other,98,4-year college,FL,1,0.506188355
+male,white,37,post-grad,OH,0,0.542676846
+female,white,41,no hs,VA,1,0.471736237
+female,white,27,some college,GA,0,0.526611726
+female,white,66,hs,TX,1,0.547132256
+male,white,23,some college,OH,0,0.542676846
+female,white,57,4-year college,VA,0,0.471736237
+female,white,34,hs,CT,0,0.428584525
+male,white,95,hs,DE,0,0.440013786
+male,other,79,post-grad,TX,0,0.547132256
+female,white,33,some college,RI,1,0.416892959
+female,white,84,hs,GA,1,0.526611726
+female,white,39,hs,IN,0,0.601173095
+male,white,60,4-year college,DE,1,0.440013786
+male,white,29,post-grad,AZ,0,0.518900234
+female,white,43,post-grad,SC,0,0.574602564
+female,white,56,hs,NH,0,0.498029716
+female,white,27,some college,FL,0,0.506188355
+female,white,85,hs,ID,1,0.683101767
+female,white,31,post-grad,MO,1,0.59818561
+female,white,18,post-grad,VA,1,0.471736237
+male,black,21,some college,AZ,0,0.518900234
+female,white,100,hs,FL,0,0.506188355
+female,white,75,hs,WA,1,0.412130688
+female,other,26,some college,CA,1,0.338717892
+male,white,25,some college,VA,1,0.471736237
+female,other,70,4-year college,TX,1,0.547132256
+female,white,50,hs,PA,0,0.503755358
+male,white,37,some college,IN,1,0.601173095
+female,white,64,hs,OH,0,0.542676846
+female,white,19,some college,OH,1,0.542676846
+female,white,28,some college,OH,0,0.542676846
+male,white,43,post-grad,TX,1,0.547132256
+female,white,27,4-year college,NJ,1,0.427158099
+male,white,62,hs,CA,1,0.338717892
+female,white,42,4-year college,KY,0,0.65670629
+female,white,61,hs,AZ,1,0.518900234
+female,white,60,4-year college,NJ,0,0.427158099
+male,black,57,some college,TX,0,0.547132256
+female,white,69,hs,TN,1,0.63624343
+female,white,31,4-year college,OH,1,0.542676846
+female,white,32,some college,NY,0,0.382275815
+male,white,64,hs,CO,1,0.473166666
+male,white,24,some college,WI,0,0.50407989
+female,white,77,4-year college,IA,1,0.550635478
+male,white,28,some college,KY,1,0.65670629
+male,other,19,4-year college,UT,0,0.623836582
+female,white,63,hs,MD,1,0.359837503
+female,white,49,post-grad,NC,0,0.519037458
+male,black,47,some college,GA,0,0.526611726
+male,white,50,some college,MI,0,0.501176682
+female,white,59,hs,OH,0,0.542676846
+male,white,96,some college,CA,1,0.338717892
+female,white,42,no hs,SC,0,0.574602564
+female,black,96,4-year college,GA,0,0.526611726
+male,other,29,hs,PA,1,0.503755358
+female,white,77,hs,VA,1,0.471736237
+male,white,55,4-year college,UT,1,0.623836582
+male,white,21,some college,KY,0,0.65670629
+male,white,73,post-grad,PA,1,0.503755358
+female,black,53,hs,IN,0,0.601173095
+male,white,48,4-year college,AZ,0,0.518900234
+female,black,41,hs,TX,0,0.547132256
+female,white,52,4-year college,NY,0,0.382275815
+male,white,60,post-grad,CA,0,0.338717892
+male,white,51,4-year college,AZ,1,0.518900234
+male,white,41,hs,PA,0,0.503755358
+female,white,26,4-year college,PA,0,0.503755358
+female,white,41,hs,TN,1,0.63624343
+male,white,52,hs,IN,1,0.601173095
+female,white,28,4-year college,AL,0,0.643741436
+female,black,26,4-year college,VA,0,0.471736237
+female,white,36,post-grad,TX,0,0.547132256
+female,white,59,some college,NJ,0,0.427158099
+male,other,20,some college,CA,1,0.338717892
+male,white,74,some college,PA,0,0.503755358
+male,other,44,some college,FL,0,0.506188355
+female,white,72,some college,WI,0,0.50407989
+female,white,37,post-grad,MD,0,0.359837503
+female,other,29,some college,CA,0,0.338717892
+female,white,19,some college,WI,0,0.50407989
+male,white,91,hs,MI,0,0.501176682
+male,other,42,post-grad,VA,1,0.471736237
+female,white,41,post-grad,AZ,0,0.518900234
+male,white,43,hs,MN,1,0.491681431
+female,white,71,4-year college,AZ,0,0.518900234
+male,white,47,some college,NC,1,0.519037458
+female,white,98,hs,CA,1,0.338717892
+female,white,61,post-grad,MO,1,0.59818561
+female,white,66,hs,CA,0,0.338717892
+male,other,51,some college,CA,0,0.338717892
+female,white,48,post-grad,WA,0,0.412130688
+male,white,64,hs,OH,1,0.542676846
+male,white,46,post-grad,CA,0,0.338717892
+male,white,98,no hs,FL,1,0.506188355
+female,white,73,hs,MI,1,0.501176682
+female,white,55,hs,CA,1,0.338717892
+female,black,43,4-year college,MI,0,0.501176682
+female,white,51,no hs,CA,1,0.338717892
+female,white,76,hs,FL,1,0.506188355
+female,white,48,some college,GA,1,0.526611726
+male,white,62,4-year college,WA,1,0.412130688
+male,white,65,some college,LA,1,0.601716772
+female,white,43,some college,MA,1,0.353487213
+male,black,28,no hs,MI,0,0.501176682
+female,white,77,4-year college,AL,1,0.643741436
+male,other,22,some college,CA,1,0.338717892
+male,white,67,some college,TN,1,0.63624343
+male,white,65,4-year college,TX,1,0.547132256
+male,white,68,some college,TX,1,0.547132256
+female,white,41,post-grad,FL,0,0.506188355
+female,white,55,hs,AK,0,0.583856547
+female,other,35,some college,WA,0,0.412130688
+male,other,97,post-grad,LA,1,0.601716772
+female,white,77,hs,ID,0,0.683101767
+male,black,31,4-year college,GA,0,0.526611726
+male,other,34,hs,ID,1,0.683101767
+male,white,56,some college,WA,0,0.412130688
+male,white,23,4-year college,PA,0,0.503755358
+female,black,27,no hs,IL,0,0.409799486
+female,white,65,some college,NY,0,0.382275815
+female,white,86,hs,NC,1,0.519037458
+female,other,21,hs,TX,0,0.547132256
+female,white,31,post-grad,OH,0,0.542676846
+male,white,80,some college,CA,1,0.338717892
+male,white,66,hs,PA,1,0.503755358
+female,white,46,hs,MT,0,0.611096643
+male,white,42,hs,VA,0,0.471736237
+female,other,29,4-year college,FL,0,0.506188355
+female,other,46,some college,FL,0,0.506188355
+male,white,44,hs,NM,1,0.453492051
+male,white,50,4-year college,MI,0,0.501176682
+male,white,58,some college,CO,1,0.473166666
+female,white,57,hs,IN,0,0.601173095
+male,other,52,some college,AZ,1,0.518900234
+male,white,83,4-year college,RI,1,0.416892959
+male,white,34,some college,CA,1,0.338717892
+male,white,20,no hs,CA,0,0.338717892
+male,white,38,4-year college,VA,0,0.471736237
+female,white,84,hs,NY,1,0.382275815
+female,white,61,no hs,IL,1,0.409799486
+male,white,96,some college,CA,1,0.338717892
+female,white,30,4-year college,MI,0,0.501176682
+female,other,36,hs,MI,1,0.501176682
+female,white,40,some college,VA,1,0.471736237
+female,white,57,some college,TX,1,0.547132256
+female,white,81,hs,NY,1,0.382275815
+male,white,90,post-grad,OR,0,0.438441611
+female,black,55,post-grad,TX,0,0.547132256
+female,white,46,some college,PA,0,0.503755358
+female,white,31,4-year college,WA,0,0.412130688
+male,other,45,post-grad,GA,1,0.526611726
+female,white,68,some college,FL,1,0.506188355
+female,white,46,no hs,SC,1,0.574602564
+female,white,19,post-grad,NJ,0,0.427158099
+male,white,55,some college,WI,0,0.50407989
+female,other,25,some college,CA,0,0.338717892
+female,white,25,no hs,TN,0,0.63624343
+female,white,74,some college,NY,0,0.382275815
+male,white,68,hs,WV,1,0.721610523
+male,white,51,some college,WA,0,0.412130688
+female,white,51,4-year college,NY,0,0.382275815
+female,white,25,post-grad,CA,0,0.338717892
+female,other,88,some college,FL,1,0.506188355
+male,white,55,hs,KS,0,0.611114703
+male,white,51,some college,MI,0,0.501176682
+male,white,73,hs,NY,0,0.382275815
+male,white,41,hs,MA,0,0.353487213
+female,white,50,some college,AZ,0,0.518900234
+male,white,71,post-grad,TX,1,0.547132256
+male,white,54,some college,MO,1,0.59818561
+female,white,23,some college,MO,0,0.59818561
+male,white,51,hs,OH,1,0.542676846
+male,other,33,hs,NY,1,0.382275815
+female,other,27,hs,TX,0,0.547132256
+male,white,57,hs,PA,1,0.503755358
+male,white,20,hs,CA,0,0.338717892
+male,white,65,some college,WV,1,0.721610523
+female,black,37,4-year college,PA,1,0.503755358
+male,white,85,hs,MO,1,0.59818561
+male,black,38,hs,GA,0,0.526611726
+male,white,86,post-grad,IL,0,0.409799486
+female,white,63,hs,OK,0,0.693047372
+male,black,28,some college,FL,0,0.506188355
+male,white,34,4-year college,NY,0,0.382275815
+female,white,29,post-grad,IN,1,0.601173095
+male,white,55,post-grad,SC,1,0.574602564
+male,white,63,post-grad,UT,1,0.623836582
+male,white,55,hs,ID,0,0.683101767
+male,white,35,4-year college,CT,0,0.428584525
+female,white,42,hs,NJ,1,0.427158099
+male,white,46,some college,NY,0,0.382275815
+female,other,35,4-year college,CA,0,0.338717892
+female,white,57,post-grad,VA,0,0.471736237
+female,white,23,some college,MO,1,0.59818561
+male,white,24,hs,TX,1,0.547132256
+female,white,54,some college,MO,0,0.59818561
+female,white,53,no hs,DE,1,0.440013786
+female,white,45,some college,CO,0,0.473166666
+female,white,44,4-year college,NV,0,0.487062906
+male,white,60,post-grad,MD,1,0.359837503
+female,white,24,some college,NJ,0,0.427158099
+female,white,22,hs,NC,1,0.519037458
+female,other,65,some college,CA,1,0.338717892
+male,white,82,post-grad,MI,0,0.501176682
+male,other,23,4-year college,TX,0,0.547132256
+female,white,67,hs,MA,0,0.353487213
+male,other,28,some college,VA,0,0.471736237
+female,other,21,4-year college,AZ,1,0.518900234
+female,black,30,some college,TX,0,0.547132256
+female,white,62,hs,PA,1,0.503755358
+female,white,36,hs,PA,1,0.503755358
+female,black,60,some college,MI,1,0.501176682
+female,white,39,4-year college,MD,1,0.359837503
+male,white,73,4-year college,NC,1,0.519037458
+male,white,49,4-year college,NJ,0,0.427158099
+female,white,78,hs,MO,1,0.59818561
+female,white,60,post-grad,KS,0,0.611114703
+male,white,46,hs,AL,1,0.643741436
+male,white,68,hs,TN,1,0.63624343
+male,white,66,hs,IL,0,0.409799486
+female,black,50,4-year college,NY,0,0.382275815
+female,white,67,some college,WA,0,0.412130688
+male,white,69,4-year college,UT,1,0.623836582
+female,white,91,some college,WA,1,0.412130688
+female,white,100,4-year college,VT,0,0.348135737
+female,white,29,some college,TX,1,0.547132256
+female,white,88,hs,IN,0,0.601173095
+male,white,32,4-year college,NY,0,0.382275815
+male,white,97,some college,TX,0,0.547132256
+male,other,18,some college,NJ,0,0.427158099
+female,other,87,some college,TX,0,0.547132256
+female,white,67,no hs,MI,0,0.501176682
+female,white,27,some college,NC,0,0.519037458
+male,white,46,hs,NY,0,0.382275815
+male,white,39,hs,GA,1,0.526611726
+male,white,88,some college,TX,1,0.547132256
+female,white,76,some college,WA,1,0.412130688
+female,black,47,4-year college,CO,0,0.473166666
+female,white,35,hs,IL,0,0.409799486
+female,other,18,4-year college,NJ,0,0.427158099
+male,white,92,some college,HI,1,0.325586625
+female,white,54,4-year college,GA,1,0.526611726
+male,white,47,4-year college,KY,1,0.65670629
+male,white,39,4-year college,WA,0,0.412130688
+female,white,62,some college,FL,0,0.506188355
+male,white,31,4-year college,MI,0,0.501176682
+female,white,20,hs,AL,0,0.643741436
+female,white,52,hs,OH,1,0.542676846
+female,white,56,some college,MS,1,0.590898473
+female,white,33,4-year college,TX,0,0.547132256
+female,white,92,some college,MA,0,0.353487213
+female,other,68,some college,CA,0,0.338717892
+female,black,28,4-year college,GA,1,0.526611726
+female,white,25,some college,MA,0,0.353487213
+female,other,26,hs,TX,1,0.547132256
+female,other,35,post-grad,NY,0,0.382275815
+female,other,33,post-grad,WI,0,0.50407989
+male,white,67,some college,FL,0,0.506188355
+female,white,45,some college,UT,1,0.623836582
+female,white,56,hs,WV,1,0.721610523
+male,white,23,some college,TX,0,0.547132256
+male,white,24,4-year college,MI,1,0.501176682
+female,black,62,some college,OH,0,0.542676846
+male,other,22,some college,TX,0,0.547132256
+male,white,69,4-year college,CA,0,0.338717892
+female,white,54,some college,KY,1,0.65670629
+male,black,29,some college,IL,1,0.409799486
+female,white,37,4-year college,IN,1,0.601173095
+female,other,31,4-year college,OR,0,0.438441611
+male,white,36,some college,NY,1,0.382275815
+female,white,60,hs,MO,1,0.59818561
+female,other,44,4-year college,FL,0,0.506188355
+female,white,57,some college,TX,0,0.547132256
+male,white,98,4-year college,MO,1,0.59818561
+female,white,46,4-year college,NC,1,0.519037458
+male,white,65,4-year college,OR,1,0.438441611
+male,white,73,4-year college,NY,0,0.382275815
+female,white,29,some college,OH,1,0.542676846
+female,white,81,hs,FL,1,0.506188355
+female,white,39,4-year college,OH,1,0.542676846
+male,white,54,4-year college,FL,0,0.506188355
+female,white,52,4-year college,MA,0,0.353487213
+female,white,75,4-year college,WA,0,0.412130688
+male,other,30,4-year college,TX,1,0.547132256
+female,black,42,some college,AL,0,0.643741436
+male,white,21,4-year college,MO,1,0.59818561
+male,white,60,hs,OH,1,0.542676846
+male,other,18,some college,CA,0,0.338717892
+male,white,58,hs,WV,1,0.721610523
+male,white,39,post-grad,TN,0,0.63624343
+female,black,28,4-year college,VA,0,0.471736237
+female,white,71,4-year college,PA,0,0.503755358
+female,white,36,hs,AL,1,0.643741436
+male,white,81,4-year college,CA,0,0.338717892
+male,white,35,4-year college,MN,0,0.491681431
+male,white,22,some college,PA,1,0.503755358
+female,white,43,4-year college,FL,0,0.506188355
+female,black,31,post-grad,IN,0,0.601173095
+female,white,67,hs,PA,1,0.503755358
+male,other,28,hs,NJ,0,0.427158099
+female,black,45,post-grad,MD,0,0.359837503
+male,white,71,some college,WA,0,0.412130688
+male,white,44,4-year college,ME,0,0.484032089
+female,other,30,some college,NC,1,0.519037458
+female,white,43,post-grad,IL,0,0.409799486
+male,white,42,post-grad,FL,1,0.506188355
+female,white,67,some college,KY,1,0.65670629
+female,white,37,some college,MA,0,0.353487213
+male,white,66,hs,AR,0,0.642851377
+female,white,21,post-grad,KY,0,0.65670629
+male,white,24,no hs,LA,1,0.601716772
+female,white,22,some college,AR,1,0.642851377
+female,white,18,post-grad,GA,1,0.526611726
+male,white,48,hs,NY,0,0.382275815
+male,white,45,hs,KY,0,0.65670629
+female,white,55,hs,CA,0,0.338717892
+female,white,37,hs,MO,0,0.59818561
+male,other,51,hs,CO,0,0.473166666
+female,black,44,4-year college,GA,0,0.526611726
+male,white,69,some college,PA,0,0.503755358
+male,white,57,some college,NM,0,0.453492051
+female,white,40,post-grad,FL,0,0.506188355
+male,black,22,some college,CA,1,0.338717892
+male,white,75,some college,CA,1,0.338717892
+female,white,37,4-year college,CA,0,0.338717892
+female,white,82,no hs,CA,1,0.338717892
+female,white,33,some college,AR,1,0.642851377
+female,white,53,4-year college,FL,1,0.506188355
+male,white,42,4-year college,MA,1,0.353487213
+male,white,56,4-year college,MD,0,0.359837503
+female,white,59,hs,CO,1,0.473166666
+female,white,37,some college,MO,0,0.59818561
+male,white,66,some college,AZ,1,0.518900234
+female,white,68,4-year college,KS,1,0.611114703
+male,black,69,some college,FL,0,0.506188355
+male,other,45,4-year college,MD,1,0.359837503
+female,white,38,post-grad,IL,0,0.409799486
+male,white,93,post-grad,TX,0,0.547132256
+female,white,44,some college,NV,0,0.487062906
+female,other,29,some college,OK,1,0.693047372
+male,white,60,4-year college,TX,1,0.547132256
+female,other,49,4-year college,NY,0,0.382275815
+female,white,37,4-year college,FL,1,0.506188355
+male,white,33,4-year college,MN,1,0.491681431
+male,white,82,4-year college,KS,0,0.611114703
+male,white,36,hs,NY,1,0.382275815
+female,white,68,some college,MO,1,0.59818561
+male,white,32,hs,SD,0,0.659718581
+female,white,21,hs,TX,0,0.547132256
+male,other,52,no hs,RI,1,0.416892959
+female,other,58,4-year college,TX,0,0.547132256
+female,other,20,some college,MI,0,0.501176682
+male,white,87,4-year college,GA,1,0.526611726
+male,white,73,some college,NJ,1,0.427158099
+female,other,60,hs,TX,1,0.547132256
+female,other,40,some college,NV,0,0.487062906
+female,white,50,hs,WI,0,0.50407989
+male,white,62,4-year college,NM,0,0.453492051
+male,white,45,some college,NC,1,0.519037458
+male,white,34,4-year college,WI,0,0.50407989
+male,white,60,some college,NC,1,0.519037458
+female,white,65,hs,AZ,1,0.518900234
+female,white,52,post-grad,FL,0,0.506188355
+female,other,35,post-grad,KS,0,0.611114703
+female,white,54,hs,OH,0,0.542676846
+female,white,45,some college,NC,1,0.519037458
+female,white,62,hs,VA,0,0.471736237
+male,white,69,hs,PA,1,0.503755358
+female,other,21,some college,CA,0,0.338717892
+female,white,26,4-year college,PA,1,0.503755358
+female,black,35,4-year college,GA,1,0.526611726
+female,white,67,4-year college,FL,0,0.506188355
+female,other,48,hs,HI,0,0.325586625
+male,white,66,4-year college,MO,0,0.59818561
+male,white,30,hs,PA,1,0.503755358
+female,white,52,post-grad,GA,1,0.526611726
+female,white,55,post-grad,MI,1,0.501176682
+female,white,38,some college,PA,0,0.503755358
+male,white,64,hs,OH,1,0.542676846
+male,white,54,some college,NY,1,0.382275815
+male,white,55,4-year college,MI,1,0.501176682
+female,white,31,hs,WA,1,0.412130688
+female,white,54,hs,MD,0,0.359837503
+female,white,42,no hs,FL,1,0.506188355
+male,other,32,4-year college,IL,0,0.409799486
+male,white,80,4-year college,MN,0,0.491681431
+female,white,45,hs,TX,1,0.547132256
+male,white,36,post-grad,CA,0,0.338717892
+male,white,48,hs,CA,0,0.338717892
+male,white,74,post-grad,MN,1,0.491681431
+male,white,66,4-year college,IN,1,0.601173095
+female,black,43,some college,CA,0,0.338717892
+male,white,28,some college,MI,0,0.501176682
+female,white,64,hs,NJ,0,0.427158099
+female,white,35,hs,AZ,1,0.518900234
+female,other,33,some college,TX,0,0.547132256
+female,white,37,post-grad,CA,0,0.338717892
+male,white,61,some college,PA,1,0.503755358
+male,white,57,some college,CA,0,0.338717892
+female,white,28,4-year college,CT,0,0.428584525
+female,white,61,post-grad,NC,0,0.519037458
+female,white,57,no hs,AZ,1,0.518900234
+female,white,29,no hs,ID,1,0.683101767
+male,white,44,4-year college,PA,1,0.503755358
+female,black,30,hs,LA,0,0.601716772
+female,white,25,hs,TX,1,0.547132256
+male,white,63,hs,NC,1,0.519037458
+male,black,35,4-year college,IL,0,0.409799486
+female,white,66,hs,GA,1,0.526611726
+female,black,22,4-year college,NY,0,0.382275815
+male,white,63,some college,CA,1,0.338717892
+male,white,85,some college,IN,1,0.601173095
+male,white,32,4-year college,FL,0,0.506188355
+female,white,62,post-grad,MO,0,0.59818561
+male,white,53,hs,WY,1,0.757053196
+male,white,32,hs,GA,1,0.526611726
+female,black,24,hs,TX,0,0.547132256
+female,white,58,hs,FL,0,0.506188355
+male,white,98,post-grad,TN,0,0.63624343
+male,white,23,some college,TX,0,0.547132256
+female,white,69,hs,NJ,1,0.427158099
+female,white,38,hs,FL,0,0.506188355
+female,white,62,no hs,FL,0,0.506188355
+female,white,60,4-year college,IL,1,0.409799486
+male,white,40,some college,KY,1,0.65670629
+female,white,49,post-grad,IL,1,0.409799486
+female,white,43,4-year college,OH,0,0.542676846
+female,white,32,post-grad,NY,0,0.382275815
+male,other,79,some college,OK,0,0.693047372
+male,white,28,hs,OH,0,0.542676846
+female,black,20,hs,NC,1,0.519037458
+male,white,66,hs,AZ,0,0.518900234
+male,white,19,hs,WA,0,0.412130688
+male,other,25,hs,FL,1,0.506188355
+male,white,75,some college,CA,1,0.338717892
+female,white,38,hs,TX,1,0.547132256
+female,white,54,some college,MI,1,0.501176682
+female,white,44,some college,VA,1,0.471736237
+female,white,42,4-year college,OK,0,0.693047372
+male,white,65,post-grad,MA,1,0.353487213
+female,other,43,4-year college,IL,0,0.409799486
+female,white,83,4-year college,VA,0,0.471736237
+female,white,78,hs,AL,1,0.643741436
+female,other,19,4-year college,CA,1,0.338717892
+male,white,100,no hs,MD,1,0.359837503
+female,white,70,some college,WV,0,0.721610523
+female,white,33,hs,NC,0,0.519037458
+female,white,72,some college,MO,1,0.59818561
+female,other,30,4-year college,CA,1,0.338717892
+male,black,53,some college,TX,0,0.547132256
+female,black,43,4-year college,NJ,0,0.427158099
+female,other,41,some college,TX,0,0.547132256
+female,white,81,some college,CA,1,0.338717892
+female,white,56,some college,WI,0,0.50407989
+male,white,63,4-year college,NJ,0,0.427158099
+female,white,37,post-grad,MD,0,0.359837503
+female,white,67,some college,MA,0,0.353487213
+male,black,52,hs,NY,0,0.382275815
+female,black,35,4-year college,UT,0,0.623836582
+female,white,32,post-grad,IL,0,0.409799486
+female,white,32,hs,CO,1,0.473166666
+male,white,63,post-grad,OR,0,0.438441611
+female,white,52,4-year college,WY,0,0.757053196
+male,other,82,hs,MT,1,0.611096643
+female,white,24,some college,CA,0,0.338717892
+female,white,49,hs,LA,0,0.601716772
+female,white,49,some college,NJ,0,0.427158099
+male,white,43,post-grad,OR,1,0.438441611
+male,other,22,4-year college,AZ,0,0.518900234
+female,other,47,4-year college,TX,1,0.547132256
+female,white,35,4-year college,IA,0,0.550635478
+female,white,53,some college,WI,0,0.50407989
+female,white,25,some college,FL,0,0.506188355
+male,white,68,post-grad,HI,1,0.325586625
+female,white,41,hs,LA,1,0.601716772
+female,white,54,hs,SC,1,0.574602564
+female,white,41,post-grad,OH,0,0.542676846
+female,white,52,post-grad,CT,0,0.428584525
+female,white,73,hs,IN,0,0.601173095
+female,white,77,post-grad,NJ,1,0.427158099
+female,white,49,4-year college,NY,0,0.382275815
+female,white,69,hs,MN,1,0.491681431
+female,white,45,some college,NC,0,0.519037458
+female,white,51,hs,MA,0,0.353487213
+female,white,70,post-grad,OH,1,0.542676846
+female,white,47,some college,KY,1,0.65670629
+female,white,65,post-grad,KS,1,0.611114703
+male,other,34,no hs,NY,0,0.382275815
+female,black,30,post-grad,MA,0,0.353487213
+male,white,84,4-year college,WI,0,0.50407989
+male,white,41,hs,OH,0,0.542676846
+female,white,50,some college,DE,1,0.440013786
+male,white,86,some college,PA,0,0.503755358
+male,other,68,some college,NY,1,0.382275815
+female,other,23,hs,CA,0,0.338717892
+male,white,35,4-year college,MD,1,0.359837503
+male,other,23,some college,CA,0,0.338717892
+male,white,53,hs,TX,1,0.547132256
+male,white,29,hs,NC,1,0.519037458
+female,white,46,some college,NC,0,0.519037458
+male,white,20,hs,NH,1,0.498029716
+male,white,31,some college,NC,0,0.519037458
+male,black,32,some college,CA,1,0.338717892
+female,other,37,4-year college,TX,0,0.547132256
+male,white,53,4-year college,IN,0,0.601173095
+female,white,23,4-year college,GA,1,0.526611726
+male,white,40,post-grad,PA,0,0.503755358
+female,white,50,hs,WI,0,0.50407989
+male,white,47,some college,NH,1,0.498029716
+male,black,91,post-grad,MD,0,0.359837503
+male,other,19,hs,MO,1,0.59818561
+female,white,58,post-grad,CA,0,0.338717892
+female,white,94,post-grad,MA,0,0.353487213
+female,white,19,some college,TX,1,0.547132256
+female,white,28,4-year college,NY,0,0.382275815
+male,white,56,post-grad,WA,1,0.412130688
+male,white,55,hs,ID,1,0.683101767
+male,white,60,4-year college,KS,1,0.611114703
+female,white,63,hs,OH,0,0.542676846
+female,white,54,hs,ID,0,0.683101767
+female,black,64,post-grad,GA,0,0.526611726
+male,white,31,some college,TX,0,0.547132256
+female,white,56,hs,IA,1,0.550635478
+male,white,58,hs,PA,0,0.503755358
+female,white,54,4-year college,UT,0,0.623836582
+female,white,18,some college,CA,0,0.338717892
+male,other,33,some college,IL,1,0.409799486
+male,white,54,post-grad,CA,1,0.338717892
+female,white,51,some college,WA,0,0.412130688
+female,other,25,post-grad,CA,1,0.338717892
+female,white,26,post-grad,OH,0,0.542676846
+male,white,76,4-year college,CA,0,0.338717892
+female,white,45,4-year college,NJ,1,0.427158099
+female,white,23,hs,CA,0,0.338717892
+female,black,40,4-year college,CA,1,0.338717892
+female,white,18,post-grad,MO,0,0.59818561
+female,white,64,some college,MO,1,0.59818561
+female,white,26,hs,FL,0,0.506188355
+male,other,32,some college,CA,0,0.338717892
+male,white,54,4-year college,KY,1,0.65670629
+female,white,37,4-year college,OH,0,0.542676846
+female,white,47,4-year college,NY,1,0.382275815
+male,other,19,some college,FL,0,0.506188355
+female,white,66,4-year college,MI,1,0.501176682
+female,white,25,some college,NC,0,0.519037458
+female,white,59,no hs,PA,0,0.503755358
+male,white,63,hs,MN,0,0.491681431
+male,black,28,some college,SC,0,0.574602564
+female,white,92,hs,NE,1,0.635476741
+male,white,20,some college,NM,0,0.453492051
+female,white,62,hs,FL,0,0.506188355
+female,white,33,some college,MO,1,0.59818561
+male,white,90,some college,OH,0,0.542676846
+male,white,96,4-year college,OH,1,0.542676846
+female,white,73,hs,NY,0,0.382275815
+female,white,49,4-year college,MD,0,0.359837503
+female,white,21,hs,PA,0,0.503755358
+female,black,62,4-year college,MI,1,0.501176682
+female,white,19,some college,NC,0,0.519037458
+female,white,41,hs,IA,0,0.550635478
+male,white,59,some college,OH,1,0.542676846
+female,white,37,post-grad,MO,0,0.59818561
+female,white,25,hs,MO,0,0.59818561
+female,white,51,hs,NY,1,0.382275815
+female,white,48,some college,WA,1,0.412130688
+female,white,57,hs,IA,0,0.550635478
+male,white,67,post-grad,CO,1,0.473166666
+female,white,24,post-grad,NE,0,0.635476741
+female,white,97,hs,NH,0,0.498029716
+female,white,57,hs,CT,0,0.428584525
+male,white,49,hs,TN,0,0.63624343
+female,white,48,4-year college,PA,1,0.503755358
+male,white,24,some college,CA,1,0.338717892
+male,white,30,some college,VA,0,0.471736237
+female,white,61,4-year college,NC,0,0.519037458
+female,white,67,4-year college,OH,0,0.542676846
+female,other,49,hs,OH,0,0.542676846
+female,white,55,hs,WI,1,0.50407989
+male,other,58,some college,OH,1,0.542676846
+male,white,72,4-year college,MD,1,0.359837503
+female,white,49,hs,IL,0,0.409799486
+male,white,24,4-year college,VA,1,0.471736237
+male,white,59,hs,MN,0,0.491681431
+female,white,92,some college,CT,1,0.428584525
+female,white,35,some college,IL,0,0.409799486
+female,white,36,hs,OH,0,0.542676846
+male,white,22,hs,NY,0,0.382275815
+male,other,65,some college,FL,1,0.506188355
+female,white,66,hs,IL,0,0.409799486
+male,white,32,some college,FL,1,0.506188355
+female,white,43,post-grad,IA,0,0.550635478
+male,white,66,some college,IL,0,0.409799486
+male,white,29,hs,MN,1,0.491681431
+male,black,27,no hs,NY,0,0.382275815
+female,black,43,some college,MI,1,0.501176682
+male,white,98,4-year college,MI,0,0.501176682
+female,white,58,hs,NC,0,0.519037458
+female,other,50,some college,CA,1,0.338717892
+female,white,33,hs,WY,1,0.757053196
+male,white,50,hs,PA,0,0.503755358
+female,other,32,hs,WA,0,0.412130688
+male,white,59,some college,SC,1,0.574602564
+female,white,40,some college,MO,0,0.59818561
+female,white,74,hs,WI,0,0.50407989
+male,white,21,hs,NY,0,0.382275815
+male,other,33,post-grad,VA,1,0.471736237
+female,white,95,some college,MI,1,0.501176682
+male,black,39,hs,IN,0,0.601173095
+female,black,33,some college,AL,0,0.643741436
+male,white,66,4-year college,OH,1,0.542676846
+female,white,68,some college,IL,0,0.409799486
+female,black,62,4-year college,ID,0,0.683101767
+female,white,63,hs,NE,0,0.635476741
+female,white,62,hs,TX,1,0.547132256
+male,white,40,some college,NY,1,0.382275815
+male,white,48,some college,MN,1,0.491681431
+female,white,53,some college,KY,0,0.65670629
+female,white,18,4-year college,DE,1,0.440013786
+female,black,67,4-year college,NY,0,0.382275815
+male,other,54,4-year college,VA,0,0.471736237
+female,white,62,some college,OK,0,0.693047372
+male,white,36,some college,NC,0,0.519037458
+female,white,51,some college,KY,1,0.65670629
+male,white,57,hs,NY,1,0.382275815
+female,white,38,4-year college,MI,0,0.501176682
+female,other,64,some college,FL,0,0.506188355
+female,black,38,some college,NY,1,0.382275815
+female,black,66,4-year college,MS,1,0.590898473
+female,white,95,post-grad,TX,1,0.547132256
+female,white,87,hs,WA,0,0.412130688
+male,white,31,hs,NC,0,0.519037458
+female,white,22,post-grad,TX,0,0.547132256
+male,white,99,4-year college,WA,0,0.412130688
+female,white,28,4-year college,TX,0,0.547132256
+female,white,23,post-grad,IA,0,0.550635478
+male,white,38,4-year college,IL,1,0.409799486
+male,white,89,hs,CA,0,0.338717892
+female,other,23,some college,CT,0,0.428584525
+female,white,52,some college,TX,0,0.547132256
+female,white,55,hs,TN,0,0.63624343
+female,white,63,some college,CA,0,0.338717892
+female,white,33,hs,WV,1,0.721610523
+female,other,36,some college,NY,0,0.382275815
+male,white,91,some college,MO,1,0.59818561
+male,white,51,4-year college,OK,1,0.693047372
+male,other,49,some college,OK,1,0.693047372
+female,black,26,4-year college,MS,1,0.590898473
+female,white,36,some college,AL,1,0.643741436
+male,other,18,4-year college,CA,0,0.338717892
+female,white,48,some college,MA,0,0.353487213
+female,white,70,post-grad,CA,0,0.338717892
+male,white,64,4-year college,NY,0,0.382275815
+female,white,69,some college,MI,0,0.501176682
+male,other,66,4-year college,FL,0,0.506188355
+male,white,61,hs,SC,0,0.574602564
+male,black,47,hs,AR,0,0.642851377
+male,white,59,some college,UT,0,0.623836582
+female,white,53,no hs,OH,1,0.542676846
+male,white,39,post-grad,FL,0,0.506188355
+female,white,26,some college,MN,0,0.491681431
+male,white,67,4-year college,IN,1,0.601173095
+male,white,66,some college,FL,0,0.506188355
+female,white,43,hs,IL,0,0.409799486
+male,other,18,post-grad,FL,0,0.506188355
+male,white,66,some college,TX,0,0.547132256
+female,white,27,4-year college,IA,1,0.550635478
+female,other,55,4-year college,NM,1,0.453492051
+male,other,29,some college,MI,0,0.501176682
+male,white,19,some college,NC,1,0.519037458
+female,white,67,hs,WV,0,0.721610523
+male,other,37,some college,CA,0,0.338717892
+female,white,40,hs,NJ,0,0.427158099
+female,white,35,post-grad,TX,0,0.547132256
+male,white,28,4-year college,OH,0,0.542676846
+female,other,41,some college,OK,0,0.693047372
+female,white,58,some college,NC,1,0.519037458
+female,white,64,some college,CA,0,0.338717892
+female,white,50,some college,AZ,1,0.518900234
+female,white,62,hs,MS,0,0.590898473
+female,white,19,4-year college,CO,0,0.473166666
+male,white,56,hs,WV,1,0.721610523
+female,white,52,hs,IL,0,0.409799486
+female,white,40,4-year college,CO,1,0.473166666
+female,white,21,some college,WI,1,0.50407989
+male,white,96,some college,ND,1,0.698092429
+male,white,43,4-year college,TN,0,0.63624343
+female,other,23,some college,VA,0,0.471736237
+male,black,22,4-year college,MA,1,0.353487213
+male,white,46,some college,PA,1,0.503755358
+male,other,54,4-year college,WA,0,0.412130688
+male,white,19,post-grad,AR,0,0.642851377
+female,white,44,4-year college,FL,1,0.506188355
+female,white,33,post-grad,PA,0,0.503755358
+female,white,32,4-year college,MS,1,0.590898473
+female,black,30,some college,KS,1,0.611114703
+female,white,86,4-year college,MD,0,0.359837503
+female,other,23,4-year college,CA,1,0.338717892
+male,white,46,some college,NH,0,0.498029716
+female,white,76,hs,OR,0,0.438441611
+male,other,23,4-year college,CA,0,0.338717892
+female,black,69,hs,MI,0,0.501176682
+male,black,63,some college,FL,0,0.506188355
+male,white,54,4-year college,FL,1,0.506188355
+female,white,69,hs,MA,0,0.353487213
+female,white,51,hs,FL,0,0.506188355
+male,white,99,hs,TX,0,0.547132256
+female,white,61,hs,MI,0,0.501176682
+female,white,35,hs,TX,1,0.547132256
+male,white,54,hs,KY,1,0.65670629
+male,white,67,some college,VA,1,0.471736237
+female,white,25,hs,NY,1,0.382275815
+female,white,36,some college,AL,1,0.643741436
+female,white,36,4-year college,PA,0,0.503755358
+male,white,32,some college,FL,0,0.506188355
+male,white,56,some college,FL,0,0.506188355
+male,other,56,4-year college,WA,1,0.412130688
+female,white,40,hs,WI,0,0.50407989
+female,white,50,hs,NY,0,0.382275815
+female,white,31,hs,PA,0,0.503755358
+female,white,42,hs,NC,0,0.519037458
+male,other,22,4-year college,CA,1,0.338717892
+female,white,62,4-year college,TX,0,0.547132256
+male,white,98,hs,NJ,1,0.427158099
+male,other,87,4-year college,CA,0,0.338717892
+male,black,38,some college,GA,1,0.526611726
+male,white,51,hs,ND,1,0.698092429
+female,other,18,some college,FL,0,0.506188355
+female,white,20,hs,MN,0,0.491681431
+male,white,51,hs,PA,0,0.503755358
+male,white,69,4-year college,CO,0,0.473166666
+male,white,41,some college,TN,0,0.63624343
+female,other,23,some college,FL,1,0.506188355
+female,white,50,some college,IN,0,0.601173095
+male,white,67,some college,VA,1,0.471736237
+female,white,98,hs,NC,1,0.519037458
+female,white,36,hs,VA,0,0.471736237
+male,white,62,some college,FL,0,0.506188355
+female,white,58,no hs,MI,1,0.501176682
+female,white,82,4-year college,ID,1,0.683101767
+female,other,28,post-grad,TX,0,0.547132256
+female,white,85,hs,NV,0,0.487062906
+female,white,20,some college,CA,0,0.338717892
+male,white,32,some college,MO,1,0.59818561
+female,white,40,4-year college,SC,1,0.574602564
+female,white,41,4-year college,WA,1,0.412130688
+female,white,65,hs,SC,1,0.574602564
+male,white,68,4-year college,NV,1,0.487062906
+female,white,91,4-year college,NJ,0,0.427158099
+male,other,52,some college,CA,1,0.338717892
+female,black,67,no hs,VA,1,0.471736237
+female,white,35,hs,WI,0,0.50407989
+male,white,57,hs,MO,1,0.59818561
+female,white,69,post-grad,VA,0,0.471736237
+female,other,49,some college,NY,1,0.382275815
+female,white,54,hs,AZ,1,0.518900234
+female,white,23,some college,NE,0,0.635476741
+female,other,30,hs,TX,0,0.547132256
+male,white,39,post-grad,AL,1,0.643741436
+female,white,70,hs,PA,0,0.503755358
+female,white,46,4-year college,CA,1,0.338717892
+female,other,32,some college,NV,1,0.487062906
+male,white,66,4-year college,NY,1,0.382275815
+female,white,36,some college,KY,1,0.65670629
+female,white,51,some college,OH,0,0.542676846
+female,black,18,post-grad,NY,0,0.382275815
+female,white,37,4-year college,VA,0,0.471736237
+male,white,50,hs,CA,0,0.338717892
+female,white,43,some college,OR,0,0.438441611
+female,white,64,some college,NV,1,0.487062906
+male,white,54,some college,NC,1,0.519037458
+female,white,45,some college,OR,0,0.438441611
+male,white,31,hs,AZ,1,0.518900234
+male,white,53,hs,CA,1,0.338717892
+female,black,40,hs,MD,1,0.359837503
+female,white,32,hs,VA,1,0.471736237
+female,white,69,some college,NE,1,0.635476741
+male,white,36,some college,TN,0,0.63624343
+female,white,68,some college,WI,0,0.50407989
+female,white,53,hs,LA,1,0.601716772
+male,white,75,some college,OH,1,0.542676846
+female,white,30,post-grad,WA,0,0.412130688
+female,white,25,4-year college,NJ,0,0.427158099
+male,white,55,hs,MI,0,0.501176682
+male,white,50,post-grad,IL,1,0.409799486
+female,white,79,some college,AR,1,0.642851377
+female,white,34,post-grad,MT,0,0.611096643
+female,white,68,hs,NY,0,0.382275815
+male,white,90,some college,UT,0,0.623836582
+male,white,18,some college,NH,1,0.498029716
+male,white,87,some college,AZ,1,0.518900234
+female,other,44,some college,CA,0,0.338717892
+male,white,63,4-year college,NC,0,0.519037458
+male,white,81,some college,ME,0,0.484032089
+female,white,52,4-year college,TX,1,0.547132256
+female,other,31,hs,CA,0,0.338717892
+female,black,45,some college,TN,0,0.63624343
+male,white,72,post-grad,NY,0,0.382275815
+male,other,69,hs,CA,0,0.338717892
+male,white,22,4-year college,TX,1,0.547132256
+male,white,71,hs,MO,0,0.59818561
+male,black,37,hs,LA,0,0.601716772
+male,black,33,some college,CA,0,0.338717892
+male,white,69,4-year college,PA,0,0.503755358
+female,other,28,some college,WA,1,0.412130688
+female,other,38,4-year college,GA,0,0.526611726
+male,white,77,post-grad,WA,1,0.412130688
+male,other,61,hs,CA,0,0.338717892
+male,other,18,some college,WA,0,0.412130688
+female,white,62,post-grad,AZ,0,0.518900234
+female,other,51,post-grad,WA,0,0.412130688
+male,other,35,post-grad,NC,0,0.519037458
+female,white,70,hs,MT,1,0.611096643
+female,white,56,4-year college,NY,0,0.382275815
+male,white,85,some college,KS,1,0.611114703
+female,white,52,no hs,PA,0,0.503755358
+male,white,99,some college,NM,1,0.453492051
+female,other,94,4-year college,CO,0,0.473166666
+female,white,36,post-grad,MA,1,0.353487213
+female,white,58,hs,NY,0,0.382275815
+female,other,22,4-year college,FL,0,0.506188355
+male,other,55,post-grad,IL,0,0.409799486
+male,other,46,post-grad,WA,0,0.412130688
+female,white,99,4-year college,FL,1,0.506188355
+female,white,75,hs,NY,0,0.382275815
+female,white,55,some college,KY,0,0.65670629
+female,white,22,hs,VA,0,0.471736237
+female,white,37,hs,MD,0,0.359837503
+male,white,50,hs,FL,1,0.506188355
+female,white,68,hs,AZ,1,0.518900234
+female,white,67,4-year college,NJ,1,0.427158099
+male,white,30,4-year college,CA,1,0.338717892
+female,other,37,hs,AL,0,0.643741436
+male,white,81,post-grad,CO,1,0.473166666
+male,white,68,some college,MT,0,0.611096643
+female,black,54,some college,GA,0,0.526611726
+female,white,60,hs,IL,0,0.409799486
+female,other,55,some college,TX,0,0.547132256
+male,white,69,some college,LA,0,0.601716772
+female,white,29,4-year college,PA,0,0.503755358
+male,white,50,post-grad,TX,0,0.547132256
+male,other,50,some college,NJ,1,0.427158099
+female,white,35,some college,UT,1,0.623836582
+male,white,45,post-grad,MO,0,0.59818561
+female,white,90,hs,FL,0,0.506188355
+female,other,23,4-year college,CA,1,0.338717892
+male,white,36,some college,MN,0,0.491681431
+male,white,61,4-year college,TX,0,0.547132256
+female,white,20,some college,MN,0,0.491681431
+male,other,32,some college,FL,0,0.506188355
+female,other,45,4-year college,FL,0,0.506188355
+male,white,52,4-year college,CA,1,0.338717892
+male,white,64,no hs,NJ,1,0.427158099
+male,other,36,4-year college,CA,0,0.338717892
+female,white,29,4-year college,NJ,0,0.427158099
+male,black,24,some college,LA,0,0.601716772
+female,white,34,post-grad,CO,1,0.473166666
+female,white,26,hs,NJ,0,0.427158099
+male,black,24,4-year college,VA,0,0.471736237
+female,white,56,some college,MI,0,0.501176682
+male,white,74,hs,OH,1,0.542676846
+male,white,70,4-year college,CA,1,0.338717892
+male,white,65,some college,WA,1,0.412130688
+female,white,54,some college,ID,1,0.683101767
+female,black,36,some college,FL,1,0.506188355
+female,white,45,some college,OK,1,0.693047372
+female,other,21,post-grad,WA,0,0.412130688
+male,white,54,some college,MT,1,0.611096643
+female,black,33,some college,IN,0,0.601173095
+female,white,52,no hs,AZ,0,0.518900234
+female,white,62,no hs,WA,0,0.412130688
+female,white,50,hs,TX,0,0.547132256
+female,white,61,hs,IN,1,0.601173095
+female,other,69,some college,CO,1,0.473166666
+female,white,18,some college,TN,0,0.63624343
+male,white,84,post-grad,GA,1,0.526611726
+male,black,43,hs,PA,1,0.503755358
+female,white,46,some college,NC,1,0.519037458
+female,other,22,some college,WI,0,0.50407989
+male,white,84,some college,CA,1,0.338717892
+male,white,80,no hs,UT,1,0.623836582
+female,other,48,some college,RI,0,0.416892959
+male,white,58,some college,MI,1,0.501176682
+female,white,37,hs,TX,1,0.547132256
+female,white,52,hs,MA,1,0.353487213
+male,white,50,hs,TN,0,0.63624343
+female,white,26,4-year college,NY,1,0.382275815
+male,white,50,hs,OH,0,0.542676846
+male,white,76,post-grad,PA,0,0.503755358
+female,white,21,some college,ID,0,0.683101767
+female,white,41,some college,CA,0,0.338717892
+female,white,30,post-grad,MA,0,0.353487213
+female,white,55,hs,IN,0,0.601173095
+female,white,21,post-grad,VA,0,0.471736237
+male,white,90,some college,NE,1,0.635476741
+female,white,61,post-grad,KS,0,0.611114703
+male,white,64,4-year college,AL,1,0.643741436
+female,other,49,post-grad,OH,0,0.542676846
+female,white,22,some college,SC,1,0.574602564
+female,black,59,some college,IL,0,0.409799486
+female,white,66,some college,TX,1,0.547132256
+female,white,20,some college,WI,0,0.50407989
+male,white,57,post-grad,FL,1,0.506188355
+female,white,40,4-year college,TX,0,0.547132256
+male,white,61,4-year college,CA,0,0.338717892
+female,black,39,4-year college,NJ,0,0.427158099
+male,white,34,4-year college,IL,0,0.409799486
+male,black,57,post-grad,CA,0,0.338717892
+female,white,19,4-year college,CA,1,0.338717892
+female,other,56,hs,CA,0,0.338717892
+male,white,60,hs,NC,1,0.519037458
+female,white,21,hs,MI,0,0.501176682
+male,white,25,some college,KS,1,0.611114703
+male,white,46,4-year college,MI,0,0.501176682
+female,white,88,hs,IN,0,0.601173095
+male,white,60,some college,IN,1,0.601173095
+female,white,61,hs,FL,0,0.506188355
+female,white,65,4-year college,MA,0,0.353487213
+female,white,24,some college,IN,0,0.601173095
+female,white,63,4-year college,AZ,1,0.518900234
+female,other,21,4-year college,IL,1,0.409799486
+female,white,31,hs,NY,1,0.382275815
+female,white,97,post-grad,FL,0,0.506188355
+male,white,84,post-grad,MN,0,0.491681431
+female,white,53,post-grad,VA,1,0.471736237
+female,other,22,hs,MI,0,0.501176682
+female,white,55,hs,OR,0,0.438441611
+female,black,18,post-grad,MD,0,0.359837503
+male,black,32,hs,GA,1,0.526611726
+female,other,27,hs,CA,0,0.338717892
+male,white,65,post-grad,NV,0,0.487062906
+male,white,47,post-grad,TN,1,0.63624343
+female,white,27,post-grad,PA,0,0.503755358
+male,white,38,some college,NJ,0,0.427158099
+male,white,56,some college,PA,0,0.503755358
+male,other,56,post-grad,FL,1,0.506188355
+female,white,27,some college,ID,1,0.683101767
+male,white,41,4-year college,WA,1,0.412130688
+male,white,43,no hs,OR,1,0.438441611
+female,other,33,some college,IL,0,0.409799486
+female,white,62,hs,NE,1,0.635476741
+female,white,65,some college,FL,0,0.506188355
+male,white,54,4-year college,MA,1,0.353487213
+male,white,37,some college,GA,1,0.526611726
+male,white,25,hs,IN,1,0.601173095
+male,white,22,hs,NY,0,0.382275815
+male,white,21,4-year college,AZ,0,0.518900234
+female,black,59,some college,MD,1,0.359837503
+male,white,45,some college,MO,0,0.59818561
+female,white,59,4-year college,WV,0,0.721610523
+male,other,26,some college,GA,0,0.526611726
+male,white,73,post-grad,WI,0,0.50407989
+female,white,34,4-year college,NV,0,0.487062906
+male,other,55,4-year college,RI,0,0.416892959
+male,white,60,some college,GA,1,0.526611726
+male,white,39,some college,MN,0,0.491681431
+female,white,78,hs,CA,0,0.338717892
+male,white,28,some college,GA,1,0.526611726
+male,white,58,some college,WI,1,0.50407989
+female,white,56,hs,NC,1,0.519037458
+male,other,29,post-grad,NY,0,0.382275815
+male,white,20,some college,VA,1,0.471736237
+female,white,20,4-year college,CA,0,0.338717892
+female,white,30,some college,OH,0,0.542676846
+male,white,97,some college,CT,0,0.428584525
+male,white,42,post-grad,NY,0,0.382275815
+female,white,48,some college,IA,1,0.550635478
+female,white,44,hs,IN,1,0.601173095
+female,black,38,some college,GA,1,0.526611726
+male,white,93,some college,WI,1,0.50407989
+female,other,64,4-year college,TN,0,0.63624343
+female,white,88,some college,AZ,0,0.518900234
+female,other,34,hs,TN,1,0.63624343
+male,white,57,some college,AZ,1,0.518900234
+male,white,55,hs,FL,1,0.506188355
+male,black,56,4-year college,CT,0,0.428584525
+female,white,33,some college,IN,1,0.601173095
+male,white,43,4-year college,AL,1,0.643741436
+male,white,68,some college,VA,0,0.471736237
+female,other,33,hs,AZ,0,0.518900234
+female,white,23,some college,FL,1,0.506188355
+female,white,47,4-year college,GA,1,0.526611726
+male,other,89,some college,WA,0,0.412130688
+female,white,19,4-year college,FL,0,0.506188355
+female,black,28,hs,CA,0,0.338717892
+female,black,62,some college,TX,0,0.547132256
+male,white,28,4-year college,FL,1,0.506188355
+male,white,38,some college,CO,0,0.473166666
+male,white,81,some college,VA,1,0.471736237
+female,white,60,post-grad,CA,0,0.338717892
+male,white,48,hs,TX,0,0.547132256
+female,white,52,hs,GA,1,0.526611726
+female,white,84,hs,NE,0,0.635476741
+female,white,95,4-year college,FL,1,0.506188355
+female,other,29,hs,TX,0,0.547132256
+female,white,62,post-grad,TX,0,0.547132256
+female,white,19,hs,OH,1,0.542676846
+female,other,67,hs,CT,0,0.428584525
+female,white,61,hs,OR,1,0.438441611
+female,black,38,4-year college,TX,0,0.547132256
+female,white,70,4-year college,TX,0,0.547132256
+male,other,50,hs,HI,0,0.325586625
+male,white,34,4-year college,PA,0,0.503755358
+male,white,65,no hs,PA,0,0.503755358
+male,white,45,some college,DE,1,0.440013786
+male,white,30,post-grad,PA,1,0.503755358
+female,white,47,hs,SC,1,0.574602564
+male,white,55,some college,NY,1,0.382275815
+female,white,61,hs,MA,0,0.353487213
+male,white,100,hs,WI,1,0.50407989
+male,black,49,hs,AR,0,0.642851377
+female,white,25,4-year college,MN,1,0.491681431
+female,other,43,some college,CA,0,0.338717892
+male,white,29,some college,FL,0,0.506188355
+male,white,55,4-year college,IL,0,0.409799486
+female,white,44,some college,PA,1,0.503755358
+female,other,24,some college,NY,0,0.382275815
+male,white,28,4-year college,NY,1,0.382275815
+female,white,82,post-grad,VA,1,0.471736237
+female,white,46,some college,NJ,1,0.427158099
+male,other,50,some college,CA,0,0.338717892
+female,white,67,some college,WI,1,0.50407989
+female,white,32,some college,VA,0,0.471736237
+male,white,58,4-year college,WA,0,0.412130688
+male,white,35,hs,IA,1,0.550635478
+female,white,36,4-year college,KY,1,0.65670629
+male,white,33,4-year college,MN,0,0.491681431
+male,white,61,hs,MI,0,0.501176682
+male,white,61,4-year college,PA,0,0.503755358
+female,other,47,4-year college,CO,1,0.473166666
+female,white,31,4-year college,MO,0,0.59818561
+female,black,42,some college,VA,0,0.471736237
+male,white,18,some college,NY,1,0.382275815
+female,white,34,4-year college,PA,0,0.503755358
+female,white,36,no hs,NC,0,0.519037458
+male,white,52,4-year college,NY,0,0.382275815
+male,white,45,4-year college,PA,0,0.503755358
+male,white,58,hs,NY,0,0.382275815
+male,white,50,4-year college,TX,0,0.547132256
+female,white,67,hs,KY,0,0.65670629
+male,white,64,some college,FL,0,0.506188355
+male,white,59,post-grad,CA,1,0.338717892
+female,white,21,some college,SC,0,0.574602564
+female,white,63,4-year college,FL,1,0.506188355
+male,white,46,hs,VA,0,0.471736237
+male,white,56,4-year college,MT,0,0.611096643
+female,white,95,4-year college,CA,0,0.338717892
+male,white,65,4-year college,AL,1,0.643741436
+female,white,28,hs,IN,0,0.601173095
+male,white,91,some college,CO,1,0.473166666
+male,white,43,some college,TN,0,0.63624343
+female,white,69,4-year college,MD,0,0.359837503
+female,black,20,some college,CO,0,0.473166666
+male,white,38,hs,IN,1,0.601173095
+female,white,37,4-year college,WI,0,0.50407989
+male,white,31,post-grad,MN,0,0.491681431
+male,white,30,post-grad,PA,0,0.503755358
+female,other,61,hs,CO,0,0.473166666
+female,other,40,4-year college,CA,1,0.338717892
+male,black,81,some college,FL,0,0.506188355
+female,black,45,4-year college,GA,0,0.526611726
+female,other,23,4-year college,CA,0,0.338717892
+male,white,42,hs,WA,1,0.412130688
+female,other,32,post-grad,MN,0,0.491681431
+female,white,64,hs,OH,0,0.542676846
+female,white,36,some college,NJ,1,0.427158099
+female,white,46,no hs,IN,0,0.601173095
+female,white,20,4-year college,MA,0,0.353487213
+female,white,35,some college,NM,0,0.453492051
+female,white,46,hs,LA,1,0.601716772
+female,white,20,post-grad,MI,0,0.501176682
+male,white,86,no hs,AZ,1,0.518900234
+male,white,64,hs,PA,0,0.503755358
+male,white,52,4-year college,IL,1,0.409799486
+male,white,61,hs,MI,1,0.501176682
+female,white,51,4-year college,MO,0,0.59818561
+female,white,68,hs,NC,1,0.519037458
+male,white,18,hs,MD,1,0.359837503
+female,white,59,hs,CA,0,0.338717892
+male,other,59,some college,FL,0,0.506188355
+male,other,83,hs,CA,0,0.338717892
+female,white,72,4-year college,TX,1,0.547132256
+male,white,65,hs,PA,1,0.503755358
+female,black,21,some college,TN,1,0.63624343
+male,other,45,4-year college,NE,0,0.635476741
+male,other,20,4-year college,VA,0,0.471736237
+female,white,19,hs,PA,1,0.503755358
+male,white,56,4-year college,CO,1,0.473166666
+male,white,43,hs,IN,1,0.601173095
+male,white,59,4-year college,TX,1,0.547132256
+male,white,37,hs,FL,0,0.506188355
+female,other,54,hs,CA,1,0.338717892
+male,other,26,hs,CA,0,0.338717892
+female,white,66,some college,PA,0,0.503755358
+female,white,49,hs,IN,1,0.601173095
+male,white,75,post-grad,OH,1,0.542676846
+female,white,39,post-grad,WI,0,0.50407989
+female,black,24,hs,NY,0,0.382275815
+female,white,43,some college,MO,1,0.59818561
+male,white,52,post-grad,GA,1,0.526611726
+male,white,32,post-grad,KY,1,0.65670629
+female,white,59,post-grad,TX,0,0.547132256
+male,white,59,no hs,OH,1,0.542676846
+male,other,31,some college,NJ,1,0.427158099
+female,white,27,hs,WV,1,0.721610523
+male,other,42,post-grad,NY,0,0.382275815
+female,black,43,hs,VA,0,0.471736237
+male,white,60,post-grad,FL,1,0.506188355
+female,white,28,post-grad,MO,1,0.59818561
+male,white,98,hs,NV,1,0.487062906
+female,white,60,hs,NY,1,0.382275815
+male,white,33,4-year college,MI,0,0.501176682
+female,white,60,some college,TX,0,0.547132256
+male,white,61,hs,WA,0,0.412130688
+male,white,46,4-year college,NY,0,0.382275815
+male,other,66,4-year college,TX,0,0.547132256
+female,white,58,hs,SC,0,0.574602564
+female,white,49,hs,KS,1,0.611114703
+female,white,43,post-grad,MN,0,0.491681431
+male,white,54,some college,OR,0,0.438441611
+female,white,27,hs,FL,0,0.506188355
+male,white,64,some college,OR,0,0.438441611
+female,other,55,hs,CA,1,0.338717892
+male,white,92,post-grad,NY,0,0.382275815
+male,black,30,some college,CA,0,0.338717892
+female,other,47,hs,TX,1,0.547132256
+female,white,39,hs,MI,0,0.501176682
+female,other,47,some college,CA,0,0.338717892
+female,white,98,hs,GA,1,0.526611726
+female,white,40,some college,TX,1,0.547132256
+male,white,61,hs,AZ,0,0.518900234
+male,white,23,4-year college,CT,0,0.428584525
+male,white,50,4-year college,KY,1,0.65670629
+female,white,43,hs,NY,0,0.382275815
+female,white,22,4-year college,IL,0,0.409799486
+female,other,77,post-grad,KY,1,0.65670629
+male,other,46,hs,TX,0,0.547132256
+female,white,35,4-year college,IN,1,0.601173095
+male,black,45,hs,SC,0,0.574602564
+female,other,43,post-grad,NY,0,0.382275815
+female,white,63,hs,FL,0,0.506188355
+female,white,76,hs,DE,1,0.440013786
+male,other,34,some college,PA,1,0.503755358
+female,white,65,some college,GA,0,0.526611726
+female,other,61,4-year college,CA,0,0.338717892
+male,white,73,4-year college,AL,1,0.643741436
+female,white,37,post-grad,CA,0,0.338717892
+female,other,55,hs,CA,1,0.338717892
+female,white,55,hs,CA,0,0.338717892
+female,white,90,some college,AL,1,0.643741436
+female,white,97,4-year college,WA,0,0.412130688
+male,white,72,hs,PA,1,0.503755358
+male,white,27,4-year college,NV,0,0.487062906
+female,other,56,some college,TX,0,0.547132256
+female,white,62,hs,MA,0,0.353487213
+female,other,21,some college,FL,0,0.506188355
+female,white,62,hs,KY,1,0.65670629
+male,white,68,some college,LA,1,0.601716772
+female,other,24,some college,SC,0,0.574602564
+female,white,24,some college,OH,1,0.542676846
+male,white,24,some college,CA,1,0.338717892
+male,white,45,hs,TN,1,0.63624343
+female,white,64,hs,VA,1,0.471736237
+male,black,41,4-year college,CA,1,0.338717892
+female,white,49,hs,MA,0,0.353487213
+female,other,45,4-year college,CA,1,0.338717892
+female,white,43,hs,FL,0,0.506188355
+female,white,40,4-year college,CA,0,0.338717892
+female,white,46,4-year college,PA,1,0.503755358
+female,white,25,4-year college,IL,1,0.409799486
+female,other,21,hs,CA,0,0.338717892
+female,white,72,some college,AL,0,0.643741436
+female,white,56,post-grad,CA,0,0.338717892
+female,white,83,4-year college,TX,1,0.547132256
+female,black,61,some college,AL,1,0.643741436
+female,white,56,hs,OH,0,0.542676846
+female,black,85,some college,TN,0,0.63624343
+male,white,66,post-grad,TX,0,0.547132256
+female,white,44,some college,NE,1,0.635476741
+female,white,38,4-year college,CA,0,0.338717892
+male,white,58,some college,OR,1,0.438441611
+male,other,69,hs,CA,0,0.338717892
+male,other,56,some college,MD,1,0.359837503
+female,white,51,hs,AL,0,0.643741436
+female,black,98,hs,NC,0,0.519037458
+female,white,66,some college,IL,0,0.409799486
+female,white,81,4-year college,CA,1,0.338717892
+female,white,23,4-year college,NY,0,0.382275815
+female,white,72,some college,KS,1,0.611114703
+female,white,48,some college,IN,0,0.601173095
+female,black,24,no hs,NY,0,0.382275815
+female,other,31,some college,LA,0,0.601716772
+male,other,24,some college,CA,0,0.338717892
+female,white,69,hs,OH,0,0.542676846
+female,white,29,some college,VA,0,0.471736237
+male,white,57,some college,MI,1,0.501176682
+female,white,67,hs,ME,0,0.484032089
+male,other,55,post-grad,TX,1,0.547132256
+male,white,46,hs,MA,0,0.353487213
+male,white,53,4-year college,IA,0,0.550635478
+female,white,49,some college,CA,0,0.338717892
+male,white,27,some college,GA,1,0.526611726
+male,white,79,post-grad,WA,1,0.412130688
+female,other,23,4-year college,CT,1,0.428584525
+male,white,58,post-grad,WI,1,0.50407989
+male,other,52,some college,WY,1,0.757053196
+male,white,42,hs,IL,1,0.409799486
+female,other,24,post-grad,CA,1,0.338717892
+male,white,47,hs,MO,1,0.59818561
+female,white,18,no hs,GA,0,0.526611726
+female,white,52,post-grad,FL,0,0.506188355
+female,white,91,hs,NJ,0,0.427158099
+female,black,60,hs,PA,0,0.503755358
+female,black,65,some college,FL,0,0.506188355
+male,white,64,post-grad,MI,0,0.501176682
+male,white,64,4-year college,NM,0,0.453492051
+female,white,54,some college,DE,1,0.440013786
+female,white,44,some college,AZ,0,0.518900234
+male,white,47,4-year college,TN,1,0.63624343
+female,white,61,hs,OH,1,0.542676846
+female,white,28,4-year college,NH,0,0.498029716
+male,other,18,hs,VA,0,0.471736237
+male,other,40,some college,MO,1,0.59818561
+female,white,60,hs,IA,1,0.550635478
+male,white,49,hs,MN,1,0.491681431
+male,white,44,hs,IN,0,0.601173095
+female,white,27,hs,KY,0,0.65670629
+female,white,46,no hs,ME,0,0.484032089
+female,white,22,some college,NY,0,0.382275815
+male,white,29,4-year college,MA,0,0.353487213
+female,white,82,4-year college,CA,0,0.338717892
+female,other,41,post-grad,NH,0,0.498029716
+male,other,22,some college,PA,0,0.503755358
+female,black,63,some college,KS,0,0.611114703
+male,white,24,4-year college,AL,0,0.643741436
+male,black,25,hs,FL,1,0.506188355
+female,other,48,4-year college,MA,0,0.353487213
+female,white,28,hs,RI,1,0.416892959
+male,white,24,hs,FL,0,0.506188355
+male,white,19,hs,FL,0,0.506188355
+male,white,58,4-year college,WI,1,0.50407989
+female,other,24,no hs,PA,1,0.503755358
+male,other,35,4-year college,NJ,1,0.427158099
+male,other,36,4-year college,CA,0,0.338717892
+female,white,58,4-year college,UT,0,0.623836582
+female,white,48,hs,TN,0,0.63624343
+female,other,28,4-year college,NY,0,0.382275815
+female,black,33,hs,MI,0,0.501176682
+female,white,64,hs,KS,0,0.611114703
+female,white,20,hs,NJ,0,0.427158099
+female,white,43,hs,RI,1,0.416892959
+male,white,47,4-year college,CT,0,0.428584525
+female,white,68,post-grad,IL,0,0.409799486
+female,white,26,4-year college,OH,1,0.542676846
+female,other,34,some college,MI,0,0.501176682
+male,white,71,some college,MO,0,0.59818561
+female,white,65,hs,OH,1,0.542676846
+female,other,28,hs,NY,1,0.382275815
+female,black,30,post-grad,CA,1,0.338717892
+female,white,23,some college,MA,0,0.353487213
+female,white,42,some college,MI,1,0.501176682
+male,white,54,some college,IN,0,0.601173095
+male,white,29,hs,MI,1,0.501176682
+female,black,29,some college,MI,0,0.501176682
+male,other,40,post-grad,WA,0,0.412130688
+male,black,49,some college,FL,1,0.506188355
+male,white,95,hs,MO,1,0.59818561
+female,white,34,4-year college,NY,1,0.382275815
+female,white,24,some college,AL,1,0.643741436
+male,white,50,some college,NC,1,0.519037458
+female,white,65,no hs,KY,0,0.65670629
+female,white,44,hs,NY,0,0.382275815
+female,other,56,hs,IA,1,0.550635478
+female,white,58,some college,AL,1,0.643741436
+male,white,53,post-grad,DE,0,0.440013786
+female,white,59,hs,FL,0,0.506188355
+male,white,30,some college,IN,0,0.601173095
+female,white,24,some college,MA,0,0.353487213
+male,white,50,hs,NV,0,0.487062906
+female,white,72,hs,NY,1,0.382275815
+female,white,33,hs,MO,1,0.59818561
+female,white,54,hs,FL,0,0.506188355
+female,other,45,hs,CT,1,0.428584525
+female,white,66,hs,NY,0,0.382275815
+female,other,30,some college,OH,1,0.542676846
+female,white,98,some college,NV,0,0.487062906
+male,white,78,hs,MD,0,0.359837503
+male,white,54,4-year college,MI,1,0.501176682
+male,white,45,4-year college,MI,1,0.501176682
+female,white,84,4-year college,MI,0,0.501176682
+female,white,50,hs,NJ,1,0.427158099
+female,white,24,hs,PA,0,0.503755358
+male,white,51,4-year college,TX,1,0.547132256
+male,white,36,4-year college,WI,1,0.50407989
+male,white,38,post-grad,MI,0,0.501176682
+female,other,54,hs,UT,0,0.623836582
+female,white,34,some college,MO,0,0.59818561
+male,other,46,hs,TX,1,0.547132256
+male,other,36,some college,NV,1,0.487062906
+male,white,36,4-year college,IN,1,0.601173095
+male,other,34,hs,TX,1,0.547132256
+female,white,62,some college,OK,1,0.693047372
+male,white,93,some college,GA,1,0.526611726
+female,white,85,hs,OH,1,0.542676846
+male,black,57,4-year college,CA,0,0.338717892
+female,other,55,some college,NC,0,0.519037458
+female,white,48,4-year college,PA,0,0.503755358
+female,other,48,some college,UT,0,0.623836582
+male,white,58,4-year college,MI,0,0.501176682
+female,white,77,post-grad,NY,1,0.382275815
+female,white,44,hs,OH,1,0.542676846
+female,other,18,4-year college,CA,0,0.338717892
+male,white,23,post-grad,MA,1,0.353487213
+female,white,31,post-grad,LA,1,0.601716772
+female,black,25,some college,IL,0,0.409799486
+female,white,21,some college,OH,0,0.542676846
+female,white,75,4-year college,OK,0,0.693047372
+female,white,48,hs,AL,1,0.643741436
+female,white,44,hs,CA,0,0.338717892
+male,other,24,some college,MN,0,0.491681431
+male,other,87,4-year college,HI,1,0.325586625
+male,white,91,some college,IN,0,0.601173095
+male,white,90,4-year college,PA,1,0.503755358
+female,white,79,some college,PA,1,0.503755358
+male,white,21,some college,PA,0,0.503755358
+male,other,74,post-grad,TX,1,0.547132256
+female,white,21,some college,TX,0,0.547132256
+female,black,24,some college,IL,1,0.409799486
+female,other,39,some college,CO,0,0.473166666
+male,white,19,post-grad,IN,0,0.601173095
+female,white,74,some college,CA,0,0.338717892
+female,white,56,hs,IN,0,0.601173095
+male,white,56,hs,TX,1,0.547132256
+female,white,55,4-year college,MT,0,0.611096643
+female,white,36,hs,IN,1,0.601173095
+female,other,28,some college,AZ,0,0.518900234
+female,white,25,hs,AR,0,0.642851377
+male,white,49,some college,NY,0,0.382275815
+female,white,39,4-year college,IL,0,0.409799486
+male,other,48,some college,IL,1,0.409799486
+male,white,99,some college,FL,0,0.506188355
+male,white,21,hs,MO,1,0.59818561
+male,white,52,some college,NC,1,0.519037458
+female,white,21,4-year college,PA,0,0.503755358
+male,white,58,post-grad,CA,1,0.338717892
+male,white,66,hs,VA,1,0.471736237
+female,white,39,some college,AR,1,0.642851377
+female,white,30,some college,OH,0,0.542676846
+male,white,32,post-grad,MI,1,0.501176682
+female,white,20,no hs,OH,0,0.542676846
+female,other,22,hs,CA,1,0.338717892
+male,white,55,4-year college,NY,0,0.382275815
+male,white,24,4-year college,KS,1,0.611114703
+male,white,66,post-grad,TX,1,0.547132256
+female,white,60,some college,NC,0,0.519037458
+male,other,34,4-year college,CA,1,0.338717892
+male,white,72,post-grad,FL,0,0.506188355
+male,white,45,some college,MI,0,0.501176682
+male,white,33,post-grad,MD,1,0.359837503
+female,white,28,hs,TX,1,0.547132256
+female,white,23,some college,WV,0,0.721610523
+male,other,30,4-year college,GA,0,0.526611726
+female,white,24,some college,MO,0,0.59818561
+female,white,43,hs,NY,0,0.382275815
+male,white,60,some college,PA,1,0.503755358
+male,other,27,4-year college,GA,0,0.526611726
+male,white,76,hs,FL,1,0.506188355
+female,white,55,hs,TN,1,0.63624343
+female,white,61,4-year college,MA,0,0.353487213
+male,other,31,hs,WI,1,0.50407989
+female,white,41,hs,TX,1,0.547132256
+male,white,62,4-year college,NJ,0,0.427158099
+female,other,52,post-grad,KS,0,0.611114703
+female,white,67,no hs,CA,0,0.338717892
+male,white,97,post-grad,VA,1,0.471736237
+male,white,38,4-year college,OH,0,0.542676846
+male,white,55,hs,OR,0,0.438441611
+male,white,43,post-grad,VA,0,0.471736237
+male,white,24,no hs,IA,0,0.550635478
+female,other,36,post-grad,MD,0,0.359837503
+male,white,59,4-year college,VA,1,0.471736237
+male,white,73,4-year college,CA,1,0.338717892
+female,white,37,hs,GA,0,0.526611726
+female,white,64,4-year college,NC,0,0.519037458
+male,white,44,some college,MO,0,0.59818561
+female,white,38,some college,CO,1,0.473166666
+female,white,58,hs,KY,0,0.65670629
+female,white,67,4-year college,CA,1,0.338717892
+female,white,34,hs,OH,0,0.542676846
+male,white,42,hs,OH,0,0.542676846
+male,white,23,some college,PA,1,0.503755358
+female,white,56,post-grad,NJ,0,0.427158099
+male,white,85,some college,KS,1,0.611114703
+female,other,28,some college,AZ,0,0.518900234
+female,other,46,post-grad,CA,0,0.338717892
+female,white,85,post-grad,OR,0,0.438441611
+male,white,67,hs,PA,1,0.503755358
+male,other,44,post-grad,GA,0,0.526611726
+male,other,32,4-year college,KY,0,0.65670629
+female,white,50,4-year college,CO,0,0.473166666
+male,white,51,some college,TN,1,0.63624343
+female,black,21,4-year college,NJ,0,0.427158099
+female,white,81,hs,TX,1,0.547132256
+male,white,68,hs,PA,0,0.503755358
+male,white,29,hs,PA,1,0.503755358
+female,black,36,4-year college,NJ,0,0.427158099
+male,white,60,hs,WI,0,0.50407989
+female,white,52,no hs,NY,0,0.382275815
+female,white,38,post-grad,NY,0,0.382275815
+female,white,21,4-year college,KY,0,0.65670629
+female,white,63,some college,AZ,0,0.518900234
+female,white,47,hs,AL,0,0.643741436
+female,black,54,some college,GA,0,0.526611726


### PR DESCRIPTION
- Remove 'region' from example cross-sectional data
- Add code to prepare_data_covid to present only numeric covariates to users
- Variable list follows Gelman's convention: categorical variables are only included in models as varying effects
- Fix Stan code generation backend for structured prior
- Now CmdStan is automatically installed without asking users
- Allow users to run model comparison in the web version
- Switching tabs no longer clear variable selection